### PR TITLE
feat(engine-core): config loader + schema bridge (Task 3.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "release": "changeset publish"
   },
   "devDependencies": {
-    "@changesets/cli": "^2.27.0"
+    "@changesets/cli": "^2.27.0",
+    "@types/node": "^22.0.0"
   },
   "engines": {
     "node": ">=18",

--- a/packages/engine-core/package.json
+++ b/packages/engine-core/package.json
@@ -11,6 +11,10 @@
     "dev": "echo 'dev not yet configured'",
     "check": "tsc --noEmit"
   },
+  "dependencies": {
+    "@portfolio-engine/schema": "workspace:*",
+    "zod": "^3.25.76"
+  },
   "peerDependencies": {
     "astro": ">=5.0.0"
   },

--- a/packages/engine-core/src/config-loader.ts
+++ b/packages/engine-core/src/config-loader.ts
@@ -11,7 +11,7 @@ import {
   type ThemeConfig,
   type FeaturesConfig,
 } from '@portfolio-engine/schema';
-import type { ZodError, ZodTypeAny } from 'zod';
+import type { ZodError, ZodType } from 'zod';
 
 export interface EngineConfig {
   siteConfigPath: string;
@@ -28,12 +28,21 @@ export interface ResolvedConfig {
 }
 
 async function readJson(absolutePath: string): Promise<unknown> {
+  let text: string;
+
   try {
-    const text = await readFile(absolutePath, 'utf-8');
-    return JSON.parse(text);
+    text = await readFile(absolutePath, 'utf-8');
   } catch (err) {
     throw new Error(
       `[portfolio-engine] Cannot read config file "${absolutePath}"\n${String(err)}`,
+    );
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch (err) {
+    throw new Error(
+      `[portfolio-engine] Cannot parse JSON config file "${absolutePath}"\n${String(err)}`,
     );
   }
 }
@@ -46,12 +55,12 @@ function formatZodError(error: ZodError, filePath: string): string {
   return [`[portfolio-engine] Invalid config in "${filePath}":`, ...issues].join('\n');
 }
 
-function validate<T>(schema: ZodTypeAny, raw: unknown, filePath: string): T {
+function validate<T>(schema: ZodType<T>, raw: unknown, filePath: string): T {
   const result = schema.safeParse(raw);
   if (!result.success) {
     throw new Error(formatZodError(result.error as ZodError, filePath));
   }
-  return result.data as T;
+  return result.data;
 }
 
 export async function loadConfig(
@@ -60,25 +69,30 @@ export async function loadConfig(
 ): Promise<ResolvedConfig> {
   const root = fileURLToPath(projectRoot);
 
+  const siteConfigPath = resolve(root, engineConfig.siteConfigPath);
+  const navigationConfigPath = resolve(root, engineConfig.navigationConfigPath);
+  const themeConfigPath = resolve(root, engineConfig.themeConfigPath);
+  const featuresConfigPath = resolve(root, engineConfig.featuresConfigPath);
+
   const [siteRaw, navRaw, themeRaw, featuresRaw] = await Promise.all([
-    readJson(resolve(root, engineConfig.siteConfigPath)),
-    readJson(resolve(root, engineConfig.navigationConfigPath)),
-    readJson(resolve(root, engineConfig.themeConfigPath)),
-    readJson(resolve(root, engineConfig.featuresConfigPath)),
+    readJson(siteConfigPath),
+    readJson(navigationConfigPath),
+    readJson(themeConfigPath),
+    readJson(featuresConfigPath),
   ]);
 
   return {
-    site: validate<SiteConfig>(SiteConfigSchema, siteRaw, engineConfig.siteConfigPath),
+    site: validate<SiteConfig>(SiteConfigSchema, siteRaw, siteConfigPath),
     navigation: validate<NavigationConfig>(
       NavigationConfigSchema,
       navRaw,
-      engineConfig.navigationConfigPath,
+      navigationConfigPath,
     ),
-    theme: validate<ThemeConfig>(ThemeConfigSchema, themeRaw, engineConfig.themeConfigPath),
+    theme: validate<ThemeConfig>(ThemeConfigSchema, themeRaw, themeConfigPath),
     features: validate<FeaturesConfig>(
       FeaturesConfigSchema,
       featuresRaw,
-      engineConfig.featuresConfigPath,
+      featuresConfigPath,
     ),
   };
 }

--- a/packages/engine-core/src/config-loader.ts
+++ b/packages/engine-core/src/config-loader.ts
@@ -1,0 +1,84 @@
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
+import {
+  SiteConfigSchema,
+  NavigationConfigSchema,
+  ThemeConfigSchema,
+  FeaturesConfigSchema,
+  type SiteConfig,
+  type NavigationConfig,
+  type ThemeConfig,
+  type FeaturesConfig,
+} from '@portfolio-engine/schema';
+import type { ZodError, ZodTypeAny } from 'zod';
+
+export interface EngineConfig {
+  siteConfigPath: string;
+  navigationConfigPath: string;
+  themeConfigPath: string;
+  featuresConfigPath: string;
+}
+
+export interface ResolvedConfig {
+  site: SiteConfig;
+  navigation: NavigationConfig;
+  theme: ThemeConfig;
+  features: FeaturesConfig;
+}
+
+async function readJson(absolutePath: string): Promise<unknown> {
+  try {
+    const text = await readFile(absolutePath, 'utf-8');
+    return JSON.parse(text);
+  } catch (err) {
+    throw new Error(
+      `[portfolio-engine] Cannot read config file "${absolutePath}"\n${String(err)}`,
+    );
+  }
+}
+
+function formatZodError(error: ZodError, filePath: string): string {
+  const issues = error.issues.map((issue) => {
+    const path = issue.path.length > 0 ? issue.path.join('.') : '(root)';
+    return `  • ${path}: ${issue.message}`;
+  });
+  return [`[portfolio-engine] Invalid config in "${filePath}":`, ...issues].join('\n');
+}
+
+function validate<T>(schema: ZodTypeAny, raw: unknown, filePath: string): T {
+  const result = schema.safeParse(raw);
+  if (!result.success) {
+    throw new Error(formatZodError(result.error as ZodError, filePath));
+  }
+  return result.data as T;
+}
+
+export async function loadConfig(
+  engineConfig: EngineConfig,
+  projectRoot: URL,
+): Promise<ResolvedConfig> {
+  const root = fileURLToPath(projectRoot);
+
+  const [siteRaw, navRaw, themeRaw, featuresRaw] = await Promise.all([
+    readJson(resolve(root, engineConfig.siteConfigPath)),
+    readJson(resolve(root, engineConfig.navigationConfigPath)),
+    readJson(resolve(root, engineConfig.themeConfigPath)),
+    readJson(resolve(root, engineConfig.featuresConfigPath)),
+  ]);
+
+  return {
+    site: validate<SiteConfig>(SiteConfigSchema, siteRaw, engineConfig.siteConfigPath),
+    navigation: validate<NavigationConfig>(
+      NavigationConfigSchema,
+      navRaw,
+      engineConfig.navigationConfigPath,
+    ),
+    theme: validate<ThemeConfig>(ThemeConfigSchema, themeRaw, engineConfig.themeConfigPath),
+    features: validate<FeaturesConfig>(
+      FeaturesConfigSchema,
+      featuresRaw,
+      engineConfig.featuresConfigPath,
+    ),
+  };
+}

--- a/packages/engine-core/src/config-loader.ts
+++ b/packages/engine-core/src/config-loader.ts
@@ -11,7 +11,7 @@ import {
   type ThemeConfig,
   type FeaturesConfig,
 } from '@portfolio-engine/schema';
-import type { ZodError, ZodType } from 'zod';
+import type { ZodError, ZodType, ZodTypeDef } from 'zod';
 
 export interface EngineConfig {
   siteConfigPath: string;
@@ -55,7 +55,7 @@ function formatZodError(error: ZodError, filePath: string): string {
   return [`[portfolio-engine] Invalid config in "${filePath}":`, ...issues].join('\n');
 }
 
-function validate<T>(schema: ZodType<T>, raw: unknown, filePath: string): T {
+function validate<T>(schema: ZodType<T, ZodTypeDef, unknown>, raw: unknown, filePath: string): T {
   const result = schema.safeParse(raw);
   if (!result.success) {
     throw new Error(formatZodError(result.error as ZodError, filePath));

--- a/packages/engine-core/src/index.ts
+++ b/packages/engine-core/src/index.ts
@@ -1,4 +1,2 @@
-// @portfolio-engine/engine-core
-// Route registry, config loader, virtual modules, override resolution.
-// Implementation follows in Epic 3.
-export {};
+export { loadConfig } from './config-loader.js';
+export type { EngineConfig, ResolvedConfig } from './config-loader.js';

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -1,4 +1,59 @@
-// @portfolio-engine/schema
-// Shared Zod schemas: person, writing, project, testimonial, site config.
-// Implementation follows in Epic 3.
-export {};
+import { z } from 'zod';
+
+export const SiteConfigSchema = z.object({
+  title: z.string(),
+  description: z.string(),
+  baseUrl: z.string().url(),
+  social: z
+    .object({
+      github: z.string().url().optional(),
+      twitter: z.string().url().optional(),
+      linkedin: z.string().url().optional(),
+    })
+    .optional(),
+});
+
+export const NavigationConfigSchema = z.object({
+  items: z.array(
+    z.object({
+      label: z.string(),
+      href: z.string(),
+      order: z.number().int().optional(),
+      visible: z.boolean().default(true),
+    }),
+  ),
+});
+
+export const ThemeConfigSchema = z.object({
+  typography: z
+    .object({
+      fontFamily: z.string().optional(),
+      fontSize: z.string().optional(),
+    })
+    .optional(),
+  colors: z
+    .object({
+      primary: z.string().optional(),
+      secondary: z.string().optional(),
+      background: z.string().optional(),
+      text: z.string().optional(),
+    })
+    .optional(),
+  layout: z
+    .object({
+      maxWidth: z.string().optional(),
+    })
+    .optional(),
+});
+
+export const FeaturesConfigSchema = z.object({
+  blog: z.boolean().default(true),
+  testimonials: z.boolean().default(false),
+  work: z.boolean().default(true),
+  contact: z.boolean().default(true),
+});
+
+export type SiteConfig = z.infer<typeof SiteConfigSchema>;
+export type NavigationConfig = z.infer<typeof NavigationConfigSchema>;
+export type ThemeConfig = z.infer<typeof ThemeConfigSchema>;
+export type FeaturesConfig = z.infer<typeof FeaturesConfigSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,10 @@ importers:
     devDependencies:
       '@changesets/cli':
         specifier: ^2.27.0
-        version: 2.31.0
+        version: 2.31.0(@types/node@22.19.17)
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
 
   examples/demo-site:
     dependencies:
@@ -23,7 +26,7 @@ importers:
     devDependencies:
       astro:
         specifier: ^5.18.1
-        version: 5.18.1(rollup@4.60.2)(typescript@5.9.3)
+        version: 5.18.1(@types/node@22.19.17)(rollup@4.60.2)(typescript@5.9.3)
 
   packages/admin-tools:
     dependencies:
@@ -33,7 +36,7 @@ importers:
     devDependencies:
       astro:
         specifier: ^5.18.1
-        version: 5.18.1(rollup@4.60.2)(typescript@5.9.3)
+        version: 5.18.1(@types/node@22.19.17)(rollup@4.60.2)(typescript@5.9.3)
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -46,16 +49,23 @@ importers:
     devDependencies:
       astro:
         specifier: ^5.18.1
-        version: 5.18.1(rollup@4.60.2)(typescript@5.9.3)
+        version: 5.18.1(@types/node@22.19.17)(rollup@4.60.2)(typescript@5.9.3)
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
 
   packages/engine-core:
+    dependencies:
+      '@portfolio-engine/schema':
+        specifier: workspace:*
+        version: link:../schema
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
       astro:
         specifier: ^5.18.1
-        version: 5.18.1(rollup@4.60.2)(typescript@5.9.3)
+        version: 5.18.1(@types/node@22.19.17)(rollup@4.60.2)(typescript@5.9.3)
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -835,6 +845,9 @@ packages:
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
+
+  '@types/node@22.19.17':
+    resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -1839,6 +1852,9 @@ packages:
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
@@ -2147,7 +2163,7 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
-  '@changesets/cli@2.31.0':
+  '@changesets/cli@2.31.0(@types/node@22.19.17)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.1
       '@changesets/assemble-release-plan': 6.0.10
@@ -2163,7 +2179,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.3
+      '@inquirer/external-editor': 1.0.3(@types/node@22.19.17)
       '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
       enquirer: 2.4.1
@@ -2519,10 +2535,12 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@inquirer/external-editor@1.0.3':
+  '@inquirer/external-editor@1.0.3(@types/node@22.19.17)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 22.19.17
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
@@ -2694,6 +2712,10 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
+  '@types/node@22.19.17':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/unist@3.0.3': {}
 
   '@ungap/structured-clone@1.3.0': {}
@@ -2729,7 +2751,7 @@ snapshots:
 
   array-union@2.1.0: {}
 
-  astro@5.18.1(rollup@4.60.2)(typescript@5.9.3):
+  astro@5.18.1(@types/node@22.19.17)(rollup@4.60.2)(typescript@5.9.3):
     dependencies:
       '@astrojs/compiler': 2.13.1
       '@astrojs/internal-helpers': 0.7.6
@@ -2786,8 +2808,8 @@ snapshots:
       unist-util-visit: 5.1.0
       unstorage: 1.17.5
       vfile: 6.0.3
-      vite: 6.4.2
-      vitefu: 1.1.3(vite@6.4.2)
+      vite: 6.4.2(@types/node@22.19.17)
+      vitefu: 1.1.3(vite@6.4.2(@types/node@22.19.17))
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
       yocto-spinner: 0.2.3
@@ -4072,6 +4094,8 @@ snapshots:
 
   uncrypto@0.1.3: {}
 
+  undici-types@6.21.0: {}
+
   unified@11.0.5:
     dependencies:
       '@types/unist': 3.0.3
@@ -4158,7 +4182,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@6.4.2:
+  vite@6.4.2(@types/node@22.19.17):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -4167,11 +4191,12 @@ snapshots:
       rollup: 4.60.2
       tinyglobby: 0.2.16
     optionalDependencies:
+      '@types/node': 22.19.17
       fsevents: 2.3.3
 
-  vitefu@1.1.3(vite@6.4.2):
+  vitefu@1.1.3(vite@6.4.2(@types/node@22.19.17)):
     optionalDependencies:
-      vite: 6.4.2
+      vite: 6.4.2(@types/node@22.19.17)
 
   web-namespaces@2.0.1: {}
 


### PR DESCRIPTION
## Summary

Implements Task 3.2 — config loader + schema bridge for `@portfolio-engine/engine-core`.

- **`@portfolio-engine/schema`**: Adds four Zod config schemas — `SiteConfigSchema`, `NavigationConfigSchema`, `ThemeConfigSchema`, `FeaturesConfigSchema` — with exported inferred types (`SiteConfig`, `NavigationConfig`, `ThemeConfig`, `FeaturesConfig`)
- **`@portfolio-engine/engine-core`**: Implements `loadConfig(engineConfig, projectRoot)` — reads all four `config/*.json` files in parallel, validates each against its schema, returns a fully-typed `ResolvedConfig`. Invalid config throws a human-readable error with field-level detail, not a raw Vite stack trace
- **Root `package.json`**: Adds `@types/node` at the workspace root (needed by the shared root tsconfig for `node:` module imports in engine-core)

Closes rainonej/profesional_site#201

## Acceptance criteria

- [x] Engine-core reads all four `config/*.json` files and validates them
- [x] Invalid config produces a human-readable error at build time
- [x] `ResolvedConfig` is typed end-to-end (no `any`)

## Test plan

- [ ] `pnpm --filter @portfolio-engine/schema check` — passes clean
- [ ] `pnpm --filter @portfolio-engine/engine-core check` — passes clean
- [ ] Manual smoke test: call `loadConfig` with valid JSON fixtures and verify returned `ResolvedConfig` shape
- [ ] Manual smoke test: call `loadConfig` with an invalid JSON fixture and verify error message names the field and file

🤖 Generated with [Claude Code](https://claude.com/claude-code)