### PR TITLE
epic(175): extract editorial theme + Vercel deploy config

### DIFF
--- a/docs/issue-labels.md
+++ b/docs/issue-labels.md
@@ -39,7 +39,7 @@ For small chores you may use only a subset (for example `task:chore` + `area:ci`
 | ------------------ | --------------------------- | --------------------------------------------------------------------------------------------------------- |
 | `owner:simple-ai`  | GitHub Copilot coding agent | Fully specced, single-file or mechanical multi-file change. No decisions required.                        |
 | `owner:agentic-ai` | Claude / agentic automation | Multi-file, exploratory, or reasoning-required work. Can be picked up autonomously with `claude-ready`.   |
-| `owner:human-dev`  | Human maintainer (Jordan)   | Requires a human: UI click, credential/access grant, architecture decision, or something outside a shell. |
+| `owner:human-dev`  | Human maintainer            | Requires a human: UI click, credential/access grant, architecture decision, or something outside a shell. |
 | `owner:site-owner` | Site/product owner          | Content entry, approval, or config decision made by the site owner (e.g. Agreni for downstream sites).    |
 
 **Rule of thumb for `owner:human-dev`:** if you cannot complete this ticket entirely from a terminal + editor, it is `human-dev`. Examples: connecting a repo to Vercel in the dashboard, granting GitHub App access, approving a PR, setting a secret in GitHub UI.

--- a/docs/issue-labels.md
+++ b/docs/issue-labels.md
@@ -33,12 +33,16 @@ For small chores you may use only a subset (for example `task:chore` + `area:ci`
 
 ## Owner labels
 
-| Label              | Meaning                     | When to use                                               |
-| ------------------ | --------------------------- | --------------------------------------------------------- |
-| `owner:simple-ai`  | GitHub Copilot coding agent | Small, fully specced tasks                                |
-| `owner:agentic-ai` | Claude / agentic automation | Multi-file or exploratory work                            |
-| `owner:human-dev`  | Human maintainer            | Architecture, security, infra                             |
-| `owner:site-owner` | Site/product owner          | Content and approvals (often Agreni for downstream sites) |
+**Every task issue must carry exactly one owner label.** This is not optional. The label determines who can pick up the ticket — do not mix owners on a single ticket; split the ticket instead.
+
+| Label              | Who executes                | Concrete meaning                                                                                         |
+| ------------------ | --------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `owner:simple-ai`  | GitHub Copilot coding agent | Fully specced, single-file or mechanical multi-file change. No decisions required.                       |
+| `owner:agentic-ai` | Claude / agentic automation | Multi-file, exploratory, or reasoning-required work. Can be picked up autonomously with `claude-ready`.  |
+| `owner:human-dev`  | Human maintainer (Jordan)   | Requires a human: UI click, credential/access grant, architecture decision, or something outside a shell.|
+| `owner:site-owner` | Site/product owner          | Content entry, approval, or config decision made by the site owner (e.g. Agreni for downstream sites).  |
+
+**Rule of thumb for `owner:human-dev`:** if you cannot complete this ticket entirely from a terminal + editor, it is `human-dev`. Examples: connecting a repo to Vercel in the dashboard, granting GitHub App access, approving a PR, setting a secret in GitHub UI.
 
 ---
 

--- a/docs/issue-labels.md
+++ b/docs/issue-labels.md
@@ -35,12 +35,12 @@ For small chores you may use only a subset (for example `task:chore` + `area:ci`
 
 **Every task issue must carry exactly one owner label.** This is not optional. The label determines who can pick up the ticket — do not mix owners on a single ticket; split the ticket instead.
 
-| Label              | Who executes                | Concrete meaning                                                                                         |
-| ------------------ | --------------------------- | -------------------------------------------------------------------------------------------------------- |
-| `owner:simple-ai`  | GitHub Copilot coding agent | Fully specced, single-file or mechanical multi-file change. No decisions required.                       |
-| `owner:agentic-ai` | Claude / agentic automation | Multi-file, exploratory, or reasoning-required work. Can be picked up autonomously with `claude-ready`.  |
-| `owner:human-dev`  | Human maintainer (Jordan)   | Requires a human: UI click, credential/access grant, architecture decision, or something outside a shell.|
-| `owner:site-owner` | Site/product owner          | Content entry, approval, or config decision made by the site owner (e.g. Agreni for downstream sites).  |
+| Label              | Who executes                | Concrete meaning                                                                                          |
+| ------------------ | --------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `owner:simple-ai`  | GitHub Copilot coding agent | Fully specced, single-file or mechanical multi-file change. No decisions required.                        |
+| `owner:agentic-ai` | Claude / agentic automation | Multi-file, exploratory, or reasoning-required work. Can be picked up autonomously with `claude-ready`.   |
+| `owner:human-dev`  | Human maintainer (Jordan)   | Requires a human: UI click, credential/access grant, architecture decision, or something outside a shell. |
+| `owner:site-owner` | Site/product owner          | Content entry, approval, or config decision made by the site owner (e.g. Agreni for downstream sites).    |
 
 **Rule of thumb for `owner:human-dev`:** if you cannot complete this ticket entirely from a terminal + editor, it is `human-dev`. Examples: connecting a repo to Vercel in the dashboard, granting GitHub App access, approving a PR, setting a secret in GitHub UI.
 

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -20,7 +20,7 @@ This repo manages work in **GitHub Issues** and **[Project 2](https://github.com
 - **Epics** (`type:epic`): parent deliverables. Title: describe the outcome. Child tasks are linked via Relationships → Sub-issues.
 - **Tasks**: child issues. Every task issue **must** have exactly one `task:*` label and exactly one `owner:*` label — no exceptions, no omissions.
 - **Narrow scope**: each ticket covers one specific outcome. If completing it requires two distinct decisions or deliverables, split it. A good test: can the entire issue body fit in two sentences?
-- **Owner label defines who executes** — see [issue-labels.md](issue-labels.md) for the full contract. Key rule: `owner:human-dev` means nothing can be automated; a human must act (UI click, decision, access grant). All other owners can be handled without a human.
+- **Owner label defines who executes** — see [issue-labels.md](issue-labels.md) for the full contract. Key rule: `owner:human-dev` means nothing can be automated; a human must act (UI click, decision, access grant). Other owner labels do not necessarily require a maintainer/developer, but some still require human action (for example, `owner:site-owner`); follow `issue-labels.md` for the exact contract.
 - **Blocking:** Relationships → Blocked by / Blocking. Wire these for every dependency. A ticket without a blocker that depends on something unreleased is misconfigured.
 - **Epic linkage:** attach every task to its parent epic via Relationships → Sub-issues. If no epic exists for the work, create one first.
 - **Status:** Inbox → Planned → Blocked/Ready → In Progress → In Review → Done

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -17,10 +17,12 @@ This repo manages work in **GitHub Issues** and **[Project 2](https://github.com
 
 ## Conventions at a glance
 
-- **Epics** (`type:epic`): parent deliverables. Title: describe the outcome.
-- **Tasks**: child issues, each with exactly one `task:*` and one `owner:*` label (when using the full taxonomy).
-- **Linking:** use GitHub sub-issues (Relationships sidebar) to attach tasks to their epic.
-- **Blocking:** Relationships → Blocked by / Blocking.
+- **Epics** (`type:epic`): parent deliverables. Title: describe the outcome. Child tasks are linked via Relationships → Sub-issues.
+- **Tasks**: child issues. Every task issue **must** have exactly one `task:*` label and exactly one `owner:*` label — no exceptions, no omissions.
+- **Narrow scope**: each ticket covers one specific outcome. If completing it requires two distinct decisions or deliverables, split it. A good test: can the entire issue body fit in two sentences?
+- **Owner label defines who executes** — see [issue-labels.md](issue-labels.md) for the full contract. Key rule: `owner:human-dev` means nothing can be automated; a human must act (UI click, decision, access grant). All other owners can be handled without a human.
+- **Blocking:** Relationships → Blocked by / Blocking. Wire these for every dependency. A ticket without a blocker that depends on something unreleased is misconfigured.
+- **Epic linkage:** attach every task to its parent epic via Relationships → Sub-issues. If no epic exists for the work, create one first.
 - **Status:** Inbox → Planned → Blocked/Ready → In Progress → In Review → Done
 
 ---

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "buildCommand": "pnpm --filter demo-site build",
+  "outputDirectory": "examples/demo-site/dist",
+  "installCommand": "pnpm install --frozen-lockfile",
+  "framework": null
+}


### PR DESCRIPTION
## Summary

Merges Epic 175 (`epic/175-extract-editorial-theme`) into `dev`.

- Tasks 4.1–4.5: port components, layouts, styles, routes, `editorialTheme()` integration, override surfaces, and consumer demo into `@portfolio-engine/editorial-theme`
- `vercel.json` added for monorepo demo-site Vercel deployment
- Docs: tightened ticket conventions (narrow scope, exactly-one owner label), updated `issue-labels.md` and `project-management.md`

## Test plan

- [ ] CI lint / check / build passes
- [ ] `pnpm --filter demo-site build` succeeds locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)