### PR TITLE
feat(engine-core): virtual modules (Task 3.3)

### DIFF
--- a/docs/packages/engine-core.md
+++ b/docs/packages/engine-core.md
@@ -27,12 +27,22 @@ Consumers never call engine-core directly. The public API is `editorialTheme()` 
 
 ## Virtual modules
 
-| Module ID | Type | Contents |
-|-----------|------|----------|
-| `@portfolio-engine:config` | `ResolvedConfig` | Validated site + navigation + theme + features config |
-| `@portfolio-engine:context` | `BuildContext` | Env, mode, base URL |
-| `@portfolio-engine:routes` | `RouteRecord[]` | All registered public + admin routes |
-| `@portfolio-engine:overrides` | `OverrideMap` | Component override map (component name → downstream path) |
+Implemented via native Vite `resolveId`/`load` plugin hooks. The `\0` prefix on resolved IDs is the Vite convention for virtual modules — it tells Vite not to look for the ID as a real file.
+
+| Module ID | Export | Type | Contents |
+|-----------|--------|------|----------|
+| `@portfolio-engine:config` | `config` | `ResolvedConfig` | Validated site + navigation + theme + features config |
+| `@portfolio-engine:context` | `context` | `BuildContext` | Env, mode, base URL |
+| `@portfolio-engine:routes` | `routes` | `RouteRecord[]` | All registered public + admin routes |
+| `@portfolio-engine:overrides` | `overrides` | `OverrideMap` | Component override map (component name → downstream path) |
+
+Consumer packages (e.g. `editorial-theme`) get full TypeScript types by adding a reference directive:
+
+```typescript
+/// <reference types="@portfolio-engine/engine-core/client" />
+```
+
+The plugin is created with `createVirtualModulesPlugin()` from `@portfolio-engine/engine-core` and passed to `updateConfig({ vite: { plugins: [...] } })` inside the `astro:config:setup` hook.
 
 ## Route registry shape
 

