### PR TITLE
feat(engine-core): type injection (Task 3.8)

### DIFF
--- a/docs/packages/engine-core.md
+++ b/docs/packages/engine-core.md
@@ -33,7 +33,7 @@ Implemented via native Vite `resolveId`/`load` plugin hooks. The `\0` prefix on 
 |-----------|--------|------|----------|
 | `@portfolio-engine:config` | `config` | `ResolvedConfig` | Validated site + navigation + theme + features config |
 | `@portfolio-engine:context` | `context` | `BuildContext` | Env, mode, base URL |
-| `@portfolio-engine:routes` | `routes` | `RouteRecord[]` | All registered public + admin routes |
+| `@portfolio-engine:routes` | `routes` | `RouteRecord[]` | Active (post-override) route registry — disabled routes excluded, remapped routes reflected |
 | `@portfolio-engine:overrides` | `overrides` | `OverrideMap` | Component override map (component name → downstream path) |
 
 Consumer packages (e.g. `editorial-theme`) get full TypeScript types by adding a reference directive:
@@ -49,6 +49,7 @@ The plugin is created with `createVirtualModulesPlugin()` from `@portfolio-engin
 ```typescript
 interface RouteRecord {
   pattern: string;           // e.g. /work/[slug]
+  resolved: string;          // actual injected path after any remap (equals pattern when not remapped)
   label: string;             // human-readable
   section: string | null;    // nav group
   visibility: 'public' | 'admin-only' | 'hidden';

--- a/docs/packages/engine-core.md
+++ b/docs/packages/engine-core.md
@@ -8,7 +8,7 @@ The Astro integration at the heart of portfolio-engine.
 - **Virtual modules** — exposes resolved config and build context to theme components via `@portfolio-engine:config`, `@portfolio-engine:context`, `@portfolio-engine:routes`, `@portfolio-engine:overrides`. Implemented with native Vite `resolveId`/`load` hooks.
 - **Route discovery + injection** — scans the `editorial-theme` pages directory and injects routes via Astro's `injectRoute` hook.
 - **Route remap / enable / disable** — consumers can disable or remap individual routes via config.
-- **Route registry** — exports a typed `RouteRecord[]` covering all public + admin routes.
+- **Route registry** — exports a typed `RouteRegistry` covering all active (post-override) public + admin routes.
 - **Override resolution** — resolves named component override surfaces declared by `editorial-theme`.
 - **Type injection** — provides TypeScript types for all virtual modules.
 
@@ -33,14 +33,10 @@ Implemented via native Vite `resolveId`/`load` plugin hooks. The `\0` prefix on 
 |-----------|--------|------|----------|
 | `@portfolio-engine:config` | `config` | `ResolvedConfig` | Validated site + navigation + theme + features config |
 | `@portfolio-engine:context` | `context` | `BuildContext` | Env, mode, base URL |
-| `@portfolio-engine:routes` | `routes` | `RouteRecord[]` | Active (post-override) route registry — disabled routes excluded, remapped routes reflected |
-| `@portfolio-engine:overrides` | `overrides` | `OverrideMap` | Component override map (component name → downstream path) |
+| `@portfolio-engine:routes` | `routes` | `RouteRegistry` | Active (post-override) route registry — disabled routes excluded, remapped routes reflected |
+| `@portfolio-engine:overrides` | `overrides` | `OverrideMap` | Component override map (component name → absolute path). Reserved key `__styles__` holds a JSON-encoded `string[]` of absolute CSS paths to append after the theme's global stylesheet. |
 
-Consumer packages (e.g. `editorial-theme`) get full TypeScript types by adding a reference directive:
-
-```typescript
-/// <reference types="@portfolio-engine/engine-core/client" />
-```
+Consumer packages (e.g. `editorial-theme`) get full TypeScript types automatically — the integration calls Astro's `injectTypes()` hook to inject a reference directive into the consumer's TypeScript environment. No manual setup is needed.
 
 The plugin is created with `createVirtualModulesPlugin()` from `@portfolio-engine/engine-core` and passed to `updateConfig({ vite: { plugins: [...] } })` inside the `astro:config:setup` hook.
 

--- a/docs/packages/engine-core.md
+++ b/docs/packages/engine-core.md
@@ -27,12 +27,22 @@ Consumers never call engine-core directly. The public API is `editorialTheme()` 
 
 ## Virtual modules
 
-| Module ID | Type | Contents |
-|-----------|------|----------|
-| `@portfolio-engine:config` | `ResolvedConfig` | Validated site + navigation + theme + features config |
-| `@portfolio-engine:context` | `BuildContext` | Env, mode, base URL |
-| `@portfolio-engine:routes` | `RouteRecord[]` | All registered public + admin routes |
-| `@portfolio-engine:overrides` | `OverrideMap` | Component override map (component name → downstream path) |
+Implemented via native Vite `resolveId`/`load` plugin hooks. The `\0` prefix on resolved IDs is the Vite convention for virtual modules — it tells Vite not to look for the ID as a real file.
+
+| Module ID | Export | Type | Contents |
+|-----------|--------|------|----------|
+| `@portfolio-engine:config` | `config` | `ResolvedConfig` | Validated site + navigation + theme + features config |
+| `@portfolio-engine:context` | `context` | `BuildContext` | Env, mode, base URL |
+| `@portfolio-engine:routes` | `routes` | `RouteRecord[]` | All registered public + admin routes |
+| `@portfolio-engine:overrides` | `overrides` | `OverrideMap` | Component override map (component name → downstream path) |
+
+Consumer packages (e.g. `editorial-theme`) get full TypeScript types by adding a reference directive:
+
+```typescript
+/// <reference types="@portfolio-engine/engine-core/client" />
+```
+
+The plugin is created with `createVirtualModulesPlugin()` from `@portfolio-engine/engine-core` and passed to `updateConfig({ vite: { plugins: [...] } })` inside the `astro:config:setup` hook.
 
 ## Route registry shape
 

--- a/packages/engine-core/package.json
+++ b/packages/engine-core/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
-    "./client": "./src/client.d.ts"
+    "./client": {
+      "types": "./src/client.d.ts"
+    }
   },
   "scripts": {
     "build": "echo 'build not yet configured'",

--- a/packages/engine-core/package.json
+++ b/packages/engine-core/package.json
@@ -4,7 +4,8 @@
   "description": "Route registry, config loader, virtual modules, and override resolution for portfolio-engine",
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./client": "./src/client.d.ts"
   },
   "scripts": {
     "build": "echo 'build not yet configured'",

--- a/packages/engine-core/src/client.d.ts
+++ b/packages/engine-core/src/client.d.ts
@@ -1,0 +1,22 @@
+// Ambient type declarations for @portfolio-engine virtual modules.
+// Reference this file in consuming packages:
+//   /// <reference types="@portfolio-engine/engine-core/client" />
+
+import type { ResolvedConfig } from './config-loader.js';
+import type { BuildContext, OverrideMap, RouteRecord } from './types.js';
+
+declare module '@portfolio-engine:config' {
+  export const config: ResolvedConfig;
+}
+
+declare module '@portfolio-engine:context' {
+  export const context: BuildContext;
+}
+
+declare module '@portfolio-engine:routes' {
+  export const routes: RouteRecord[];
+}
+
+declare module '@portfolio-engine:overrides' {
+  export const overrides: OverrideMap;
+}

--- a/packages/engine-core/src/client.d.ts
+++ b/packages/engine-core/src/client.d.ts
@@ -3,7 +3,7 @@
 //   /// <reference types="@portfolio-engine/engine-core/client" />
 
 import type { ResolvedConfig } from './config-loader.js';
-import type { BuildContext, OverrideMap, RouteRecord } from './types.js';
+import type { BuildContext, OverrideMap, RouteRegistry } from './types.js';
 
 declare module '@portfolio-engine:config' {
   export const config: ResolvedConfig;
@@ -14,7 +14,7 @@ declare module '@portfolio-engine:context' {
 }
 
 declare module '@portfolio-engine:routes' {
-  export const routes: RouteRecord[];
+  export const routes: RouteRegistry;
 }
 
 declare module '@portfolio-engine:overrides' {

--- a/packages/engine-core/src/index.ts
+++ b/packages/engine-core/src/index.ts
@@ -9,5 +9,8 @@ export type { BuildContext, OverrideMap, RouteRecord } from './types.js';
 export { createEngineIntegration } from './integration.js';
 export type { EngineIntegrationOptions } from './integration.js';
 
+export { applyRouteOverrides } from './route-remap.js';
+export type { RouteOverrides, RouteOverrideEntry, RouteRemapResult } from './route-remap.js';
+
 export { discoverRoutes, resolveThemePagesDir } from './route-discovery.js';
 export type { DiscoveredRoute } from './route-discovery.js';

--- a/packages/engine-core/src/index.ts
+++ b/packages/engine-core/src/index.ts
@@ -5,3 +5,9 @@ export { createVirtualModulesPlugin } from './virtual-modules.js';
 export type { VirtualModulePluginOptions } from './virtual-modules.js';
 
 export type { BuildContext, OverrideMap, RouteRecord } from './types.js';
+
+export { createEngineIntegration } from './integration.js';
+export type { EngineIntegrationOptions } from './integration.js';
+
+export { discoverRoutes, resolveThemePagesDir } from './route-discovery.js';
+export type { DiscoveredRoute } from './route-discovery.js';

--- a/packages/engine-core/src/index.ts
+++ b/packages/engine-core/src/index.ts
@@ -12,5 +12,8 @@ export type { EngineIntegrationOptions } from './integration.js';
 export { applyRouteOverrides } from './route-remap.js';
 export type { RouteOverrides, RouteOverrideEntry, RouteRemapResult } from './route-remap.js';
 
+export { resolveOverrides } from './override-resolution.js';
+export type { OverrideConfig } from './override-resolution.js';
+
 export { discoverRoutes, resolveThemePagesDir } from './route-discovery.js';
 export type { DiscoveredRoute } from './route-discovery.js';

--- a/packages/engine-core/src/index.ts
+++ b/packages/engine-core/src/index.ts
@@ -4,7 +4,7 @@ export type { EngineConfig, ResolvedConfig } from './config-loader.js';
 export { createVirtualModulesPlugin } from './virtual-modules.js';
 export type { VirtualModulePluginOptions } from './virtual-modules.js';
 
-export type { BuildContext, OverrideMap, RouteRecord } from './types.js';
+export type { BuildContext, OverrideMap, RouteRecord, RouteRegistry } from './types.js';
 
 export { createEngineIntegration } from './integration.js';
 export type { EngineIntegrationOptions } from './integration.js';

--- a/packages/engine-core/src/index.ts
+++ b/packages/engine-core/src/index.ts
@@ -1,2 +1,7 @@
 export { loadConfig } from './config-loader.js';
 export type { EngineConfig, ResolvedConfig } from './config-loader.js';
+
+export { createVirtualModulesPlugin } from './virtual-modules.js';
+export type { VirtualModulePluginOptions } from './virtual-modules.js';
+
+export type { BuildContext, OverrideMap, RouteRecord } from './types.js';

--- a/packages/engine-core/src/integration.ts
+++ b/packages/engine-core/src/integration.ts
@@ -42,9 +42,12 @@ export function createEngineIntegration(options: EngineIntegrationOptions): Astr
         // 3. Apply route remaps / disables from downstream config
         const { routes: activeRoutes } = applyRouteOverrides(discovered, options.routes ?? {});
 
-        // 4. Inject each active route into the consumer's Astro config
+        // 4. Inject each active route into the consumer's Astro config.
+        // Use routeRecord.resolved (the post-remap injected path) rather than
+        // route.pattern (canonical name), so remapped routes are injected at
+        // their new URL.
         for (const route of activeRoutes) {
-          injectRoute({ pattern: route.pattern, entrypoint: route.entrypoint });
+          injectRoute({ pattern: route.routeRecord.resolved, entrypoint: route.entrypoint });
         }
 
         // 5. Resolve component and style overrides

--- a/packages/engine-core/src/integration.ts
+++ b/packages/engine-core/src/integration.ts
@@ -1,0 +1,69 @@
+import type { AstroIntegration } from 'astro';
+import { fileURLToPath } from 'node:url';
+import type { EngineConfig } from './config-loader.js';
+import { loadConfig } from './config-loader.js';
+import { discoverRoutes, resolveThemePagesDir } from './route-discovery.js';
+import { createVirtualModulesPlugin } from './virtual-modules.js';
+import type { BuildContext } from './types.js';
+
+export interface EngineIntegrationOptions extends EngineConfig {
+  // Extended by Task 3.5 (route overrides) and Task 3.7 (component overrides)
+}
+
+export function createEngineIntegration(options: EngineIntegrationOptions): AstroIntegration {
+  return {
+    name: '@portfolio-engine/engine-core',
+    hooks: {
+      'astro:config:setup': async ({ config, command, injectRoute, updateConfig }) => {
+        const rootDir = fileURLToPath(config.root);
+
+        // 1. Load and validate config files
+        const resolvedConfig = await loadConfig(
+          {
+            siteConfigPath: options.siteConfigPath,
+            navigationConfigPath: options.navigationConfigPath,
+            themeConfigPath: options.themeConfigPath,
+            featuresConfigPath: options.featuresConfigPath,
+          },
+          config.root,
+        );
+
+        // 2. Discover routes from editorial-theme pages directory
+        const pagesDir = resolveThemePagesDir(rootDir);
+        const discovered = discoverRoutes(pagesDir);
+
+        // 3. Inject each discovered route into the consumer's Astro config
+        for (const route of discovered) {
+          injectRoute({ pattern: route.pattern, entrypoint: route.entrypoint });
+        }
+
+        // 4. Build context for virtual modules
+        const context: BuildContext = {
+          env: command === 'build' ? 'production' : 'development',
+          mode: command === 'build' ? 'production' : 'development',
+          base: config.base,
+        };
+
+        // 5. Register virtual modules plugin
+        // Cast needed: our local VitePlugin is a structural subset of Vite's Plugin
+        // type; the shapes are compatible at runtime but TypeScript can't verify
+        // this across the astro/vite type boundary without adding vite as a dep.
+        updateConfig({
+          vite: {
+            plugins: [
+              createVirtualModulesPlugin({
+                resolvedConfig,
+                context,
+                routes: discovered.map((r) => r.routeRecord),
+              }) as Parameters<typeof updateConfig>[0]['vite'] extends {
+                plugins?: (infer P)[] | undefined;
+              }
+                ? P
+                : never,
+            ],
+          },
+        });
+      },
+    },
+  };
+}

--- a/packages/engine-core/src/integration.ts
+++ b/packages/engine-core/src/integration.ts
@@ -3,11 +3,15 @@ import { fileURLToPath } from 'node:url';
 import type { EngineConfig } from './config-loader.js';
 import { loadConfig } from './config-loader.js';
 import { discoverRoutes, resolveThemePagesDir } from './route-discovery.js';
+import { applyRouteOverrides } from './route-remap.js';
+import type { RouteOverrides } from './route-remap.js';
 import { createVirtualModulesPlugin } from './virtual-modules.js';
 import type { BuildContext } from './types.js';
 
 export interface EngineIntegrationOptions extends EngineConfig {
-  // Extended by Task 3.5 (route overrides) and Task 3.7 (component overrides)
+  /** Remap or disable individual routes before injection. */
+  routes?: RouteOverrides;
+  // Extended by Task 3.7 (component overrides)
 }
 
 export function createEngineIntegration(options: EngineIntegrationOptions): AstroIntegration {
@@ -32,19 +36,22 @@ export function createEngineIntegration(options: EngineIntegrationOptions): Astr
         const pagesDir = resolveThemePagesDir(rootDir);
         const discovered = discoverRoutes(pagesDir);
 
-        // 3. Inject each discovered route into the consumer's Astro config
-        for (const route of discovered) {
+        // 3. Apply route remaps / disables from downstream config
+        const { routes: activeRoutes } = applyRouteOverrides(discovered, options.routes ?? {});
+
+        // 4. Inject each active route into the consumer's Astro config
+        for (const route of activeRoutes) {
           injectRoute({ pattern: route.pattern, entrypoint: route.entrypoint });
         }
 
-        // 4. Build context for virtual modules
+        // 5. Build context for virtual modules
         const context: BuildContext = {
           env: command === 'build' ? 'production' : 'development',
           mode: command === 'build' ? 'production' : 'development',
           base: config.base,
         };
 
-        // 5. Register virtual modules plugin
+        // 6. Register virtual modules plugin
         // Cast needed: our local VitePlugin is a structural subset of Vite's Plugin
         // type; the shapes are compatible at runtime but TypeScript can't verify
         // this across the astro/vite type boundary without adding vite as a dep.
@@ -54,7 +61,7 @@ export function createEngineIntegration(options: EngineIntegrationOptions): Astr
               createVirtualModulesPlugin({
                 resolvedConfig,
                 context,
-                routes: discovered.map((r) => r.routeRecord),
+                routes: activeRoutes.map((r) => r.routeRecord),
               }) as Parameters<typeof updateConfig>[0]['vite'] extends {
                 plugins?: (infer P)[] | undefined;
               }

--- a/packages/engine-core/src/integration.ts
+++ b/packages/engine-core/src/integration.ts
@@ -78,6 +78,15 @@ export function createEngineIntegration(options: EngineIntegrationOptions): Astr
           },
         });
       },
+
+      'astro:config:done': ({ injectTypes }) => {
+        // Inject the virtual module type declarations into the consumer's TS
+        // environment automatically — no manual reference directive needed.
+        injectTypes({
+          filename: 'types/portfolio-engine.d.ts',
+          content: '/// <reference types="@portfolio-engine/engine-core/client" />\n',
+        });
+      },
     },
   };
 }

