### PR TITLE
feat(scaffold): Task 2.3 — docs shell for architecture and workflows

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,50 @@
+# Architecture
+
+portfolio-engine is organised into four layers. Each layer has a single responsibility and a strict dependency direction: layers only depend downward.
+
+## Four-Layer Model
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  Layer 4 — Consumer site (agreni-site, private)                  │
+│                                                                  │
+│  What lives here: content files, site config, media, overrides   │
+│  What it owns: nothing shared — all local to this site           │
+│  Depends on: @portfolio-engine/editorial-theme                   │
+└──────────────────────────────────────────────────────────────────┘
+           ↓ depends on
+┌──────────────────────────────────────────────────────────────────┐
+│  Layer 3 — @portfolio-engine/editorial-theme                     │
+│                                                                  │
+│  What lives here: layouts, components, styles, page routes       │
+│  Named override surfaces for consumer customisation              │
+│  Depends on: @portfolio-engine/engine-core                       │
+└──────────────────────────────────────────────────────────────────┘
+           ↓ depends on
+┌──────────────────────────────────────────────────────────────────┐
+│  Layer 2 — @portfolio-engine/engine-core                         │
+│                                                                  │
+│  What lives here: Astro integration, config loader, virtual      │
+│  modules, route registry, override resolution, type injection    │
+│  Depends on: @portfolio-engine/schema, astro-integration-kit     │
+└──────────────────────────────────────────────────────────────────┘
+           ↓ depends on
+┌──────────────────────────────────────────────────────────────────┐
+│  Layer 1 — @portfolio-engine/schema                              │
+│                                                                  │
+│  What lives here: Zod schemas for all content and config types   │
+│  No Astro dependency — pure TypeScript + Zod                     │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+## Design Principles
+
+**First-party, not generic.** This engine is built for one consumer (`agreni-site`). It is not designed to support arbitrary third-party themes or infinite configuration surfaces. Being open-source is about transparency, not extensibility.
+
+**Explicit override surfaces.** Consumers can override named components and styles. They cannot override arbitrary files — override points are declared by the theme and stable across versions.
+
+**Two-repo model.** Engine packages live in the public `portfolio-engine` repo. Consumer content and config live in the private `agreni-site` repo. They share no git history.
+
+**No packaged public-dir in v1.** Static assets are managed by the consumer, not the engine. This is a deliberate v1 non-goal.
+
+See [dependencies.md](dependencies.md) for the approved and banned package list.

--- a/docs/architecture/dependencies.md
+++ b/docs/architecture/dependencies.md
@@ -1,0 +1,30 @@
+# Dependency Policy
+
+This document records the approved and banned external dependencies for portfolio-engine packages. All new dependencies must be reviewed against this policy before being added.
+
+## Approved
+
+| Package | Used in | Reason |
+|---------|---------|--------|
+| `astro` | all packages (peerDep) | Core framework |
+| `zod` | `@portfolio-engine/schema` | Schema validation and type inference |
+| `@florian-lefebvre/astro-integration-kit` | `@portfolio-engine/engine-core` | Virtual module creation helper; narrow, well-maintained |
+| `@changesets/cli` | workspace root (devDep) | Release automation |
+| `typescript` | all packages (devDep) | Type checking |
+
+## Banned
+
+| Package | Reason |
+|---------|--------|
+| `astro-theme-provider` | Would be a long-term trust dependency we cannot control. engine-core implements its own route injection and virtual modules first-party. |
+| `astro-pages` | Route injection is implemented first-party in engine-core (Task 3.4). A third-party dependency here creates version coupling we cannot absorb. |
+| `astro-public` | Packaged public-dir support is an explicit v1 non-goal (Task 3.9). Consumers manage their own public assets. |
+
+## Adding new dependencies
+
+Before adding any new external dependency:
+
+1. Check whether it can be implemented simply first-party.
+2. Evaluate maintenance status, license (MIT/Apache-2.0 preferred), and size.
+3. Consider whether a future version bump could break our API contract with downstream.
+4. Add an entry to this document explaining the decision.