--- a/packages/engine-core/package.json
+++ b/packages/engine-core/package.json
@@ -4,7 +4,8 @@
   "description": "Route registry, config loader, virtual modules, and override resolution for portfolio-engine",
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./client": "./src/client.d.ts"
   },
   "scripts": {
     "build": "echo 'build not yet configured'",

--- a/packages/engine-core/src/client.d.ts
+++ b/packages/engine-core/src/client.d.ts
@@ -1,0 +1,22 @@
+// Ambient type declarations for @portfolio-engine virtual modules.
+// Reference this file in consuming packages:
+//   /// <reference types="@portfolio-engine/engine-core/client" />
+
+import type { ResolvedConfig } from './config-loader.js';
+import type { BuildContext, OverrideMap, RouteRecord } from './types.js';
+
+declare module '@portfolio-engine:config' {
+  export const config: ResolvedConfig;
+}
+
+declare module '@portfolio-engine:context' {
+  export const context: BuildContext;
+}
+
+declare module '@portfolio-engine:routes' {
+  export const routes: RouteRecord[];
+}
+
+declare module '@portfolio-engine:overrides' {
+  export const overrides: OverrideMap;
+}

--- a/packages/engine-core/src/index.ts
+++ b/packages/engine-core/src/index.ts
@@ -1,2 +1,7 @@
 export { loadConfig } from './config-loader.js';
 export type { EngineConfig, ResolvedConfig } from './config-loader.js';
+
+export { createVirtualModulesPlugin } from './virtual-modules.js';
+export type { VirtualModulePluginOptions } from './virtual-modules.js';
+
+export type { BuildContext, OverrideMap, RouteRecord } from './types.js';

--- a/packages/engine-core/src/types.ts
+++ b/packages/engine-core/src/types.ts
@@ -1,0 +1,16 @@
+export interface BuildContext {
+  env: 'development' | 'production';
+  mode: string;
+  base: string;
+}
+
+export interface RouteRecord {
+  pattern: string;
+  label: string;
+  section: string | null;
+  visibility: 'public' | 'admin-only' | 'hidden';
+  remappable: boolean;
+  disableable: boolean;
+}
+
+export type OverrideMap = Record<string, string>;

--- a/packages/engine-core/src/virtual-modules.ts
+++ b/packages/engine-core/src/virtual-modules.ts
@@ -1,0 +1,68 @@
+import type { ResolvedConfig } from './config-loader.js';
+import type { BuildContext, OverrideMap, RouteRecord } from './types.js';
+
+// Minimal subset of the Vite Plugin interface — avoids a direct vite dep
+// while preserving correctness for the hooks engine-core actually uses.
+interface VitePlugin {
+  name: string;
+  resolveId?: (id: string) => string | null | undefined;
+  load?: (id: string) => string | null | undefined;
+}
+
+const VIRTUAL_MODULE_IDS = [
+  '@portfolio-engine:config',
+  '@portfolio-engine:context',
+  '@portfolio-engine:routes',
+  '@portfolio-engine:overrides',
+] as const;
+
+type VirtualModuleId = (typeof VIRTUAL_MODULE_IDS)[number];
+
+function isVirtualModuleId(id: string): id is VirtualModuleId {
+  return (VIRTUAL_MODULE_IDS as readonly string[]).includes(id);
+}
+
+// Vite convention: prefix resolved virtual IDs with \0 to avoid filesystem lookups
+function resolve(id: VirtualModuleId): string {
+  return `\0${id}`;
+}
+
+function unresolve(id: string): VirtualModuleId | undefined {
+  const candidate = id.slice(1); // strip leading \0
+  return isVirtualModuleId(candidate) ? candidate : undefined;
+}
+
+export interface VirtualModulePluginOptions {
+  resolvedConfig: ResolvedConfig;
+  context: BuildContext;
+  routes?: RouteRecord[];
+  overrides?: OverrideMap;
+}
+
+export function createVirtualModulesPlugin(options: VirtualModulePluginOptions): VitePlugin {
+  const { resolvedConfig, context, routes = [], overrides = {} } = options;
+
+  return {
+    name: '@portfolio-engine/virtual-modules',
+
+    resolveId(id) {
+      if (isVirtualModuleId(id)) return resolve(id);
+    },
+
+    load(id) {
+      const moduleId = unresolve(id);
+      if (!moduleId) return;
+
+      switch (moduleId) {
+        case '@portfolio-engine:config':
+          return `export const config = ${JSON.stringify(resolvedConfig)};`;
+        case '@portfolio-engine:context':
+          return `export const context = ${JSON.stringify(context)};`;
+        case '@portfolio-engine:routes':
+          return `export const routes = ${JSON.stringify(routes)};`;
+        case '@portfolio-engine:overrides':
+          return `export const overrides = ${JSON.stringify(overrides)};`;
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Implements Task 3.3 — virtual modules for `@portfolio-engine/engine-core`.

- **`src/types.ts`** — `BuildContext`, `RouteRecord`, `OverrideMap` types shared across engine-core and consuming packages
- **`src/virtual-modules.ts`** — `createVirtualModulesPlugin()`: a Vite plugin that serves all four `@portfolio-engine:*` virtual modules via native `resolveId`/`load` hooks (no third-party virtual module library)
- **`src/client.d.ts`** — ambient module declarations for all four virtual modules; consuming packages get full types via `/// <reference types="@portfolio-engine/engine-core/client" />`
- **`package.json`** — adds `./client` export path for the type declarations
- **`docs/packages/engine-core.md`** — documents the virtual module implementation pattern

Routes and overrides start empty. Tasks 3.4/3.6 and 3.7 pass real data into `createVirtualModulesPlugin({ ..., routes, overrides })`.

Closes rainonej/profesional_site#202

## Acceptance criteria

- [x] All four virtual modules implemented with correct `resolveId`/`load` hooks
- [x] TypeScript types available via `client.d.ts` — no `any` for module contents
- [x] `docs/packages/engine-core.md` updated with implementation detail
- [ ] `astro check` in demo-site — demo-site doesn't exist yet (Task 4.5); will verify when it lands

## Test plan

- [ ] `pnpm --filter @portfolio-engine/engine-core check` — passes clean
- [ ] In a consuming package: `import { config } from '@portfolio-engine:config'` resolves with correct type after adding `/// <reference types="@portfolio-engine/engine-core/client" />`

🤖 Generated with [Claude Code](https://claude.com/claude-code)