### PR TITLE
feat(engine-core): route registry contract (Task 3.6)

### DIFF
--- a/docs/packages/engine-core.md
+++ b/docs/packages/engine-core.md
@@ -27,12 +27,22 @@ Consumers never call engine-core directly. The public API is `editorialTheme()` 
 
 ## Virtual modules
 
-| Module ID | Type | Contents |
-|-----------|------|----------|
-| `@portfolio-engine:config` | `ResolvedConfig` | Validated site + navigation + theme + features config |
-| `@portfolio-engine:context` | `BuildContext` | Env, mode, base URL |
-| `@portfolio-engine:routes` | `RouteRecord[]` | All registered public + admin routes |
-| `@portfolio-engine:overrides` | `OverrideMap` | Component override map (component name → downstream path) |
+Implemented via native Vite `resolveId`/`load` plugin hooks. The `\0` prefix on resolved IDs is the Vite convention for virtual modules — it tells Vite not to look for the ID as a real file.
+
+| Module ID | Export | Type | Contents |
+|-----------|--------|------|----------|
+| `@portfolio-engine:config` | `config` | `ResolvedConfig` | Validated site + navigation + theme + features config |
+| `@portfolio-engine:context` | `context` | `BuildContext` | Env, mode, base URL |
+| `@portfolio-engine:routes` | `routes` | `RouteRecord[]` | All registered public + admin routes |
+| `@portfolio-engine:overrides` | `overrides` | `OverrideMap` | Component override map (component name → downstream path) |
+
+Consumer packages (e.g. `editorial-theme`) get full TypeScript types by adding a reference directive:
+
+```typescript
+/// <reference types="@portfolio-engine/engine-core/client" />
+```
+
+The plugin is created with `createVirtualModulesPlugin()` from `@portfolio-engine/engine-core` and passed to `updateConfig({ vite: { plugins: [...] } })` inside the `astro:config:setup` hook.
 
 ## Route registry shape
 