--- a/docs/downstream/consumption.md
+++ b/docs/downstream/consumption.md
@@ -1,0 +1,53 @@
+# Consuming portfolio-engine
+
+There are two modes for consuming portfolio-engine packages, depending on whether you are editing the engine or just using it.
+
+## Installed mode (normal consumption)
+
+Install from npm at a pinned version. This is the production mode for `agreni-site`.
+
+```bash
+pnpm add @portfolio-engine/editorial-theme@0.1.0
+```
+
+```js
+// astro.config.mjs
+import { defineConfig } from "astro/config";
+import { editorialTheme } from "@portfolio-engine/editorial-theme";
+
+export default defineConfig({
+  integrations: [
+    editorialTheme({
+      config: "./config/site.json",
+    }),
+  ],
+});
+```
+
+Upgrade by bumping the version in `package.json` and running `pnpm install`.
+
+## Local-dev mode (cross-repo development)
+
+When making changes to engine packages and testing them in `agreni-site` simultaneously, use `pnpm link` or `workspace:*` references.
+
+```json
+{
+  "dependencies": {
+    "@portfolio-engine/editorial-theme": "link:../portfolio-engine/packages/editorial-theme"
+  }
+}
+```
+
+Run `pnpm install` in `agreni-site` after changing the reference. Changes in `portfolio-engine` packages reflect immediately.
+
+## Overrides
+
+Place override files in `src/overrides/components/` in your consumer site. The exact named surfaces are defined by `@portfolio-engine/editorial-theme` (Task 4.4). Do not override arbitrary internal files — only named surfaces are stable.
+
+```
+agreni-site/
+  src/
+    overrides/
+      components/
+        Nav.astro         ← replaces the theme's Nav
+```

--- a/docs/downstream/upgrade-path.md
+++ b/docs/downstream/upgrade-path.md
@@ -1,0 +1,26 @@
+# Upgrade Path
+
+## Normal upgrades
+
+1. Check the [changelog](../../packages/editorial-theme/CHANGELOG.md) for breaking changes.
+2. Bump the version in `agreni-site/package.json`.
+3. Run `pnpm install`.
+4. Run `pnpm check` and `pnpm build` to catch type errors early.
+5. Test the site locally.
+
+## Patch tracking
+
+When `agreni-site` needs a fix that isn't yet in a portfolio-engine release:
+
+1. Apply the fix locally in `agreni-site` using a patch file.
+2. Open an upstream PR in `portfolio-engine` with the same fix.
+3. Record the patch in the tracking artifact (Epic 9 — `engine_patches` in `package.json` or a dedicated tracking file).
+4. When the fix ships in a portfolio-engine release, upgrade and remove the patch.
+
+Epic 10 automation watches for upstream releases and opens a cleanup PR in `agreni-site` automatically when a patched issue is resolved.
+
+## Breaking changes
+
+`engine-core` and `schema` follow strict semver — breaking changes only in major versions.
+`editorial-theme` follows semver — override surface removals or renames are breaking changes.
+`admin-tools` and `workflow-kit` are experimental in v1 — minor bumps may include breaking changes.

--- a/docs/packages/admin-tools.md
+++ b/docs/packages/admin-tools.md
@@ -1,0 +1,15 @@
+# @portfolio-engine/admin-tools
+
+Admin and reviewer UI for portfolio-engine sites.
+
+## Planned capabilities
+
+- Admin/reviewer interface components (extracted from `profesional_site` admin route)
+- Site map generated from the route registry
+- Content and config inspection panels
+
+## Status
+
+Deferred — Epic 7. Requires:
+- Epic 5 (agreni-site consumer working, auth/admin behaviour preserved)
+- Epic 3 (route registry contract — Task 3.6)

