### PR TITLE
feat(scaffold): Task 2.5 — public-repo hygiene files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Report a defect in a portfolio-engine package
+title: "bug: "
+labels: "task:bug-fix"
+assignees: rainonej
+---
+
+## Package
+
+Which package is affected? (engine-core / editorial-theme / schema / admin-tools / workflow-kit)
+
+## Description
+
+A clear description of the bug.
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behaviour
+
+What should happen.
+
+## Actual behaviour
+
+What actually happens.
+
+## Environment
+
+- `@portfolio-engine/*` version:
+- Astro version:
+- Node version:
+- Reproduction repo or minimal example (if available):

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Suggest a new capability for portfolio-engine
+title: "feat: "
+labels: "task:feat"
+assignees: rainonej
+---
+
+## Problem
+
+What problem does this solve? Which package does it relate to?
+
+## Proposed solution
+
+Describe what you'd like to see added or changed.
+
+## Alternatives considered
+
+What else did you consider?
+
+## Additional context
+
+Any other context, links, or examples.
+
+---
+
+> **Note:** portfolio-engine v1 is a first-party project. We do not accept arbitrary third-party theme PRs. Feature requests that expand the generic surface area of the engine are unlikely to be accepted in v1.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Summary
+
+<!-- What does this PR do? 1–3 bullets. -->
+
+## Checklist
+
+- [ ] `pnpm check` passes
+- [ ] `pnpm build` passes
+- [ ] Changeset added (`pnpm changeset`) — or this PR is docs/chore only
+- [ ] Tests updated (if applicable)
+- [ ] Relevant docs updated
+
+## Related issue
+
+Closes #

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,9 @@
+# Default owner for everything
+* @rainonej
+
+# Package-level ownership
+/packages/engine-core/    @rainonej
+/packages/editorial-theme/ @rainonej
+/packages/schema/          @rainonej
+/packages/admin-tools/     @rainonej
+/packages/workflow-kit/    @rainonej

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,75 @@
+# Contributing to portfolio-engine
+
+## Prerequisites
+
+- Node.js ≥ 18
+- pnpm ≥ 9 (`npm install -g pnpm`)
+
+## Local setup
+
+```bash
+git clone https://github.com/rainonej/portfolio-engine
+cd portfolio-engine
+pnpm install
+```
+
+## Two development modes
+
+### Installed mode (normal consumption)
+
+`agreni-site` installs `@portfolio-engine/*` packages from npm at a pinned semver version.
+
+```bash
+# In agreni-site
+pnpm add @portfolio-engine/editorial-theme@0.1.0
+```
+
+### Local-dev mode (working across repos simultaneously)
+
+Use `pnpm link` or `workspace:*` references in `agreni-site`'s `package.json` to point directly at local packages:
+
+```json
+{
+  "dependencies": {
+    "@portfolio-engine/editorial-theme": "link:../portfolio-engine/packages/editorial-theme"
+  }
+}
+```
+
+Changes in `portfolio-engine` packages reflect immediately in `agreni-site` without publishing.
+
+## Making changes
+
+1. Create a branch: `task/<issue-number>-<slug>`
+2. Make changes in the relevant `packages/` directory
+3. Add a changeset: `pnpm changeset`
+4. Open a PR targeting `dev` (or an `epic/*` branch if part of a larger epic)
+
+## Changesets
+
+This project uses [Changesets](https://github.com/changesets/changesets) for versioning and publishing.
+
+- `pnpm changeset` — add a changeset describing your change
+- `pnpm changeset version` — bump versions and update changelogs (done by the release PR bot)
+- `pnpm release` — publish packages to npm (runs in CI on merge to `main`)
+
+## PR conventions
+
+```
+task/<N>-<slug>  →  epic/<N>-<slug>  →  dev  →  main
+```
+
+- One logical change per PR
+- All PRs must include a changeset (for publishable packages)
+- Check that `pnpm check` and `pnpm build` pass locally before opening a PR
+
+## Versioning policy
+
+- Follows semantic versioning
+- `engine-core` and `schema` have stable APIs once v1 is published
+- `admin-tools` and `workflow-kit` are experimental in v1 — minor bumps may include breaking changes
+- We do not accept third-party theme PRs in v1; this project is intentionally first-party
+
+## Support
+
+This project is maintained by Jordan Rainone. Issues welcome for bugs and feature requests; see the issue templates.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Jordan Rainone
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,60 @@
 # portfolio-engine
 
-Reusable Astro portfolio engine. Provides packages for building personal portfolio sites:
+A first-party Astro engine for building personal portfolio sites. Opinionated, not generic — built for one downstream consumer (`agreni-site`) and open-sourced so the design decisions are transparent.
 
-- `@portfolio-engine/engine-core` — route registry, config loader, virtual modules
-- `@portfolio-engine/editorial-theme` — the Astro theme built on engine-core
-- `@portfolio-engine/schema` — shared Zod schemas
-- `@portfolio-engine/admin-tools` — admin UI and site map
-- `@portfolio-engine/workflow-kit` — reusable GitHub workflow templates
+## Four-Layer Model
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Consumer site (agreni-site)                            │
+│  Content, config, overrides — private                   │
+├─────────────────────────────────────────────────────────┤
+│  @portfolio-engine/editorial-theme                      │
+│  Layouts, components, routes, styles                    │
+├─────────────────────────────────────────────────────────┤
+│  @portfolio-engine/engine-core                          │
+│  Config loader, virtual modules, route registry,        │
+│  override resolution                                    │
+├─────────────────────────────────────────────────────────┤
+│  @portfolio-engine/schema                               │
+│  Shared Zod schemas for content + config                │
+└─────────────────────────────────────────────────────────┘
+```
+
+## Packages
+
+| Package | Description |
+|---------|-------------|
+| [`@portfolio-engine/engine-core`](packages/engine-core/) | Route registry, config loader, virtual modules, override resolution |
+| [`@portfolio-engine/editorial-theme`](packages/editorial-theme/) | The Astro theme: layouts, components, page routes |
+| [`@portfolio-engine/schema`](packages/schema/) | Shared Zod schemas for content and configuration |
+| [`@portfolio-engine/admin-tools`](packages/admin-tools/) | Admin/reviewer UI, site map from route registry *(Epic 7)* |
+| [`@portfolio-engine/workflow-kit`](packages/workflow-kit/) | Reusable GitHub workflows and AI change classifier *(Epic 8)* |
+
+## Consuming the theme
+
+```js
+// astro.config.mjs
+import { defineConfig } from "astro/config";
+import { editorialTheme } from "@portfolio-engine/editorial-theme";
+
+export default defineConfig({
+  integrations: [
+    editorialTheme({
+      config: "./config/site.json",
+    }),
+  ],
+});
+```
+
+## Development
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup and the dual-mode workflow.
 
 ## Status
 
-Under active development. Not yet published to npm.
+Under active development. Packages are not yet published to npm.
 
 ## Consumer repos
 
-- `agreni-site` (private) — reference downstream consumer
+- [`agreni-site`](https://github.com/rainonej/agreni-site) (private) — reference downstream consumer


### PR DESCRIPTION
## Summary

- `LICENSE` — MIT, 2025
- `README.md` — full project overview with four-layer model diagram, package table, minimal consumption example, and status
- `CONTRIBUTING.md` — local setup, dual-mode dev (installed vs local-dev), Changesets workflow, PR conventions, versioning policy
- `.github/ISSUE_TEMPLATE/bug_report.md` and `feature_request.md` with appropriate labels and notes
- `.github/PULL_REQUEST_TEMPLATE.md` — checklist: check, build, changeset, docs
- `CODEOWNERS` — @rainonej owns everything

## Test plan

- [ ] Issue templates appear correctly in GitHub's "New Issue" UI
- [ ] PR template pre-fills on new PRs
- [ ] LICENSE is recognised by GitHub (MIT badge should appear)

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)