--- a/packages/engine-core/src/integration.ts
+++ b/packages/engine-core/src/integration.ts
@@ -5,13 +5,16 @@ import { loadConfig } from './config-loader.js';
 import { discoverRoutes, resolveThemePagesDir } from './route-discovery.js';
 import { applyRouteOverrides } from './route-remap.js';
 import type { RouteOverrides } from './route-remap.js';
+import { resolveOverrides } from './override-resolution.js';
+import type { OverrideConfig } from './override-resolution.js';
 import { createVirtualModulesPlugin } from './virtual-modules.js';
 import type { BuildContext } from './types.js';
 
 export interface EngineIntegrationOptions extends EngineConfig {
   /** Remap or disable individual routes before injection. */
   routes?: RouteOverrides;
-  // Extended by Task 3.7 (component overrides)
+  /** Component and style overrides — downstream paths replace theme defaults. */
+  overrides?: OverrideConfig;
 }
 
 export function createEngineIntegration(options: EngineIntegrationOptions): AstroIntegration {
@@ -44,14 +47,17 @@ export function createEngineIntegration(options: EngineIntegrationOptions): Astr
           injectRoute({ pattern: route.pattern, entrypoint: route.entrypoint });
         }
 
-        // 5. Build context for virtual modules
+        // 5. Resolve component and style overrides
+        const overrides = resolveOverrides(options.overrides ?? {}, rootDir);
+
+        // 6. Build context for virtual modules
         const context: BuildContext = {
           env: command === 'build' ? 'production' : 'development',
           mode: command === 'build' ? 'production' : 'development',
           base: config.base,
         };
 
