### PR TITLE
feat(scaffold): Task 2.2 — package and example skeletons

### DIFF
--- a/examples/demo-site/astro.config.mjs
+++ b/examples/demo-site/astro.config.mjs
@@ -1,0 +1,10 @@
+// @ts-check
+import { defineConfig } from "astro/config";
+// import { editorialTheme } from "@portfolio-engine/editorial-theme";
+
+// Theme integration wired up in Task 4.5.
+// Placeholder config until Epic 3 (engine-core) and Epic 4 (editorial-theme) complete.
+
+export default defineConfig({
+  // integrations: [editorialTheme({ ... })],
+});

--- a/examples/demo-site/package.json
+++ b/examples/demo-site/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "demo-site",
+  "private": true,
+  "version": "0.0.1",
+  "description": "Example Astro site consuming @portfolio-engine/editorial-theme",
+  "type": "module",
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "check": "astro check"
+  },
+  "dependencies": {
+    "@portfolio-engine/editorial-theme": "workspace:*",
+    "@portfolio-engine/schema": "workspace:*"
+  },
+  "devDependencies": {
+    "astro": "^5.0.0"
+  }
+}

--- a/packages/admin-tools/README.md
+++ b/packages/admin-tools/README.md
@@ -1,0 +1,13 @@
+# @portfolio-engine/admin-tools
+
+Admin and reviewer UI for portfolio-engine sites. Provides:
+
+- Admin/reviewer interface components
+- Site map generated from the route registry
+- Content and config inspection panels
+
+See [`docs/packages/admin-tools.md`](../../docs/packages/admin-tools.md) for architecture detail.
+
+## Status
+
+Deferred — Epic 7 (after Epics 3–6 complete).