--- a/docs/packages/editorial-theme.md
+++ b/docs/packages/editorial-theme.md
@@ -1,0 +1,39 @@
+# @portfolio-engine/editorial-theme
+
+The first-party Astro theme built on `engine-core`.
+
+## Contents
+
+### Layouts
+- `Layout.astro` — base page wrapper
+
+### Components
+- `Nav.astro` — site navigation
+- `SectionIntro.astro` — section header with title and description
+- `FeaturePillars.astro` — services/feature grid
+- `WritingList.astro` — writing index
+- `TestimonialBlock.astro` — testimonial display
+- `CollaborationCTA.astro` — collaboration call-to-action
+- `AmbientBackground.astro` — decorative background
+- `Reveal.astro` — scroll reveal wrapper
+
+### Routes
+| Path | Description |
+|------|-------------|
+| `/` | Home page |
+| `/about` | About page |
+| `/work` | Work index |
+| `/work/[slug]` | Work detail |
+| `/writing` | Writing index |
+| `/writing/[slug]` | Writing detail |
+| `/contact` | Contact page |
+
+Admin route handled separately in `@portfolio-engine/admin-tools` (Epic 7).
+
+### Override surfaces
+
+Named override points are explicit and stable. Consumers can override individual components by placing a file in their `src/overrides/components/` directory. The exact surface list is defined in Task 4.4.
+
+## Implementation
+
+Epic 4 tasks: 4.1–4.5. See [../../packages/editorial-theme/](../../packages/editorial-theme/).

--- a/docs/packages/engine-core.md
+++ b/docs/packages/engine-core.md
@@ -1,0 +1,23 @@
+# @portfolio-engine/engine-core
+
+The Astro integration at the heart of portfolio-engine.
+
+## Responsibilities
+
+- **Config loader + schema bridge** — loads and validates `site.json`, `navigation.json`, `theme.json`, `features.json` against `@portfolio-engine/schema`
+- **Virtual modules** — exposes validated config and content data to Astro components without filesystem coupling
+- **Route discovery + injection** — scans the theme's route directory and injects them into the consumer Astro project
+- **Route remap / enable / disable** — consumers can disable or remap individual routes via config
+- **Route registry** — exports a stable contract listing all registered routes (public + admin)
+- **Override resolution** — resolves named override surfaces: consumer overrides take precedence over theme defaults
+- **Type injection** — provides TypeScript types for all virtual modules
+
+## Non-goals (v1)
+
+- Packaged public-dir assets (see Task 3.9)
+- Generic multi-theme support
+- Runtime API routes
+
+## Implementation
+
+Epic 3 tasks: 3.1–3.9. See [../../packages/engine-core/](../../packages/engine-core/).