-        // 6. Register virtual modules plugin
+        // 7. Register virtual modules plugin
         // Cast needed: our local VitePlugin is a structural subset of Vite's Plugin
         // type; the shapes are compatible at runtime but TypeScript can't verify
         // this across the astro/vite type boundary without adding vite as a dep.
@@ -62,6 +68,7 @@ export function createEngineIntegration(options: EngineIntegrationOptions): Astr
                 resolvedConfig,
                 context,
                 routes: activeRoutes.map((r) => r.routeRecord),
+                overrides,
               }) as Parameters<typeof updateConfig>[0]['vite'] extends {
                 plugins?: (infer P)[] | undefined;
               }

--- a/packages/engine-core/src/override-resolution.ts
+++ b/packages/engine-core/src/override-resolution.ts
@@ -1,0 +1,53 @@
+import { resolve } from 'node:path';
+import type { OverrideMap } from './types.js';
+
+export interface OverrideConfig {
+  /**
+   * Named component overrides. Keys are the override surface names declared
+   * by editorial-theme; values are paths relative to the consumer project root.
+   *
+   * Example: { Hero: './src/overrides/components/Hero.astro' }
+   *
+   * Only surfaces explicitly declared by the theme are supported. Unrecognized
+   * surface names produce a build-time error.
+   */
+  components?: Record<string, string>;
+
+  /**
+   * CSS files to append after the theme's global.css.
+   * Paths are relative to the consumer project root.
+   *
+   * Example: ['./src/overrides/styles/custom.css']
+   */
+  styles?: string[];
+}
+
+/**
+ * Named override surfaces declared by editorial-theme in v1.
+ * Attempting to override a surface not in this list is a build-time error.
+ */
+const SUPPORTED_COMPONENT_SURFACES = new Set<string>([
+  // Populated by Task 4.4 (define override points). Empty in v1 until theme exists.
+]);
+
+export function resolveOverrides(config: OverrideConfig, projectRootDir: string): OverrideMap {
+  const overrideMap: OverrideMap = {};
+
+  const components = config.components ?? {};
+  for (const [surface, relativePath] of Object.entries(components)) {
+    if (!SUPPORTED_COMPONENT_SURFACES.has(surface)) {
+      throw new Error(
+        `[portfolio-engine] Unknown component override surface: "${surface}".\n` +
+          `  Supported surfaces: ${SUPPORTED_COMPONENT_SURFACES.size > 0 ? [...SUPPORTED_COMPONENT_SURFACES].join(', ') : '(none declared yet — override surfaces are defined in Task 4.4)'}`,
+      );
+    }
+    overrideMap[surface] = resolve(projectRootDir, relativePath);
+  }
+
+  const styles = config.styles ?? [];
+  if (styles.length > 0) {
+    overrideMap['__styles__'] = styles.map((p) => resolve(projectRootDir, p)).join(';');
+  }
+
+  return overrideMap;
+}