--- a/packages/admin-tools/package.json
+++ b/packages/admin-tools/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@portfolio-engine/admin-tools",
+  "version": "0.0.1",
+  "description": "Admin and reviewer UI components for portfolio-engine sites",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "echo 'build not yet configured'",
+    "dev": "echo 'dev not yet configured'",
+    "check": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "astro": ">=5.0.0"
+  },
+  "dependencies": {
+    "@portfolio-engine/engine-core": "workspace:*"
+  },
+  "devDependencies": {
+    "astro": "^5.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/admin-tools/src/index.ts
+++ b/packages/admin-tools/src/index.ts
@@ -1,0 +1,4 @@
+// @portfolio-engine/admin-tools
+// Admin/reviewer UI and route-registry-backed site map.
+// Implementation follows in Epic 7.
+export {};

--- a/packages/editorial-theme/README.md
+++ b/packages/editorial-theme/README.md
@@ -1,0 +1,15 @@
+# @portfolio-engine/editorial-theme
+
+The first-party portfolio theme built on `@portfolio-engine/engine-core`. Provides:
+
+- Shared layouts (`Layout.astro`)
+- Components (`Nav`, `SectionIntro`, `WritingList`, `TestimonialBlock`, etc.)
+- Global styles (`styles/global.css`)
+- Page routes (`/`, `/about`, `/work`, `/work/[slug]`, `/writing`, `/writing/[slug]`, `/contact`)
+- Named override surfaces for downstream customisation
+
+See [`docs/packages/editorial-theme.md`](../../docs/packages/editorial-theme.md) for architecture detail.
+
+## Status
+
+Under development — Epic 4.

--- a/packages/editorial-theme/package.json
+++ b/packages/editorial-theme/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@portfolio-engine/editorial-theme",
+  "version": "0.0.1",
+  "description": "The first-party Astro theme built on @portfolio-engine/engine-core",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "echo 'build not yet configured'",
+    "dev": "echo 'dev not yet configured'",
+    "check": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "astro": ">=5.0.0"
+  },
+  "dependencies": {
+    "@portfolio-engine/engine-core": "workspace:*"
+  },
+  "devDependencies": {
+    "astro": "^5.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/editorial-theme/src/index.ts
+++ b/packages/editorial-theme/src/index.ts
@@ -1,0 +1,4 @@
+// @portfolio-engine/editorial-theme
+// Layouts, components, styles, and page routes for the editorial portfolio theme.
+// Implementation follows in Epic 4.
+export {};

--- a/packages/engine-core/README.md
+++ b/packages/engine-core/README.md
@@ -1,0 +1,16 @@
+# @portfolio-engine/engine-core
+
+The Astro integration that powers portfolio-engine. Provides:
+
+- Config loader and schema bridge
+- Virtual modules for shared data access
+- Route discovery, injection, enable/disable semantics
+- Route registry contract (public + admin routes)
+- Override resolution (named, explicit override surfaces)
+- Type injection
+
+See [`docs/packages/engine-core.md`](../../docs/packages/engine-core.md) for architecture detail.
+
+## Status
+
+Under development — Epic 3.

--- a/packages/engine-core/package.json
+++ b/packages/engine-core/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@portfolio-engine/engine-core",
+  "version": "0.0.1",
+  "description": "Route registry, config loader, virtual modules, and override resolution for portfolio-engine",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "echo 'build not yet configured'",
+    "dev": "echo 'dev not yet configured'",
+    "check": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "astro": ">=5.0.0"
+  },
+  "devDependencies": {
+    "astro": "^5.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/engine-core/src/index.ts
+++ b/packages/engine-core/src/index.ts
@@ -1,0 +1,4 @@
+// @portfolio-engine/engine-core
+// Route registry, config loader, virtual modules, override resolution.
+// Implementation follows in Epic 3.
+export {};

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -1,0 +1,14 @@
+# @portfolio-engine/schema
+
+Shared Zod schemas for portfolio-engine content and configuration:
+
+- Content types: `person`, `writing`, `project`, `testimonial`
+- Config types: `siteConfig`, `navigationConfig`, `themeConfig`, `featuresConfig`
+
+Consumed by both `engine-core` (for validation) and downstream consumer sites (for type safety).
+
+See [`docs/packages/schema.md`](../../docs/packages/schema.md) for architecture detail.
+
+## Status
+
+Under development — Epic 3.

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@portfolio-engine/schema",
+  "version": "0.0.1",
+  "description": "Shared Zod schemas for portfolio-engine content and config",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "echo 'build not yet configured'",
+    "dev": "echo 'dev not yet configured'",
+    "check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "zod": "^3.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -1,0 +1,4 @@
+// @portfolio-engine/schema
+// Shared Zod schemas: person, writing, project, testimonial, site config.
+// Implementation follows in Epic 3.
+export {};

--- a/packages/workflow-kit/README.md
+++ b/packages/workflow-kit/README.md
@@ -1,0 +1,14 @@
+# @portfolio-engine/workflow-kit
+
+Reusable GitHub Actions workflow templates and AI change classifier for portfolio-engine downstream sites.
+
+- Workflow classification contract (`local-content`, `local-config`, `local-override`, `engine-change`, `engine-bug`, `human-review`)
+- Reusable workflow templates
+- Engine-aware classifier
+- Downstream-to-upstream routing contract
+
+See [`docs/packages/workflow-kit.md`](../../docs/packages/workflow-kit.md) for architecture detail.
+
+## Status
+
+Deferred — Epic 8 (after Epics 3–6 complete).

--- a/packages/workflow-kit/package.json
+++ b/packages/workflow-kit/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@portfolio-engine/workflow-kit",
+  "version": "0.0.1",
+  "description": "Reusable GitHub workflow templates and AI workflow classifier for portfolio-engine sites",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "echo 'build not yet configured'",
+    "dev": "echo 'dev not yet configured'",
+    "check": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/workflow-kit/src/index.ts
+++ b/packages/workflow-kit/src/index.ts
@@ -1,0 +1,4 @@
+// @portfolio-engine/workflow-kit
+// Reusable GitHub workflow templates and engine-aware change classifier.
+// Implementation follows in Epic 8.
+export {};


### PR DESCRIPTION
## Summary

- Creates stub `package.json` / `src/index.ts` / `README.md` for all five packages: `engine-core`, `editorial-theme`, `schema`, `admin-tools`, `workflow-kit`
- Wires internal `workspace:*` references: `editorial-theme` and `admin-tools` depend on `engine-core`
- Adds `examples/demo-site/` with `package.json` (consuming `editorial-theme` + `schema`) and placeholder `astro.config.mjs` (theme integration commented out until Epics 3–4)

## Test plan

- [ ] `pnpm install` from workspace root resolves all packages without error
- [ ] `demo-site` can import from `engine-core` via workspace reference

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)