### PR TITLE
docs(engine-core): ban packaged public-dir in v1 (Task 3.9)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Check no public/ directories in packages
+        run: |
+          if find packages -name 'public' -type d -not -path '*/node_modules/*' | grep -q .; then
+            echo "Error: public/ directory found inside packages/ (violates v1 constraint — see Task 3.9)"
+            find packages -name 'public' -type d -not -path '*/node_modules/*'
+            exit 1
+          fi
+
       - name: Check types
         run: pnpm check
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -45,6 +45,6 @@ portfolio-engine is organised into four layers. Each layer has a single responsi
 
 **Two-repo model.** Engine packages live in the public `portfolio-engine` repo. Consumer content and config live in the private `agreni-site` repo. They share no git history.
 
-**No packaged public-dir in v1.** Static assets are managed by the consumer, not the engine. This is a deliberate v1 non-goal.
+**No packaged `public/` directory in v1.** Static assets are managed by the consumer, not the engine. Theme packages use imported assets only (Vite handles them at build time). Packaged `public/` directory merging would require `astro-public`, which is not an approved dependency. This is a deliberate v1 non-goal codified in Task 3.9 (#208). No `public/` directories are permitted inside any `packages/` subdirectory — CI enforces this.
 
 See [dependencies.md](dependencies.md) for the approved and banned package list.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -45,6 +45,6 @@ portfolio-engine is organised into four layers. Each layer has a single responsi
 
 **Two-repo model.** Engine packages live in the public `portfolio-engine` repo. Consumer content and config live in the private `agreni-site` repo. They share no git history.
 
-**No packaged `public/` directory in v1.** Static assets are managed by the consumer, not the engine. Theme packages use imported assets only (Vite handles them at build time). Packaged `public/` directory merging would require `astro-public`, which is not an approved dependency. This is a deliberate v1 non-goal codified in Task 3.9 (#208). No `public/` directories are permitted inside any `packages/` subdirectory — CI enforces this.
+**No packaged `public/` directory in v1.** Static assets are managed by the consumer, not the engine. Theme packages use imported assets only (Vite handles them at build time). Packaged `public/` directory merging would require `astro-public`, which is not an approved dependency. This is a deliberate v1 non-goal codified in Task 3.9 (#208). No `public/` directories are permitted inside any `packages/` subdirectory — CI enforces this via a `find` check in `.github/workflows/ci.yml`.
 
 See [dependencies.md](dependencies.md) for the approved and banned package list.

--- a/packages/engine-core/README.md
+++ b/packages/engine-core/README.md
@@ -97,12 +97,30 @@ Provides TypeScript types for all virtual modules so theme and consumer code has
 
 ## Non-goals (v1)
 
-- **Packaged `public/` directory assets** — static assets are managed by the consumer (Task 3.9)
+- **Packaged `public/` directory assets** — static assets are managed by the consumer (see v1 constraints below)
 - **Generic multi-theme support** — engine-core is first-party, built for one theme
 - **Content collection management** — Astro's native content collections handle all content files
 - **Runtime API routes** — out of scope
 - **Arbitrary ecosystem plugin compatibility**
 - **Multi-theme marketplace abstractions**
+
+## v1 Constraints
+
+### No packaged `public/` directory
+
+Theme packages use **imported assets only**. No `public/` directory is shipped inside any package.
+
+| Asset type | Location | How it works |
+|---|---|---|
+| Theme CSS, fonts, inline SVGs | Imported inside theme components | Bundled by Vite at build time |
+| Site media (photos, project images) | `agreni-site/public/media/` | Served by Astro from consumer's public dir |
+| Theme-owned decorative assets | Imported inside theme components | Not placed in any `public/` dir |
+
+**Why:** Packaged `public/` directory merging requires `astro-public` or equivalent hacks. `astro-public` is not an approved dependency. This is a deliberate v1 non-goal.
+
+**Enforced by:** No `public/` directories are allowed inside any `packages/` subdirectory. CI will fail if one is introduced (see `docs/architecture/README.md`).
+
+If this constraint needs to be revisited, open a new issue referencing this decision (Task 3.9 — #208).
 
 ## Implementation
 

--- a/packages/engine-core/README.md
+++ b/packages/engine-core/README.md
@@ -118,7 +118,7 @@ Theme packages use **imported assets only**. No `public/` directory is shipped i
 
 **Why:** Packaged `public/` directory merging requires `astro-public` or equivalent hacks. `astro-public` is not an approved dependency. This is a deliberate v1 non-goal.
 
-**Enforced by:** No `public/` directories are allowed inside any `packages/` subdirectory. CI will fail if one is introduced (see `docs/architecture/README.md`).
+**Enforced by:** No `public/` directories are allowed inside any `packages/` subdirectory. CI fails if one is introduced (see [docs/architecture/README.md](../../docs/architecture/README.md)).
 
 If this constraint needs to be revisited, open a new issue referencing this decision (Task 3.9 — #208).
 


### PR DESCRIPTION
## Summary

Codifies the v1 policy that no `public/` directory may exist inside any package.

- **`packages/engine-core/README.md`** — new "v1 Constraints" section with an asset placement table, rationale (astro-public not approved), and CI enforcement note
- **`docs/architecture/README.md`** — expands the existing public-dir note to include rationale, enforcement mechanism, and #208 reference

Closes rainonej/profesional_site#208

## Acceptance criteria

- [x] Policy documented in engine-core README under "v1 Constraints"
- [x] Policy documented in docs/architecture/README.md
- [x] No `public/` directories exist in any package (verified — none present)
- [x] Future issues referencing this decision can cite Task 3.9 / #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)