--- a/packages/engine-core/src/override-resolution.ts
+++ b/packages/engine-core/src/override-resolution.ts
@@ -46,7 +46,8 @@ export function resolveOverrides(config: OverrideConfig, projectRootDir: string)
 
   const styles = config.styles ?? [];
   if (styles.length > 0) {
-    overrideMap['__styles__'] = styles.map((p) => resolve(projectRootDir, p)).join(';');
+    // JSON-encoded array — avoids ambiguity since file paths can legally contain ';'.
+    overrideMap['__styles__'] = JSON.stringify(styles.map((p) => resolve(projectRootDir, p)));
   }
 
   return overrideMap;

--- a/packages/engine-core/src/route-discovery.ts
+++ b/packages/engine-core/src/route-discovery.ts
@@ -1,5 +1,7 @@
 import { readdirSync } from 'node:fs';
 import { resolve, join } from 'node:path';
+import { createRequire } from 'node:module';
+import type { Dirent } from 'node:fs';
 import type { RouteRecord } from './types.js';
 
 export interface DiscoveredRoute {
@@ -80,46 +82,83 @@ function fileToPattern(relativePath: string): string {
   return p.startsWith('/') ? p : `/${p}`;
 }
 
-/**
- * Scans pagesDir for .astro files and returns one DiscoveredRoute per file.
- * Returns an empty array if the directory does not exist (expected before Epic 4).
- */
-export function discoverRoutes(pagesDir: string): DiscoveredRoute[] {
-  let entries: string[];
+// Manual recursive readdir — Node 18 doesn't support readdirSync({ recursive: true }).
+function walkAstroFiles(dir: string, base = ''): string[] {
+  let entries: Dirent[];
   try {
-    entries = readdirSync(pagesDir, { recursive: true }) as string[];
+    entries = readdirSync(dir, { withFileTypes: true });
   } catch {
     return [];
   }
-
-  return entries
-    .filter((f) => f.endsWith('.astro'))
-    .map((f) => {
-      const pattern = fileToPattern(f);
-      const meta: Omit<RouteRecord, 'pattern' | 'resolved'> = ROUTE_METADATA[pattern] ?? {
-        label: pattern,
-        section: null,
-        visibility: 'public' as const,
-        remappable: true,
-        disableable: true,
-      };
-      return {
-        pattern,
-        entrypoint: join(pagesDir, f),
-        // resolved starts equal to pattern; applyRouteOverrides may update it
-        routeRecord: { ...meta, pattern, resolved: pattern },
-      };
-    });
+  const results: string[] = [];
+  for (const entry of entries) {
+    const rel = base ? join(base, entry.name) : entry.name;
+    if (entry.isDirectory()) {
+      results.push(...walkAstroFiles(join(dir, entry.name), rel));
+    } else if (entry.name.endsWith('.astro')) {
+      results.push(rel);
+    }
+  }
+  return results;
 }
 
-/** Resolve the editorial-theme pages directory from a given project root. */
+/**
+ * Scans pagesDir for .astro files and returns one DiscoveredRoute per file.
+ * Returns an empty array only if the directory does not exist (ENOENT/ENOTDIR).
+ * Other filesystem errors (permissions, I/O) are rethrown.
+ */
+export function discoverRoutes(pagesDir: string): DiscoveredRoute[] {
+  let files: string[];
+  try {
+    files = walkAstroFiles(pagesDir);
+  } catch (error) {
+    const code =
+      typeof error === 'object' && error !== null && 'code' in error
+        ? (error as NodeJS.ErrnoException).code
+        : undefined;
+    if (code === 'ENOENT' || code === 'ENOTDIR') return [];
+    throw error;
+  }
+
+  return files.map((f) => {
+    const pattern = fileToPattern(f);
+    const meta: Omit<RouteRecord, 'pattern' | 'resolved'> = ROUTE_METADATA[pattern] ?? {
+      label: pattern,
+      section: null,
+      visibility: 'public' as const,
+      remappable: true,
+      disableable: true,
+    };
+    return {
+      pattern,
+      entrypoint: join(pagesDir, f),
+      // resolved starts equal to pattern; applyRouteOverrides may update it
+      routeRecord: { ...meta, pattern, resolved: pattern },
+    };
+  });
+}
+
+/**
+ * Resolve the editorial-theme pages directory from a given project root.
+ * Uses createRequire to respect non-standard layouts (workspaces, pnpm, etc.)
+ * and falls back to the conventional node_modules path.
+ */
 export function resolveThemePagesDir(projectRootDir: string): string {
-  return resolve(
-    projectRootDir,
-    'node_modules',
-    '@portfolio-engine',
-    'editorial-theme',
-    'src',
-    'pages',
-  );
+  try {
+    const req = createRequire(join(projectRootDir, 'package.json'));
+    const entry = req.resolve('@portfolio-engine/editorial-theme');
+    // entry = .../editorial-theme/src/index.ts (or .js)
+    // Walk up to find the directory that contains src/pages.
+    // We go two levels up: index.ts → src/ → package root, then append src/pages.
+    return resolve(entry, '..', '..', '..', 'src', 'pages');
+  } catch {
+    return resolve(
+      projectRootDir,
+      'node_modules',
+      '@portfolio-engine',
+      'editorial-theme',
+      'src',
+      'pages',
+    );
+  }
 }

--- a/packages/engine-core/src/route-discovery.ts
+++ b/packages/engine-core/src/route-discovery.ts
@@ -91,6 +91,7 @@ function walkAstroFiles(dir: string, base = ''): string[] {
     return [];
   }
   const results: string[] = [];
+  entries.sort((a, b) => a.name.localeCompare(b.name));
   for (const entry of entries) {
     const rel = base ? join(base, entry.name) : entry.name;
     if (entry.isDirectory()) {

--- a/packages/engine-core/src/route-discovery.ts
+++ b/packages/engine-core/src/route-discovery.ts
@@ -1,0 +1,124 @@
+import { readdirSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+import type { RouteRecord } from './types.js';
+
+export interface DiscoveredRoute {
+  /** Canonical URL pattern, e.g. /work/[slug] */
+  pattern: string;
+  /** Absolute path to the .astro source file */
+  entrypoint: string;
+  routeRecord: RouteRecord;
+}
+
+// Static metadata for the v1 route surface. Route files discovered on disk
+// are looked up here; unknown files get sensible defaults.
+const ROUTE_METADATA: Record<string, Omit<RouteRecord, 'pattern'>> = {
+  '/': {
+    label: 'Home',
+    section: null,
+    visibility: 'public',
+    remappable: true,
+    disableable: false,
+  },
+  '/about': {
+    label: 'About',
+    section: null,
+    visibility: 'public',
+    remappable: true,
+    disableable: true,
+  },
+  '/work': {
+    label: 'Work',
+    section: null,
+    visibility: 'public',
+    remappable: true,
+    disableable: true,
+  },
+  '/work/[slug]': {
+    label: 'Work detail',
+    section: null,
+    visibility: 'hidden',
+    remappable: false,
+    disableable: false,
+  },
+  '/writing': {
+    label: 'Writing',
+    section: null,
+    visibility: 'public',
+    remappable: true,
+    disableable: true,
+  },
+  '/writing/[slug]': {
+    label: 'Writing detail',
+    section: null,
+    visibility: 'hidden',
+    remappable: false,
+    disableable: false,
+  },
+  '/contact': {
+    label: 'Contact',
+    section: null,
+    visibility: 'public',
+    remappable: true,
+    disableable: true,
+  },
+  '/admin': {
+    label: 'Admin',
+    section: null,
+    visibility: 'admin-only',
+    remappable: false,
+    disableable: false,
+  },
+};
+
+function fileToPattern(relativePath: string): string {
+  let p = relativePath.replace(/\\/g, '/').replace(/\.astro$/, '');
+  if (p === 'index' || p.endsWith('/index')) {
+    p = p.slice(0, -'index'.length);
+  }
+  p = p.replace(/\/$/, '') || '/';
+  return p.startsWith('/') ? p : `/${p}`;
+}
+
+/**
+ * Scans pagesDir for .astro files and returns one DiscoveredRoute per file.
+ * Returns an empty array if the directory does not exist (expected before Epic 4).
+ */
+export function discoverRoutes(pagesDir: string): DiscoveredRoute[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(pagesDir, { recursive: true }) as string[];
+  } catch {
+    return [];
+  }
+
+  return entries
+    .filter((f) => f.endsWith('.astro'))
+    .map((f) => {
+      const pattern = fileToPattern(f);
+      const meta = ROUTE_METADATA[pattern] ?? {
+        label: pattern,
+        section: null,
+        visibility: 'public' as const,
+        remappable: true,
+        disableable: true,
+      };
+      return {
+        pattern,
+        entrypoint: join(pagesDir, f),
+        routeRecord: { pattern, ...meta },
+      };
+    });
+}
+
+/** Resolve the editorial-theme pages directory from a given project root. */
+export function resolveThemePagesDir(projectRootDir: string): string {
+  return resolve(
+    projectRootDir,
+    'node_modules',
+    '@portfolio-engine',
+    'editorial-theme',
+    'src',
+    'pages',
+  );
+}

--- a/packages/engine-core/src/route-discovery.ts
+++ b/packages/engine-core/src/route-discovery.ts
@@ -10,9 +10,9 @@ export interface DiscoveredRoute {
   routeRecord: RouteRecord;
 }
 
-// Static metadata for the v1 route surface. Route files discovered on disk
-// are looked up here; unknown files get sensible defaults.
-const ROUTE_METADATA: Record<string, Omit<RouteRecord, 'pattern'>> = {
+// Static metadata for the v1 route surface. resolved is omitted — it is
+// seeded to equal pattern at discovery time and updated by applyRouteOverrides.
+const ROUTE_METADATA: Record<string, Omit<RouteRecord, 'pattern' | 'resolved'>> = {
   '/': {
     label: 'Home',
     section: null,
@@ -96,7 +96,7 @@ export function discoverRoutes(pagesDir: string): DiscoveredRoute[] {
     .filter((f) => f.endsWith('.astro'))
     .map((f) => {
       const pattern = fileToPattern(f);
-      const meta = ROUTE_METADATA[pattern] ?? {
+      const meta: Omit<RouteRecord, 'pattern' | 'resolved'> = ROUTE_METADATA[pattern] ?? {
         label: pattern,
         section: null,
         visibility: 'public' as const,
@@ -106,7 +106,8 @@ export function discoverRoutes(pagesDir: string): DiscoveredRoute[] {
       return {
         pattern,
         entrypoint: join(pagesDir, f),
-        routeRecord: { pattern, ...meta },
+        // resolved starts equal to pattern; applyRouteOverrides may update it
+        routeRecord: { ...meta, pattern, resolved: pattern },
       };
     });
 }

--- a/packages/engine-core/src/route-remap.ts
+++ b/packages/engine-core/src/route-remap.ts
@@ -25,6 +25,18 @@ export function applyRouteOverrides(
   // 1. Reject unknown keys in override entries
   const unsupportedKeys = Object.keys(overrides).flatMap((pattern) => {
     const entry = overrides[pattern];
+    if (
+      entry === null ||
+      entry === undefined ||
+      typeof entry !== 'object' ||
+      Array.isArray(entry)
+    ) {
+      const entryType =
+        entry === null ? 'null' : Array.isArray(entry) ? 'array' : typeof entry;
+      throw new Error(
+        `[portfolio-engine] Invalid route override for pattern "${pattern}": expected an object with optional "enabled" and "path" properties, received ${entryType}.`,
+      );
+    }
     return Object.keys(entry)
       .filter((k) => k !== 'enabled' && k !== 'path')
       .map((k) => `${pattern}.${k}`);
@@ -51,10 +63,10 @@ export function applyRouteOverrides(
     if (
       'path' in entry &&
       typeof entry.path === 'string' &&
-      !entry.path.startsWith('/')
+      (entry.path.length === 0 || !entry.path.startsWith('/'))
     ) {
       throw new Error(
-        `[portfolio-engine] Route override "${pattern}.path" must start with "/", got "${entry.path}".`,
+        `[portfolio-engine] Route override "${pattern}.path" must be a non-empty string starting with "/", got "${entry.path}".`,
       );
     }
     if ('enabled' in entry && entry.enabled === false && 'path' in entry) {
@@ -102,7 +114,6 @@ export function applyRouteOverrides(
       remapped[route.pattern] = override.path;
       routes.push({
         ...route,
-        pattern: override.path,
         routeRecord: { ...route.routeRecord, resolved: override.path },
       });
       continue;
@@ -112,15 +123,18 @@ export function applyRouteOverrides(
   }
 
   // 4. Detect duplicate injected patterns after applying overrides
+  // Use routeRecord.resolved (the actual injected path) rather than route.pattern
+  // (canonical), since two different canonical routes could remap to the same target.
   const seen = new Set<string>();
   const duplicates: string[] = [];
   for (const r of routes) {
-    if (seen.has(r.pattern)) duplicates.push(r.pattern);
-    else seen.add(r.pattern);
+    const injected = r.routeRecord.resolved;
+    if (seen.has(injected)) duplicates.push(injected);
+    else seen.add(injected);
   }
   if (duplicates.length > 0) {
     throw new Error(
-      `[portfolio-engine] Duplicate route patterns after applying overrides: ${duplicates.join(', ')}`,
+      `[portfolio-engine] Duplicate injected route patterns after applying overrides: ${duplicates.join(', ')}`,
     );
   }
 

--- a/packages/engine-core/src/route-remap.ts
+++ b/packages/engine-core/src/route-remap.ts
@@ -22,15 +22,58 @@ export function applyRouteOverrides(
   discovered: DiscoveredRoute[],
   overrides: RouteOverrides,
 ): RouteRemapResult {
+  // 1. Reject unknown keys in override entries
   const unsupportedKeys = Object.keys(overrides).flatMap((pattern) => {
     const entry = overrides[pattern];
-    return Object.keys(entry).filter((k) => k !== 'enabled' && k !== 'path').map((k) => `${pattern}.${k}`);
+    return Object.keys(entry)
+      .filter((k) => k !== 'enabled' && k !== 'path')
+      .map((k) => `${pattern}.${k}`);
   });
   if (unsupportedKeys.length > 0) {
     throw new Error(
       `[portfolio-engine] Unsupported route override option(s): ${unsupportedKeys.join(', ')}\n` +
         `  Only "enabled" and "path" are supported in v1.`,
     );
+  }
+
+  // 2. Validate types of enabled/path values
+  for (const [pattern, entry] of Object.entries(overrides)) {
+    if ('enabled' in entry && typeof entry.enabled !== 'boolean') {
+      throw new Error(
+        `[portfolio-engine] Route override "${pattern}.enabled" must be a boolean, got ${typeof entry.enabled}.`,
+      );
+    }
+    if ('path' in entry && typeof entry.path !== 'string') {
+      throw new Error(
+        `[portfolio-engine] Route override "${pattern}.path" must be a string, got ${typeof entry.path}.`,
+      );
+    }
+    if (
+      'path' in entry &&
+      typeof entry.path === 'string' &&
+      !entry.path.startsWith('/')
+    ) {
+      throw new Error(
+        `[portfolio-engine] Route override "${pattern}.path" must start with "/", got "${entry.path}".`,
+      );
+    }
+    if ('enabled' in entry && entry.enabled === false && 'path' in entry) {
+      throw new Error(
+        `[portfolio-engine] Route override "${pattern}" has both enabled: false and path — these are contradictory.`,
+      );
+    }
+  }
+
+  // 3. Reject overrides that target unknown patterns (catches typos)
+  if (discovered.length > 0) {
+    const known = new Set(discovered.map((r) => r.pattern));
+    const unknown = Object.keys(overrides).filter((p) => !known.has(p));
+    if (unknown.length > 0) {
+      throw new Error(
+        `[portfolio-engine] Route override(s) target pattern(s) not in the registry: ${unknown.join(', ')}\n` +
+          `  Available patterns: ${[...known].join(', ')}`,
+      );
+    }
   }
 
   const disabled: string[] = [];
@@ -66,6 +109,19 @@ export function applyRouteOverrides(
     }
 
     routes.push(route);
+  }
+
+  // 4. Detect duplicate injected patterns after applying overrides
+  const seen = new Set<string>();
+  const duplicates: string[] = [];
+  for (const r of routes) {
+    if (seen.has(r.pattern)) duplicates.push(r.pattern);
+    else seen.add(r.pattern);
+  }
+  if (duplicates.length > 0) {
+    throw new Error(
+      `[portfolio-engine] Duplicate route patterns after applying overrides: ${duplicates.join(', ')}`,
+    );
   }
 
   return { routes, disabled, remapped };

--- a/packages/engine-core/src/route-remap.ts
+++ b/packages/engine-core/src/route-remap.ts
@@ -1,0 +1,72 @@
+import type { DiscoveredRoute } from './route-discovery.js';
+
+export interface RouteOverrideEntry {
+  /** false = exclude route from injection entirely */
+  enabled?: boolean;
+  /** Remap to a different URL path, e.g. '/essays' */
+  path?: string;
+}
+
+export type RouteOverrides = Record<string, RouteOverrideEntry>;
+
+export interface RouteRemapResult {
+  /** Routes to inject, after applying enabled/path overrides */
+  routes: DiscoveredRoute[];
+  /** Patterns explicitly disabled by downstream config */
+  disabled: string[];
+  /** Map from original pattern → remapped path for routes that were remapped */
+  remapped: Record<string, string>;
+}
+
+export function applyRouteOverrides(
+  discovered: DiscoveredRoute[],
+  overrides: RouteOverrides,
+): RouteRemapResult {
+  const unsupportedKeys = Object.keys(overrides).flatMap((pattern) => {
+    const entry = overrides[pattern];
+    return Object.keys(entry).filter((k) => k !== 'enabled' && k !== 'path').map((k) => `${pattern}.${k}`);
+  });
+  if (unsupportedKeys.length > 0) {
+    throw new Error(
+      `[portfolio-engine] Unsupported route override option(s): ${unsupportedKeys.join(', ')}\n` +
+        `  Only "enabled" and "path" are supported in v1.`,
+    );
+  }
+
+  const disabled: string[] = [];
+  const remapped: Record<string, string> = {};
+  const routes: DiscoveredRoute[] = [];
+
+  for (const route of discovered) {
+    const override = overrides[route.pattern];
+
+    if (override?.enabled === false) {
+      if (!route.routeRecord.disableable) {
+        throw new Error(
+          `[portfolio-engine] Route "${route.pattern}" cannot be disabled (disableable: false).`,
+        );
+      }
+      disabled.push(route.pattern);
+      continue;
+    }
+
+    if (override?.path !== undefined) {
+      if (!route.routeRecord.remappable) {
+        throw new Error(
+          `[portfolio-engine] Route "${route.pattern}" cannot be remapped (remappable: false).`,
+        );
+      }
+      remapped[route.pattern] = override.path;
+      routes.push({
+        ...route,
+        pattern: override.path,
+        routeRecord: { ...route.routeRecord, pattern: override.path },
+      });
+      continue;
+    }
+
+    routes.push(route);
+  }
+
+  return { routes, disabled, remapped };
+}

--- a/packages/engine-core/src/route-remap.ts
+++ b/packages/engine-core/src/route-remap.ts
@@ -60,7 +60,7 @@ export function applyRouteOverrides(
       routes.push({
         ...route,
         pattern: override.path,
-        routeRecord: { ...route.routeRecord, pattern: override.path },
+        routeRecord: { ...route.routeRecord, resolved: override.path },
       });
       continue;
     }

--- a/packages/engine-core/src/types.ts
+++ b/packages/engine-core/src/types.ts
@@ -1,0 +1,16 @@
+export interface BuildContext {
+  env: 'development' | 'production';
+  mode: string;
+  base: string;
+}
+
+export interface RouteRecord {
+  pattern: string;
+  label: string;
+  section: string | null;
+  visibility: 'public' | 'admin-only' | 'hidden';
+  remappable: boolean;
+  disableable: boolean;
+}
+
+export type OverrideMap = Record<string, string>;

--- a/packages/engine-core/src/types.ts
+++ b/packages/engine-core/src/types.ts
@@ -5,12 +5,18 @@ export interface BuildContext {
 }
 
 export interface RouteRecord {
+  /** Canonical URL pattern as declared by the theme, e.g. /work/[slug] */
   pattern: string;
+  /** Actual injected URL path after any consumer remap (equals pattern when not remapped) */
+  resolved: string;
   label: string;
   section: string | null;
   visibility: 'public' | 'admin-only' | 'hidden';
   remappable: boolean;
   disableable: boolean;
 }
+
+/** Stable public type: the full list of registered routes after override resolution. */
+export type RouteRegistry = RouteRecord[];
 
 export type OverrideMap = Record<string, string>;

--- a/packages/engine-core/src/virtual-modules.ts
+++ b/packages/engine-core/src/virtual-modules.ts
@@ -3,10 +3,12 @@ import type { BuildContext, OverrideMap, RouteRecord } from './types.js';
 
 // Minimal subset of the Vite Plugin interface — avoids a direct vite dep
 // while preserving correctness for the hooks engine-core actually uses.
+// `this: any` matches Vite/Rollup's PluginContext expectation so the object
+// is assignable to vite.plugins without a TS error at the call site.
 interface VitePlugin {
   name: string;
-  resolveId?: (id: string) => string | null | undefined;
-  load?: (id: string) => string | null | undefined;
+  resolveId?(this: any, id: string): string | null | undefined;
+  load?(this: any, id: string): string | null | undefined;
 }
 
 const VIRTUAL_MODULE_IDS = [
@@ -28,7 +30,7 @@ function resolve(id: VirtualModuleId): string {
 }
 
 function unresolve(id: string): VirtualModuleId | undefined {
-  const candidate = id.slice(1); // strip leading \0
+  const candidate = id.startsWith('\0') ? id.slice(1) : id;
   return isVirtualModuleId(candidate) ? candidate : undefined;
 }
 

--- a/packages/engine-core/src/virtual-modules.ts
+++ b/packages/engine-core/src/virtual-modules.ts
@@ -1,0 +1,68 @@
+import type { ResolvedConfig } from './config-loader.js';
+import type { BuildContext, OverrideMap, RouteRecord } from './types.js';
+
+// Minimal subset of the Vite Plugin interface — avoids a direct vite dep
+// while preserving correctness for the hooks engine-core actually uses.
+interface VitePlugin {
+  name: string;
+  resolveId?: (id: string) => string | null | undefined;
+  load?: (id: string) => string | null | undefined;
+}
+
+const VIRTUAL_MODULE_IDS = [
+  '@portfolio-engine:config',
+  '@portfolio-engine:context',
+  '@portfolio-engine:routes',
+  '@portfolio-engine:overrides',
+] as const;
+
+type VirtualModuleId = (typeof VIRTUAL_MODULE_IDS)[number];
+
+function isVirtualModuleId(id: string): id is VirtualModuleId {
+  return (VIRTUAL_MODULE_IDS as readonly string[]).includes(id);
+}
+
+// Vite convention: prefix resolved virtual IDs with \0 to avoid filesystem lookups
+function resolve(id: VirtualModuleId): string {
+  return `\0${id}`;
+}
+
+function unresolve(id: string): VirtualModuleId | undefined {
+  const candidate = id.slice(1); // strip leading \0
+  return isVirtualModuleId(candidate) ? candidate : undefined;
+}
+
+export interface VirtualModulePluginOptions {
+  resolvedConfig: ResolvedConfig;
+  context: BuildContext;
+  routes?: RouteRecord[];
+  overrides?: OverrideMap;
+}
+
+export function createVirtualModulesPlugin(options: VirtualModulePluginOptions): VitePlugin {
+  const { resolvedConfig, context, routes = [], overrides = {} } = options;
+
+  return {
+    name: '@portfolio-engine/virtual-modules',
+
+    resolveId(id) {
+      if (isVirtualModuleId(id)) return resolve(id);
+    },
+
+    load(id) {
+      const moduleId = unresolve(id);
+      if (!moduleId) return;
+
+      switch (moduleId) {
+        case '@portfolio-engine:config':
+          return `export const config = ${JSON.stringify(resolvedConfig)};`;
+        case '@portfolio-engine:context':
+          return `export const context = ${JSON.stringify(context)};`;
+        case '@portfolio-engine:routes':
+          return `export const routes = ${JSON.stringify(routes)};`;
+        case '@portfolio-engine:overrides':
+          return `export const overrides = ${JSON.stringify(overrides)};`;
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Implements Task 3.8 — virtual module types injected automatically into the consumer's TypeScript environment.

- **`src/integration.ts`** — adds `astro:config:done` hook to `createEngineIntegration()`. Calls Astro's built-in `injectTypes()` API to write `.astro/types/portfolio-engine.d.ts` with a `/// <reference types="@portfolio-engine/engine-core/client" />` directive. Astro automatically includes `.astro/types.d.ts` in the consumer's TS path, so the virtual module types are available without any manual setup in `env.d.ts`.

Consumers get full IDE autocomplete and type-checking for:
- `import { config } from '@portfolio-engine:config'` → `ResolvedConfig`
- `import { context } from '@portfolio-engine:context'` → `BuildContext`
- `import { routes } from '@portfolio-engine:routes'` → `RouteRegistry`
- `import { overrides } from '@portfolio-engine:overrides'` → `OverrideMap`

Closes rainonej/profesional_site#207

## Acceptance criteria

- [x] Key engine-provided values typed in downstream consumer — no `any` required
- [x] IDE autocomplete works for virtual module imports
- [ ] `astro check` passes in demo-site (blocked on Task 4.5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)