--- a/docs/packages/schema.md
+++ b/docs/packages/schema.md
@@ -1,0 +1,26 @@
+# @portfolio-engine/schema
+
+Shared Zod schemas. No Astro dependency — pure TypeScript + Zod. Can be used in any environment.
+
+## Content schemas
+
+| Schema | File |
+|--------|------|
+| `PersonSchema` | person.json / bio.md |
+| `WritingSchema` | writing/*.md |
+| `ProjectSchema` | projects/*.md |
+| `TestimonialSchema` | testimonials/*.md |
+| `CVSchema` | cv.json |
+
+## Config schemas
+
+| Schema | File |
+|--------|------|
+| `SiteConfigSchema` | config/site.json |
+| `NavigationConfigSchema` | config/navigation.json |
+| `ThemeConfigSchema` | config/theme.json |
+| `FeaturesConfigSchema` | config/features.json |
+
+## Implementation
+
+Part of Epic 3. See [../../packages/schema/](../../packages/schema/).

--- a/docs/packages/workflow-kit.md
+++ b/docs/packages/workflow-kit.md
@@ -1,0 +1,25 @@
+# @portfolio-engine/workflow-kit
+
+Reusable GitHub Actions workflow templates and AI change classifier for portfolio-engine downstream sites.
+
+## Planned capabilities
+
+**Workflow classification contract** — classifies changes in a consumer site into one of:
+- `local-content` — content/media edited by the site owner
+- `local-config` — site config changes (nav, features, bookingUrl)
+- `local-override` — overriding a named theme component
+- `engine-change` — feature needed in a shared engine package
+- `engine-bug` — defect in a shared engine package
+- `human-review` — requires human judgment
+
+**Reusable workflow templates** — packaged `.github/workflows/` for common downstream tasks.
+
+**Engine-aware classifier** — understands the route registry and override surfaces to distinguish local changes from shared engine changes.
+
+**Downstream-to-upstream routing contract** — knows when a change should generate an upstream PR in `portfolio-engine` vs stay local.
+
+## Status
+
+Deferred — Epic 8. Requires:
+- Epic 3 (route registry — Task 3.6)
+- Epic 4 (override surfaces — Task 4.4)

--- a/docs/workflows/ai-workflow.md
+++ b/docs/workflows/ai-workflow.md
@@ -1,0 +1,26 @@
+# AI Workflow
+
+This document describes how the AI-assisted development workflow operates for portfolio-engine and its downstream consumer `agreni-site`.
+
+## Overview
+
+Changes to `agreni-site` are classified by `@portfolio-engine/workflow-kit` into one of six categories. The category determines whether the change stays local, needs a shared engine fix, or requires human judgment.
+
+See [../../docs/packages/workflow-kit.md](../packages/workflow-kit.md) for the classification contract.
+
+## AI agents
+
+- **Agentic AI** (`owner:agentic-ai`) — handles multi-step codebase-wide tasks
+- **Simple AI** (`owner:simple-ai`) — handles targeted single-file or config changes
+
+## Workflow triggers (in agreni-site)
+
+| Trigger | Action |
+|---------|--------|
+| `automation:plan` label on issue | Planner agent shapes the issue into tasks |
+| `claude-ready` label on issue | Claude agent executes the task |
+| `@claude` comment | Claude agent responds to the comment |
+
+## Status
+
+Stub — detailed workflow documented in Epic 8 (Task 8.1–8.4).

--- a/docs/workflows/release-workflow.md
+++ b/docs/workflows/release-workflow.md
@@ -1,0 +1,30 @@
+# Release Workflow
+
+portfolio-engine uses [Changesets](https://github.com/changesets/changesets) for version management and npm publishing.
+
+## Normal release cycle
+
+1. **During development** — every PR that changes a publishable package adds a changeset: `pnpm changeset`
+2. **Changesets bot** — automatically opens a "Version Packages" PR accumulating all changesets
+3. **Merge to main** — merging the version PR triggers `.github/workflows/release.yml`, which publishes all bumped packages to npm
+
+## Packages published
+
+- `@portfolio-engine/engine-core`
+- `@portfolio-engine/editorial-theme`
+- `@portfolio-engine/schema`
+- `@portfolio-engine/admin-tools` *(when ready — Epic 7)*
+- `@portfolio-engine/workflow-kit` *(when ready — Epic 8)*
+
+## Required secrets
+
+| Secret | Where | Purpose |
+|--------|-------|---------|
+| `NPM_TOKEN` | GitHub repo → Settings → Secrets | Publishing to npm |
+| `GITHUB_TOKEN` | Auto-provided by Actions | Creating version PRs |
+
+## Patch reconciliation
+
+When `agreni-site` applies a local patch to fix a bug before it's upstreamed, the patch tracking workflow (Epic 9) opens a PR in `portfolio-engine` automatically. When the fix ships in a new release, Epic 10 automation opens a cleanup PR in `agreni-site` to remove the patch.
+
+See [../../docs/downstream/upgrade-path.md](../downstream/upgrade-path.md).


### PR DESCRIPTION
## Summary

- `docs/architecture/README.md` — four-layer model diagram with descriptions and design principles (first-party, explicit overrides, two-repo model, no packaged public-dir)
- `docs/architecture/dependencies.md` — approved packages table (astro, zod, astro-integration-kit, changesets, typescript) and banned packages table (astro-theme-provider, astro-pages, astro-public) with rationale for each
- `docs/packages/*.md` — per-package stubs for all five packages with responsibility lists, status, and epic references
- `docs/workflows/ai-workflow.md` and `release-workflow.md` — workflow stubs covering classification contract and Changesets release cycle
- `docs/downstream/consumption.md` and `upgrade-path.md` — consumer guides for installed mode, local-dev mode, overrides, and patch tracking

All paths are stable and ready to link from issue bodies.

## Test plan

- [ ] All paths in issue cross-links resolve correctly
- [ ] `docs/architecture/dependencies.md` matches what Task 2.4 installs

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)