--- a/packages/engine-core/package.json
+++ b/packages/engine-core/package.json
@@ -4,7 +4,8 @@
   "description": "Route registry, config loader, virtual modules, and override resolution for portfolio-engine",
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./client": "./src/client.d.ts"
   },
   "scripts": {
     "build": "echo 'build not yet configured'",

--- a/packages/engine-core/src/client.d.ts
+++ b/packages/engine-core/src/client.d.ts
@@ -1,0 +1,22 @@
+// Ambient type declarations for @portfolio-engine virtual modules.
+// Reference this file in consuming packages:
+//   /// <reference types="@portfolio-engine/engine-core/client" />
+
+import type { ResolvedConfig } from './config-loader.js';
+import type { BuildContext, OverrideMap, RouteRecord } from './types.js';
+
+declare module '@portfolio-engine:config' {
+  export const config: ResolvedConfig;
+}
+
+declare module '@portfolio-engine:context' {
+  export const context: BuildContext;
+}
+
+declare module '@portfolio-engine:routes' {
+  export const routes: RouteRecord[];
+}
+
+declare module '@portfolio-engine:overrides' {
+  export const overrides: OverrideMap;
+}

--- a/packages/engine-core/src/client.d.ts
+++ b/packages/engine-core/src/client.d.ts
@@ -3,7 +3,7 @@
 //   /// <reference types="@portfolio-engine/engine-core/client" />
 
 import type { ResolvedConfig } from './config-loader.js';
-import type { BuildContext, OverrideMap, RouteRecord } from './types.js';
+import type { BuildContext, OverrideMap, RouteRegistry } from './types.js';
 
 declare module '@portfolio-engine:config' {
   export const config: ResolvedConfig;
@@ -14,7 +14,7 @@ declare module '@portfolio-engine:context' {
 }
 
 declare module '@portfolio-engine:routes' {
-  export const routes: RouteRecord[];
+  export const routes: RouteRegistry;
 }
 
 declare module '@portfolio-engine:overrides' {

--- a/packages/engine-core/src/index.ts
+++ b/packages/engine-core/src/index.ts
@@ -9,5 +9,8 @@ export type { BuildContext, OverrideMap, RouteRecord } from './types.js';
 export { createEngineIntegration } from './integration.js';
 export type { EngineIntegrationOptions } from './integration.js';
 
+export { applyRouteOverrides } from './route-remap.js';
+export type { RouteOverrides, RouteOverrideEntry, RouteRemapResult } from './route-remap.js';
+
 export { discoverRoutes, resolveThemePagesDir } from './route-discovery.js';
 export type { DiscoveredRoute } from './route-discovery.js';

--- a/packages/engine-core/src/index.ts
+++ b/packages/engine-core/src/index.ts
@@ -5,3 +5,9 @@ export { createVirtualModulesPlugin } from './virtual-modules.js';
 export type { VirtualModulePluginOptions } from './virtual-modules.js';
 
 export type { BuildContext, OverrideMap, RouteRecord } from './types.js';
+
+export { createEngineIntegration } from './integration.js';
+export type { EngineIntegrationOptions } from './integration.js';
+
+export { discoverRoutes, resolveThemePagesDir } from './route-discovery.js';
+export type { DiscoveredRoute } from './route-discovery.js';

--- a/packages/engine-core/src/index.ts
+++ b/packages/engine-core/src/index.ts
@@ -4,7 +4,7 @@ export type { EngineConfig, ResolvedConfig } from './config-loader.js';
 export { createVirtualModulesPlugin } from './virtual-modules.js';
 export type { VirtualModulePluginOptions } from './virtual-modules.js';
 
-export type { BuildContext, OverrideMap, RouteRecord } from './types.js';
+export type { BuildContext, OverrideMap, RouteRecord, RouteRegistry } from './types.js';
 
 export { createEngineIntegration } from './integration.js';
 export type { EngineIntegrationOptions } from './integration.js';

--- a/packages/engine-core/src/index.ts
+++ b/packages/engine-core/src/index.ts
@@ -1,2 +1,7 @@
 export { loadConfig } from './config-loader.js';
 export type { EngineConfig, ResolvedConfig } from './config-loader.js';
+
+export { createVirtualModulesPlugin } from './virtual-modules.js';
+export type { VirtualModulePluginOptions } from './virtual-modules.js';
+
+export type { BuildContext, OverrideMap, RouteRecord } from './types.js';

--- a/packages/engine-core/src/integration.ts
+++ b/packages/engine-core/src/integration.ts
@@ -1,0 +1,69 @@
+import type { AstroIntegration } from 'astro';
+import { fileURLToPath } from 'node:url';
+import type { EngineConfig } from './config-loader.js';
+import { loadConfig } from './config-loader.js';
+import { discoverRoutes, resolveThemePagesDir } from './route-discovery.js';
+import { createVirtualModulesPlugin } from './virtual-modules.js';
+import type { BuildContext } from './types.js';
+
+export interface EngineIntegrationOptions extends EngineConfig {
+  // Extended by Task 3.5 (route overrides) and Task 3.7 (component overrides)
+}
+
+export function createEngineIntegration(options: EngineIntegrationOptions): AstroIntegration {
+  return {
+    name: '@portfolio-engine/engine-core',
+    hooks: {
+      'astro:config:setup': async ({ config, command, injectRoute, updateConfig }) => {
+        const rootDir = fileURLToPath(config.root);
+
+        // 1. Load and validate config files
+        const resolvedConfig = await loadConfig(
+          {
+            siteConfigPath: options.siteConfigPath,
+            navigationConfigPath: options.navigationConfigPath,
+            themeConfigPath: options.themeConfigPath,
+            featuresConfigPath: options.featuresConfigPath,
+          },
+          config.root,
+        );
+
+        // 2. Discover routes from editorial-theme pages directory
+        const pagesDir = resolveThemePagesDir(rootDir);
+        const discovered = discoverRoutes(pagesDir);
+
+        // 3. Inject each discovered route into the consumer's Astro config
+        for (const route of discovered) {
+          injectRoute({ pattern: route.pattern, entrypoint: route.entrypoint });
+        }
+
+        // 4. Build context for virtual modules
+        const context: BuildContext = {
+          env: command === 'build' ? 'production' : 'development',
+          mode: command === 'build' ? 'production' : 'development',
+          base: config.base,
+        };
+
+        // 5. Register virtual modules plugin
+        // Cast needed: our local VitePlugin is a structural subset of Vite's Plugin
+        // type; the shapes are compatible at runtime but TypeScript can't verify
+        // this across the astro/vite type boundary without adding vite as a dep.
+        updateConfig({
+          vite: {
+            plugins: [
+              createVirtualModulesPlugin({
+                resolvedConfig,
+                context,
+                routes: discovered.map((r) => r.routeRecord),
+              }) as Parameters<typeof updateConfig>[0]['vite'] extends {
+                plugins?: (infer P)[] | undefined;
+              }
+                ? P
+                : never,
+            ],
+          },
+        });
+      },
+    },
+  };
+}

--- a/packages/engine-core/src/integration.ts
+++ b/packages/engine-core/src/integration.ts
@@ -3,11 +3,15 @@ import { fileURLToPath } from 'node:url';
 import type { EngineConfig } from './config-loader.js';
 import { loadConfig } from './config-loader.js';
 import { discoverRoutes, resolveThemePagesDir } from './route-discovery.js';
+import { applyRouteOverrides } from './route-remap.js';
+import type { RouteOverrides } from './route-remap.js';
 import { createVirtualModulesPlugin } from './virtual-modules.js';
 import type { BuildContext } from './types.js';
 
 export interface EngineIntegrationOptions extends EngineConfig {
-  // Extended by Task 3.5 (route overrides) and Task 3.7 (component overrides)
+  /** Remap or disable individual routes before injection. */
+  routes?: RouteOverrides;
+  // Extended by Task 3.7 (component overrides)
 }
 
 export function createEngineIntegration(options: EngineIntegrationOptions): AstroIntegration {
@@ -32,19 +36,22 @@ export function createEngineIntegration(options: EngineIntegrationOptions): Astr
         const pagesDir = resolveThemePagesDir(rootDir);
         const discovered = discoverRoutes(pagesDir);
 
-        // 3. Inject each discovered route into the consumer's Astro config
-        for (const route of discovered) {
+        // 3. Apply route remaps / disables from downstream config
+        const { routes: activeRoutes } = applyRouteOverrides(discovered, options.routes ?? {});
+
+        // 4. Inject each active route into the consumer's Astro config
+        for (const route of activeRoutes) {
           injectRoute({ pattern: route.pattern, entrypoint: route.entrypoint });
         }
 
-        // 4. Build context for virtual modules
+        // 5. Build context for virtual modules
         const context: BuildContext = {
           env: command === 'build' ? 'production' : 'development',
           mode: command === 'build' ? 'production' : 'development',
           base: config.base,
         };
 
-        // 5. Register virtual modules plugin
+        // 6. Register virtual modules plugin
         // Cast needed: our local VitePlugin is a structural subset of Vite's Plugin
         // type; the shapes are compatible at runtime but TypeScript can't verify
         // this across the astro/vite type boundary without adding vite as a dep.
@@ -54,7 +61,7 @@ export function createEngineIntegration(options: EngineIntegrationOptions): Astr
               createVirtualModulesPlugin({
                 resolvedConfig,
                 context,
-                routes: discovered.map((r) => r.routeRecord),
+                routes: activeRoutes.map((r) => r.routeRecord),
               }) as Parameters<typeof updateConfig>[0]['vite'] extends {
                 plugins?: (infer P)[] | undefined;
               }

--- a/packages/engine-core/src/route-discovery.ts
+++ b/packages/engine-core/src/route-discovery.ts
@@ -1,0 +1,124 @@
+import { readdirSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+import type { RouteRecord } from './types.js';
+
+export interface DiscoveredRoute {
+  /** Canonical URL pattern, e.g. /work/[slug] */
+  pattern: string;
+  /** Absolute path to the .astro source file */
+  entrypoint: string;
+  routeRecord: RouteRecord;
+}
+
+// Static metadata for the v1 route surface. Route files discovered on disk
+// are looked up here; unknown files get sensible defaults.
+const ROUTE_METADATA: Record<string, Omit<RouteRecord, 'pattern'>> = {
+  '/': {
+    label: 'Home',
+    section: null,
+    visibility: 'public',
+    remappable: true,
+    disableable: false,
+  },
+  '/about': {
+    label: 'About',
+    section: null,
+    visibility: 'public',
+    remappable: true,
+    disableable: true,
+  },
+  '/work': {
+    label: 'Work',
+    section: null,
+    visibility: 'public',
+    remappable: true,
+    disableable: true,
+  },
+  '/work/[slug]': {
+    label: 'Work detail',
+    section: null,
+    visibility: 'hidden',
+    remappable: false,
+    disableable: false,
+  },
+  '/writing': {
+    label: 'Writing',
+    section: null,
+    visibility: 'public',
+    remappable: true,
+    disableable: true,
+  },
+  '/writing/[slug]': {
+    label: 'Writing detail',
+    section: null,
+    visibility: 'hidden',
+    remappable: false,
+    disableable: false,
+  },
+  '/contact': {
+    label: 'Contact',
+    section: null,
+    visibility: 'public',
+    remappable: true,
+    disableable: true,
+  },
+  '/admin': {
+    label: 'Admin',
+    section: null,
+    visibility: 'admin-only',
+    remappable: false,
+    disableable: false,
+  },
+};
+
+function fileToPattern(relativePath: string): string {
+  let p = relativePath.replace(/\\/g, '/').replace(/\.astro$/, '');
+  if (p === 'index' || p.endsWith('/index')) {
+    p = p.slice(0, -'index'.length);
+  }
+  p = p.replace(/\/$/, '') || '/';
+  return p.startsWith('/') ? p : `/${p}`;
+}
+
+/**
+ * Scans pagesDir for .astro files and returns one DiscoveredRoute per file.
+ * Returns an empty array if the directory does not exist (expected before Epic 4).
+ */
+export function discoverRoutes(pagesDir: string): DiscoveredRoute[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(pagesDir, { recursive: true }) as string[];
+  } catch {
+    return [];
+  }
+
+  return entries
+    .filter((f) => f.endsWith('.astro'))
+    .map((f) => {
+      const pattern = fileToPattern(f);
+      const meta = ROUTE_METADATA[pattern] ?? {
+        label: pattern,
+        section: null,
+        visibility: 'public' as const,
+        remappable: true,
+        disableable: true,
+      };
+      return {
+        pattern,
+        entrypoint: join(pagesDir, f),
+        routeRecord: { pattern, ...meta },
+      };
+    });
+}
+
+/** Resolve the editorial-theme pages directory from a given project root. */
+export function resolveThemePagesDir(projectRootDir: string): string {
+  return resolve(
+    projectRootDir,
+    'node_modules',
+    '@portfolio-engine',
+    'editorial-theme',
+    'src',
+    'pages',
+  );
+}

--- a/packages/engine-core/src/route-discovery.ts
+++ b/packages/engine-core/src/route-discovery.ts
@@ -10,9 +10,9 @@ export interface DiscoveredRoute {
   routeRecord: RouteRecord;
 }
 
-// Static metadata for the v1 route surface. Route files discovered on disk
-// are looked up here; unknown files get sensible defaults.
-const ROUTE_METADATA: Record<string, Omit<RouteRecord, 'pattern'>> = {
+// Static metadata for the v1 route surface. resolved is omitted — it is
+// seeded to equal pattern at discovery time and updated by applyRouteOverrides.
+const ROUTE_METADATA: Record<string, Omit<RouteRecord, 'pattern' | 'resolved'>> = {
   '/': {
     label: 'Home',
     section: null,
@@ -96,7 +96,7 @@ export function discoverRoutes(pagesDir: string): DiscoveredRoute[] {
     .filter((f) => f.endsWith('.astro'))
     .map((f) => {
       const pattern = fileToPattern(f);
-      const meta = ROUTE_METADATA[pattern] ?? {
+      const meta: Omit<RouteRecord, 'pattern' | 'resolved'> = ROUTE_METADATA[pattern] ?? {
         label: pattern,
         section: null,
         visibility: 'public' as const,
@@ -106,7 +106,8 @@ export function discoverRoutes(pagesDir: string): DiscoveredRoute[] {
       return {
         pattern,
         entrypoint: join(pagesDir, f),
-        routeRecord: { pattern, ...meta },
+        // resolved starts equal to pattern; applyRouteOverrides may update it
+        routeRecord: { ...meta, pattern, resolved: pattern },
       };
     });
 }

--- a/packages/engine-core/src/route-remap.ts
+++ b/packages/engine-core/src/route-remap.ts
@@ -1,0 +1,72 @@
+import type { DiscoveredRoute } from './route-discovery.js';
+
+export interface RouteOverrideEntry {
+  /** false = exclude route from injection entirely */
+  enabled?: boolean;
+  /** Remap to a different URL path, e.g. '/essays' */
+  path?: string;
+}
+
+export type RouteOverrides = Record<string, RouteOverrideEntry>;
+
+export interface RouteRemapResult {
+  /** Routes to inject, after applying enabled/path overrides */
+  routes: DiscoveredRoute[];
+  /** Patterns explicitly disabled by downstream config */
+  disabled: string[];
+  /** Map from original pattern → remapped path for routes that were remapped */
+  remapped: Record<string, string>;
+}
+
+export function applyRouteOverrides(
+  discovered: DiscoveredRoute[],
+  overrides: RouteOverrides,
+): RouteRemapResult {
+  const unsupportedKeys = Object.keys(overrides).flatMap((pattern) => {
+    const entry = overrides[pattern];
+    return Object.keys(entry).filter((k) => k !== 'enabled' && k !== 'path').map((k) => `${pattern}.${k}`);
+  });
+  if (unsupportedKeys.length > 0) {
+    throw new Error(
+      `[portfolio-engine] Unsupported route override option(s): ${unsupportedKeys.join(', ')}\n` +
+        `  Only "enabled" and "path" are supported in v1.`,
+    );
+  }
+
+  const disabled: string[] = [];
+  const remapped: Record<string, string> = {};
+  const routes: DiscoveredRoute[] = [];
+
+  for (const route of discovered) {
+    const override = overrides[route.pattern];
+
+    if (override?.enabled === false) {
+      if (!route.routeRecord.disableable) {
+        throw new Error(
+          `[portfolio-engine] Route "${route.pattern}" cannot be disabled (disableable: false).`,
+        );
+      }
+      disabled.push(route.pattern);
+      continue;
+    }
+
+    if (override?.path !== undefined) {
+      if (!route.routeRecord.remappable) {
+        throw new Error(
+          `[portfolio-engine] Route "${route.pattern}" cannot be remapped (remappable: false).`,
+        );
+      }
+      remapped[route.pattern] = override.path;
+      routes.push({
+        ...route,
+        pattern: override.path,
+        routeRecord: { ...route.routeRecord, pattern: override.path },
+      });
+      continue;
+    }
+
+    routes.push(route);
+  }
+
+  return { routes, disabled, remapped };
+}

--- a/packages/engine-core/src/route-remap.ts
+++ b/packages/engine-core/src/route-remap.ts
@@ -60,7 +60,7 @@ export function applyRouteOverrides(
       routes.push({
         ...route,
         pattern: override.path,
-        routeRecord: { ...route.routeRecord, pattern: override.path },
+        routeRecord: { ...route.routeRecord, resolved: override.path },
       });
       continue;
     }

--- a/packages/engine-core/src/types.ts
+++ b/packages/engine-core/src/types.ts
@@ -1,0 +1,16 @@
+export interface BuildContext {
+  env: 'development' | 'production';
+  mode: string;
+  base: string;
+}
+
+export interface RouteRecord {
+  pattern: string;
+  label: string;
+  section: string | null;
+  visibility: 'public' | 'admin-only' | 'hidden';
+  remappable: boolean;
+  disableable: boolean;
+}
+
+export type OverrideMap = Record<string, string>;

--- a/packages/engine-core/src/types.ts
+++ b/packages/engine-core/src/types.ts
@@ -5,12 +5,18 @@ export interface BuildContext {
 }
 
 export interface RouteRecord {
+  /** Canonical URL pattern as declared by the theme, e.g. /work/[slug] */
   pattern: string;
+  /** Actual injected URL path after any consumer remap (equals pattern when not remapped) */
+  resolved: string;
   label: string;
   section: string | null;
   visibility: 'public' | 'admin-only' | 'hidden';
   remappable: boolean;
   disableable: boolean;
 }
+
+/** Stable public type: the full list of registered routes after override resolution. */
+export type RouteRegistry = RouteRecord[];
 
 export type OverrideMap = Record<string, string>;

--- a/packages/engine-core/src/virtual-modules.ts
+++ b/packages/engine-core/src/virtual-modules.ts
@@ -1,0 +1,68 @@
+import type { ResolvedConfig } from './config-loader.js';
+import type { BuildContext, OverrideMap, RouteRecord } from './types.js';
+
+// Minimal subset of the Vite Plugin interface — avoids a direct vite dep
+// while preserving correctness for the hooks engine-core actually uses.
+interface VitePlugin {
+  name: string;
+  resolveId?: (id: string) => string | null | undefined;
+  load?: (id: string) => string | null | undefined;
+}
+
+const VIRTUAL_MODULE_IDS = [
+  '@portfolio-engine:config',
+  '@portfolio-engine:context',
+  '@portfolio-engine:routes',
+  '@portfolio-engine:overrides',
+] as const;
+
+type VirtualModuleId = (typeof VIRTUAL_MODULE_IDS)[number];
+
+function isVirtualModuleId(id: string): id is VirtualModuleId {
+  return (VIRTUAL_MODULE_IDS as readonly string[]).includes(id);
+}
+
+// Vite convention: prefix resolved virtual IDs with \0 to avoid filesystem lookups
+function resolve(id: VirtualModuleId): string {
+  return `\0${id}`;
+}
+
+function unresolve(id: string): VirtualModuleId | undefined {
+  const candidate = id.slice(1); // strip leading \0
+  return isVirtualModuleId(candidate) ? candidate : undefined;
+}
+
+export interface VirtualModulePluginOptions {
+  resolvedConfig: ResolvedConfig;
+  context: BuildContext;
+  routes?: RouteRecord[];
+  overrides?: OverrideMap;
+}
+
+export function createVirtualModulesPlugin(options: VirtualModulePluginOptions): VitePlugin {
+  const { resolvedConfig, context, routes = [], overrides = {} } = options;
+
+  return {
+    name: '@portfolio-engine/virtual-modules',
+
+    resolveId(id) {
+      if (isVirtualModuleId(id)) return resolve(id);
+    },
+
+    load(id) {
+      const moduleId = unresolve(id);
+      if (!moduleId) return;
+
+      switch (moduleId) {
+        case '@portfolio-engine:config':
+          return `export const config = ${JSON.stringify(resolvedConfig)};`;
+        case '@portfolio-engine:context':
+          return `export const context = ${JSON.stringify(context)};`;
+        case '@portfolio-engine:routes':
+          return `export const routes = ${JSON.stringify(routes)};`;
+        case '@portfolio-engine:overrides':
+          return `export const overrides = ${JSON.stringify(overrides)};`;
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Implements Task 3.6 — `RouteRecord` and `RouteRegistry` as stable public exports.

- **`src/types.ts`** — adds `resolved: string` to `RouteRecord` (the injected URL after any remap; equals `pattern` when not remapped). Adds `RouteRegistry = RouteRecord[]` as a named stable type.
- **`src/route-discovery.ts`** — seeds `resolved = pattern` at discovery time; narrows `ROUTE_METADATA` to `Omit<RouteRecord, 'pattern' | 'resolved'>` since `resolved` is computed.
- **`src/route-remap.ts`** — sets `resolved = override.path` when a route is remapped.
- **`src/client.d.ts`** — `@portfolio-engine:routes` virtual module now typed as `RouteRegistry` (not `RouteRecord[]` directly).
- **`src/index.ts`** — exports `RouteRegistry`.

Consumable by `editorial-theme` (nav rendering), `admin-tools` (site map), and `workflow-kit` (route classifier) without circular dependencies — all import from `@portfolio-engine/engine-core`.

Closes rainonej/profesional_site#205

## Acceptance criteria

- [x] Route registry is a stable, typed public export
- [x] No circular dependencies (engine-core has no runtime deps on editorial-theme/admin-tools)
- [x] Registry available via `@portfolio-engine:routes` virtual module

🤖 Generated with [Claude Code](https://claude.com/claude-code)