### PR TITLE
docs(readme): rewrite for clarity — Claude-first setup flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ An Astro theme for personal portfolio sites. It provides routes, layouts, and st
 | **Vercel account** | [vercel.com](https://vercel.com)            |
 | **Claude Code**    | [claude.ai/code](https://claude.ai/code)    |
 
-**Then follow [`docs/downstream/setup-with-claude.md`](docs/downstream/setup-with-claude.md)** — a step-by-step runbook of Claude prompts and Vercel dashboard steps that takes you from empty folder to live site.
+**Then open [`docs/downstream/setup-with-claude.md`](docs/downstream/setup-with-claude.md), copy the whole file, and paste it into Claude Code.** Claude will ask for your details, build the project, and tell you exactly when to go click something in Vercel. One conversation, start to finish.
 
 ---
 
@@ -53,12 +53,12 @@ Check the [releases](https://github.com/rainonej/portfolio-engine/releases) befo
 
 ## More docs
 
-| Topic                                               | Link                                                                         |
-| --------------------------------------------------- | ---------------------------------------------------------------------------- |
-| Setup runbook (Claude prompts + Vercel steps)       | [docs/downstream/setup-with-claude.md](docs/downstream/setup-with-claude.md) |
-| New site setup (full manual reference)              | [docs/downstream/new-site-setup.md](docs/downstream/new-site-setup.md)       |
-| Semver vs. workspace-link, overrides, Vercel detail | [docs/downstream/consumption.md](docs/downstream/consumption.md)             |
-| Lint, format, CI                                    | [docs/contributing/linting.md](docs/contributing/linting.md)                 |
+| Topic                                                   | Link                                                                         |
+| ------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Setup with Claude (paste whole file, Claude guides you) | [docs/downstream/setup-with-claude.md](docs/downstream/setup-with-claude.md) |
+| New site setup (full manual reference)                  | [docs/downstream/new-site-setup.md](docs/downstream/new-site-setup.md)       |
+| Semver vs. workspace-link, overrides, Vercel detail     | [docs/downstream/consumption.md](docs/downstream/consumption.md)             |
+| Lint, format, CI                                        | [docs/contributing/linting.md](docs/contributing/linting.md)                 |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,102 +1,195 @@
 # portfolio-engine
 
-A first-party Astro engine for building personal portfolio sites. Opinionated, not generic — the shared backbone for private consumer repos (**[agreni-site](https://github.com/rainonej/agreni-site)** and **jordan-site**), open-sourced so design decisions stay transparent.
+An Astro theme for personal portfolio sites. It provides routes, layouts, and styles so you focus on your content — and it's designed to be set up entirely through Claude prompts.
 
-## Four-layer model
+---
+
+## Get your site live
+
+### What you need first
+
+| Tool           | Where to get it                          |
+| -------------- | ---------------------------------------- |
+| GitHub account | [github.com](https://github.com)         |
+| Vercel account | [vercel.com](https://vercel.com)         |
+| Node.js 22     | [nodejs.org](https://nodejs.org)         |
+| Claude Code    | [claude.ai/code](https://claude.ai/code) |
+
+Once you have those, open a new empty folder in your terminal and work through the steps below. Each step is a prompt to paste into Claude Code.
+
+---
+
+### Step 1 — Scaffold your site
+
+Open Claude Code in a new empty folder and paste this, filling in your details:
 
 ```
-┌─────────────────────────────────────────────────────────┐
-│  Consumer site (agreni-site, jordan-site)               │
-│  Content, config, overrides — private                   │
-├─────────────────────────────────────────────────────────┤
-│  @portfolio-engine/editorial-theme                      │
-│  Layouts, components, routes, styles                    │
-├─────────────────────────────────────────────────────────┤
-│  @portfolio-engine/engine-core                          │
-│  Config loader, virtual modules, route registry,         │
-│  override resolution                                     │
-├─────────────────────────────────────────────────────────┤
-│  @portfolio-engine/schema                               │
-│  Shared Zod schemas for content + config                │
-└─────────────────────────────────────────────────────────┘
+I'm setting up a new personal portfolio site using @portfolio-engine/editorial-theme from npm.
+Read the setup guide at:
+https://github.com/rainonej/portfolio-engine/blob/main/docs/downstream/new-site-setup.md
+
+My details:
+  Name:        [YOUR FULL NAME]
+  Role:        [WHAT YOU DO — e.g. "product designer", "educator", "software engineer"]
+  Tagline:     [SHORT PUNCHY LINE — e.g. "designs for clarity"]
+  Description: [ONE SENTENCE — your work and who you do it for]
+  Location:    [CITY, COUNTRY]
+  Tone:        [HOW YOU WRITE — e.g. "warm and direct", "precise and minimal"]
+  Audience:    [WHO READS YOUR SITE — e.g. "hiring managers in education nonprofits"]
+
+Create placeholder entries in src/content/ that I can swap out for real work later.
+Fill in src/context/ using my details above.
+When you're done, list exactly which files I still need to edit myself.
 ```
 
-## Packages
+---
 
-| Package                                                          | Description                                                         |
-| ---------------------------------------------------------------- | ------------------------------------------------------------------- |
-| [`@portfolio-engine/engine-core`](packages/engine-core/)         | Route registry, config loader, virtual modules, override resolution |
-| [`@portfolio-engine/editorial-theme`](packages/editorial-theme/) | The Astro theme: layouts, components, page routes                   |
-| [`@portfolio-engine/schema`](packages/schema/)                   | Shared Zod schemas for content and configuration                    |
-| [`@portfolio-engine/admin-tools`](packages/admin-tools/)         | Admin/reviewer UI, site map from route registry _(Epic 7)_          |
-| [`@portfolio-engine/workflow-kit`](packages/workflow-kit/)       | Reusable GitHub workflows and AI change classifier _(Epic 8)_       |
+### Step 2 — Push to GitHub
 
-## Dependencies and versions
+```
+Please push this project to GitHub.
+  1. Run git init if there's no repo here yet.
+  2. Create a new GitHub repo called [YOUR-REPO-NAME] — use the GitHub CLI if available,
+     otherwise walk me through creating it manually.
+  3. Commit everything and push to main.
+```
 
-- **Where versions live:** each package declares its own `dependencies` / `devDependencies` / `peerDependencies` in its `package.json`. The monorepo root [`package.json`](package.json) lists workspace tooling; **[`pnpm-lock.yaml`](pnpm-lock.yaml)** is the lockfile of record for exact resolved versions (similar to a single-environment lock in other ecosystems).
-- **Workspace layout:** [`pnpm-workspace.yaml`](pnpm-workspace.yaml) includes `packages/*` and `examples/*`.
-- **Runtime:** Node **≥ 18** and **pnpm ≥ 9** ([`engines`](package.json) on the root). CI uses Node **20**.
-- **Astro:** consumer sites and this repo’s packages target **Astro 5** (`peerDependencies` / devDependencies use a current 5.x line). Bump Astro deliberately across the workspace when upgrading.
-- **Publishing:** packages are published with [Changesets](CONTRIBUTING.md#changesets); consumers pin semver in their own repos.
+---
 
-## Install and develop
+### Step 3 — Connect to Vercel
+
+Do this yourself in the Vercel dashboard (takes 2 minutes):
+
+1. **Add New → Project** → import your GitHub repo
+2. **Root Directory:** `.` (the repo root — don't change this)
+3. **Build Command:** `pnpm build`
+4. **Node.js:** set to **22.x** under Settings → General
+5. Click **Deploy** and wait for it to go green
+
+Note your deployment URL (looks like `your-repo.vercel.app`).
+
+---
+
+### Step 4 — Make it real
+
+Come back to Claude Code with your live URL:
+
+```
+My site is live at [https://your-site.vercel.app].
+
+Please:
+  1. Update src/config/site.json baseUrl to the live URL.
+  2. Help me add my first real project to src/content/projects/.
+  3. Help me add my first real writing piece to src/content/writing/.
+  4. Ask me the questions needed to fill in src/context/brand-voice.json
+     with my actual tone, audience, and what language I want to avoid.
+```
+
+---
+
+### Step 5 — Set your production URL in Vercel
+
+In Vercel: **Project → Settings → Environment Variables**, add:
+
+- **Name:** `SITE_URL`
+- **Value:** your production URL (e.g. `https://yourname.com`)
+- **Environment:** Production only
+
+Trigger a redeploy after saving.
+
+---
+
+### Step 6 — Add a custom domain (optional)
+
+In Vercel: **Project → Settings → Domains** → add your domain, follow the DNS instructions.
+Then update the `SITE_URL` env var to match the new domain and redeploy.
+
+---
+
+## What lives where
+
+Your portfolio is its own private repo. This repo is the engine it consumes.
+
+```
+Your repo (e.g. jordan-site)        This repo (portfolio-engine)
+────────────────────────────        ──────────────────────────────
+src/
+  config/    ← your JSON config     @portfolio-engine/editorial-theme
+  content/   ← your writing/work      layouts, components, routes
+  context/   ← your identity (AI)   @portfolio-engine/engine-core
+  overrides/ ← component swaps        config loader, route registry
+                                    @portfolio-engine/schema
+                                       Zod schemas
+```
+
+The engine packages are published to npm. Your repo just installs them.
+
+---
+
+## Updating the theme
+
+```bash
+pnpm update @portfolio-engine/editorial-theme
+pnpm build   # make sure it still builds
+```
+
+Check the [changelog](https://github.com/rainonej/portfolio-engine/releases) before upgrading across a minor version.
+
+---
+
+## More docs
+
+| Topic                                               | Link                                                                   |
+| --------------------------------------------------- | ---------------------------------------------------------------------- |
+| New site setup (full step-by-step)                  | [docs/downstream/new-site-setup.md](docs/downstream/new-site-setup.md) |
+| Semver vs. workspace-link, overrides, Vercel detail | [docs/downstream/consumption.md](docs/downstream/consumption.md)       |
+| Lint, format, CI                                    | [docs/contributing/linting.md](docs/contributing/linting.md)           |
+
+---
+
+## For contributors to this repo
+
+<details>
+<summary>Expand</summary>
+
+### Install and develop
 
 ```bash
 git clone https://github.com/rainonej/portfolio-engine
 cd portfolio-engine
 pnpm install
 pnpm check    # Typecheck all packages
-pnpm build    # Run each package’s build script
-pnpm lint     # ESLint (TypeScript sources)
-pnpm format   # Prettier check (Markdown, YAML, JSON, …)
+pnpm build    # Build all packages
+pnpm lint     # ESLint
+pnpm format   # Prettier check
 ```
 
-## Example consumer (`examples/demo-site`)
+### Packages
 
-[`examples/demo-site/`](examples/demo-site/) is the canonical **reference Astro app**: workspace `workspace:*` deps, `editorialTheme({ ... })` in `astro.config.mjs`, config JSON, and content collections. See **[examples/demo-site/README.md](examples/demo-site/README.md)** for run instructions, Vercel layout, and what files are yours vs. the theme.
+| Package                                                          | Description                                                         |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------- |
+| [`@portfolio-engine/editorial-theme`](packages/editorial-theme/) | Astro theme: layouts, components, page routes                       |
+| [`@portfolio-engine/engine-core`](packages/engine-core/)         | Config loader, virtual modules, route registry, override resolution |
+| [`@portfolio-engine/schema`](packages/schema/)                   | Shared Zod schemas for content and configuration                    |
+| [`@portfolio-engine/admin-tools`](packages/admin-tools/)         | Admin/reviewer UI _(Epic 7)_                                        |
+| [`@portfolio-engine/workflow-kit`](packages/workflow-kit/)       | Reusable GitHub workflows and AI classifier _(Epic 8)_              |
 
-## Consuming the theme (downstream repo)
+### Runtime requirements
 
-```js
-// astro.config.mjs
-import { defineConfig } from 'astro/config';
-import { editorialTheme } from '@portfolio-engine/editorial-theme';
+- Node **≥ 18**, pnpm **≥ 9** — see [`engines`](package.json) in root `package.json`
+- CI uses Node 20; Vercel serverless uses Node 22
+- Astro 5 — bump deliberately across the workspace when upgrading
 
-export default defineConfig({
-  integrations: [
-    editorialTheme({
-      siteConfigPath: './src/config/site.json',
-      navigationConfigPath: './src/config/navigation.json',
-      themeConfigPath: './src/config/theme.json',
-      featuresConfigPath: './src/config/features.json',
-    }),
-  ],
-});
-```
+### Vercel (demo site)
 
-See [`packages/editorial-theme/README.md`](packages/editorial-theme/README.md) for required config, collections, and overrides.
+Connect **`rainonej/portfolio-engine`** in Vercel with root = repo root, install `pnpm install`, build `pnpm --filter demo-site run build`, output `examples/demo-site/dist`. Production on `main`; `dev` and PRs get previews. Details: [examples/demo-site/README.md](examples/demo-site/README.md#vercel).
 
-**Setting up a new consumer site from scratch?** See **[`docs/downstream/new-site-setup.md`](docs/downstream/new-site-setup.md)** — step-by-step commands, all config file templates, content collection setup, Vercel wiring, and a ready-to-paste Claude bootstrap prompt.
+### Publishing
 
-For **separate-repo** layout, semver vs. workspace-link, overrides, and **Vercel (production on `main`, previews on `dev`)**, see **[`docs/downstream/consumption.md`](docs/downstream/consumption.md)** — especially [§ Vercel (standalone consumer repo)](docs/downstream/consumption.md#vercel-standalone-consumer-repo).
+Packages are published with [Changesets](CONTRIBUTING.md#changesets). See [CONTRIBUTING.md](CONTRIBUTING.md) for branch flow, changesets, local linking, and Copilot review expectations.
 
-## CI
+### Issues and project board
 
-GitHub Actions runs **lint → typecheck → Astro check → build** on pushes to `main` / `dev` and on pull requests targeting `main`, `dev`, or `epic/*`. See [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
+[`docs/project-management.md`](docs/project-management.md) · [GitHub Project 2](https://github.com/users/rainonej/projects/2)
 
-## Vercel
-
-- **This monorepo (`examples/demo-site`):** connect **`rainonej/portfolio-engine`**, root = repo root, `pnpm install`, `pnpm --filter demo-site run build`, output `examples/demo-site/dist`. Production on **`main`**; **`dev`** and PRs → previews. Details: [examples/demo-site/README.md](examples/demo-site/README.md#vercel).
-- **A sibling consumer repo** (standalone site): follow **[`docs/downstream/consumption.md` § Vercel](docs/downstream/consumption.md#vercel-standalone-consumer-repo)** — root = that repo’s root, `pnpm build`, adapter/output as documented there.
-
-## Issues and project board
-
-Planning conventions, labels, and GitHub Project views are documented in **[`docs/github-project-board.md`](docs/github-project-board.md)** and **[`docs/project-management.md`](docs/project-management.md)**. Work for this codebase is tracked on **[GitHub Project 2](https://github.com/users/rainonej/projects/2)**.
-
-## Contributing
-
-See **[CONTRIBUTING.md](CONTRIBUTING.md)** for branch flow, changesets, local linking to consumer repos, **lint / format**, and **Copilot** / review expectations.
-
-## Status
-
-Under active development. Packages may be consumed via `workspace:*`, `link:`, or npm once published.
+</details>

--- a/README.md
+++ b/README.md
@@ -6,103 +6,17 @@ An Astro theme for personal portfolio sites. It provides routes, layouts, and st
 
 ## Get your site live
 
-### What you need first
+**You need:**
 
-| Tool           | Where to get it                          |
-| -------------- | ---------------------------------------- |
-| GitHub account | [github.com](https://github.com)         |
-| Vercel account | [vercel.com](https://vercel.com)         |
-| Node.js 22     | [nodejs.org](https://nodejs.org)         |
-| Claude Code    | [claude.ai/code](https://claude.ai/code) |
+|                    |                                             |
+| ------------------ | ------------------------------------------- |
+| **Node.js 22**     | [nodejs.org](https://nodejs.org)            |
+| **pnpm**           | `npm install -g pnpm` after installing Node |
+| **GitHub account** | [github.com](https://github.com)            |
+| **Vercel account** | [vercel.com](https://vercel.com)            |
+| **Claude Code**    | [claude.ai/code](https://claude.ai/code)    |
 
-Once you have those, open a new empty folder in your terminal and work through the steps below. Each step is a prompt to paste into Claude Code.
-
----
-
-### Step 1 — Scaffold your site
-
-Open Claude Code in a new empty folder and paste this, filling in your details:
-
-```
-I'm setting up a new personal portfolio site using @portfolio-engine/editorial-theme from npm.
-Read the setup guide at:
-https://github.com/rainonej/portfolio-engine/blob/main/docs/downstream/new-site-setup.md
-
-My details:
-  Name:        [YOUR FULL NAME]
-  Role:        [WHAT YOU DO — e.g. "product designer", "educator", "software engineer"]
-  Tagline:     [SHORT PUNCHY LINE — e.g. "designs for clarity"]
-  Description: [ONE SENTENCE — your work and who you do it for]
-  Location:    [CITY, COUNTRY]
-  Tone:        [HOW YOU WRITE — e.g. "warm and direct", "precise and minimal"]
-  Audience:    [WHO READS YOUR SITE — e.g. "hiring managers in education nonprofits"]
-
-Create placeholder entries in src/content/ that I can swap out for real work later.
-Fill in src/context/ using my details above.
-When you're done, list exactly which files I still need to edit myself.
-```
-
----
-
-### Step 2 — Push to GitHub
-
-```
-Please push this project to GitHub.
-  1. Run git init if there's no repo here yet.
-  2. Create a new GitHub repo called [YOUR-REPO-NAME] — use the GitHub CLI if available,
-     otherwise walk me through creating it manually.
-  3. Commit everything and push to main.
-```
-
----
-
-### Step 3 — Connect to Vercel
-
-Do this yourself in the Vercel dashboard (takes 2 minutes):
-
-1. **Add New → Project** → import your GitHub repo
-2. **Root Directory:** `.` (the repo root — don't change this)
-3. **Build Command:** `pnpm build`
-4. **Node.js:** set to **22.x** under Settings → General
-5. Click **Deploy** and wait for it to go green
-
-Note your deployment URL (looks like `your-repo.vercel.app`).
-
----
-
-### Step 4 — Make it real
-
-Come back to Claude Code with your live URL:
-
-```
-My site is live at [https://your-site.vercel.app].
-
-Please:
-  1. Update src/config/site.json baseUrl to the live URL.
-  2. Help me add my first real project to src/content/projects/.
-  3. Help me add my first real writing piece to src/content/writing/.
-  4. Ask me the questions needed to fill in src/context/brand-voice.json
-     with my actual tone, audience, and what language I want to avoid.
-```
-
----
-
-### Step 5 — Set your production URL in Vercel
-
-In Vercel: **Project → Settings → Environment Variables**, add:
-
-- **Name:** `SITE_URL`
-- **Value:** your production URL (e.g. `https://yourname.com`)
-- **Environment:** Production only
-
-Trigger a redeploy after saving.
-
----
-
-### Step 6 — Add a custom domain (optional)
-
-In Vercel: **Project → Settings → Domains** → add your domain, follow the DNS instructions.
-Then update the `SITE_URL` env var to match the new domain and redeploy.
+**Then follow [`docs/downstream/setup-with-claude.md`](docs/downstream/setup-with-claude.md)** — a step-by-step runbook of Claude prompts and Vercel dashboard steps that takes you from empty folder to live site.
 
 ---
 
@@ -133,17 +47,18 @@ pnpm update @portfolio-engine/editorial-theme
 pnpm build   # make sure it still builds
 ```
 
-Check the [changelog](https://github.com/rainonej/portfolio-engine/releases) before upgrading across a minor version.
+Check the [releases](https://github.com/rainonej/portfolio-engine/releases) before upgrading across a minor version.
 
 ---
 
 ## More docs
 
-| Topic                                               | Link                                                                   |
-| --------------------------------------------------- | ---------------------------------------------------------------------- |
-| New site setup (full step-by-step)                  | [docs/downstream/new-site-setup.md](docs/downstream/new-site-setup.md) |
-| Semver vs. workspace-link, overrides, Vercel detail | [docs/downstream/consumption.md](docs/downstream/consumption.md)       |
-| Lint, format, CI                                    | [docs/contributing/linting.md](docs/contributing/linting.md)           |
+| Topic                                               | Link                                                                         |
+| --------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Setup runbook (Claude prompts + Vercel steps)       | [docs/downstream/setup-with-claude.md](docs/downstream/setup-with-claude.md) |
+| New site setup (full manual reference)              | [docs/downstream/new-site-setup.md](docs/downstream/new-site-setup.md)       |
+| Semver vs. workspace-link, overrides, Vercel detail | [docs/downstream/consumption.md](docs/downstream/consumption.md)             |
+| Lint, format, CI                                    | [docs/contributing/linting.md](docs/contributing/linting.md)                 |
 
 ---
 
@@ -174,6 +89,10 @@ pnpm format   # Prettier check
 | [`@portfolio-engine/admin-tools`](packages/admin-tools/)         | Admin/reviewer UI _(Epic 7)_                                        |
 | [`@portfolio-engine/workflow-kit`](packages/workflow-kit/)       | Reusable GitHub workflows and AI classifier _(Epic 8)_              |
 
+### CI
+
+GitHub Actions runs **lint → typecheck → Astro check → build** on every push to `main` / `dev` and on pull requests. See [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
+
 ### Runtime requirements
 
 - Node **≥ 18**, pnpm **≥ 9** — see [`engines`](package.json) in root `package.json`
@@ -182,11 +101,11 @@ pnpm format   # Prettier check
 
 ### Vercel (demo site)
 
-Connect **`rainonej/portfolio-engine`** in Vercel with root = repo root, install `pnpm install`, build `pnpm --filter demo-site run build`, output `examples/demo-site/dist`. Production on `main`; `dev` and PRs get previews. Details: [examples/demo-site/README.md](examples/demo-site/README.md#vercel).
+Connect **`rainonej/portfolio-engine`** in Vercel: root = repo root, build = `pnpm --filter demo-site run build`, output = `examples/demo-site/dist`. Production on `main`; `dev` and PRs get previews. Details: [examples/demo-site/README.md](examples/demo-site/README.md#vercel).
 
 ### Publishing
 
-Packages are published with [Changesets](CONTRIBUTING.md#changesets). See [CONTRIBUTING.md](CONTRIBUTING.md) for branch flow, changesets, local linking, and Copilot review expectations.
+Packages are published with [Changesets](CONTRIBUTING.md#changesets). See [CONTRIBUTING.md](CONTRIBUTING.md) for branch flow, changesets, and local linking.
 
 ### Issues and project board
 

--- a/docs/downstream/consumption.md
+++ b/docs/downstream/consumption.md
@@ -57,10 +57,10 @@ Use this when the consumer site is its **own Git repository** (for example `agre
 2. **Root Directory:** the repository root (`.`). The Astro app, `package.json`, and `pnpm-lock.yaml` should live at that root.
 3. **Framework Preset:** Astro when auto-detected; otherwise set commands manually:
 
-   | Setting | Typical value |
-   |---------|----------------|
-   | **Install Command** | `pnpm install` |
-   | **Build Command** | `pnpm build` |
+   | Setting              | Typical value                                                                                                                                                                                                                                                                |
+   | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+   | **Install Command**  | `pnpm install`                                                                                                                                                                                                                                                               |
+   | **Build Command**    | `pnpm build`                                                                                                                                                                                                                                                                 |
    | **Output Directory** | Leave default when using [`@astrojs/vercel`](https://docs.astro.build/en/guides/integrations-guide/vercel/) — the adapter emits the correct serverless output. Do **not** point only at `dist` unless you know you are shipping a fully static export with no server routes. |
 
 4. **Node.js version:** **22.x** in **Project → Settings → General** (matches common Vercel serverless runtimes and reduces “works on my machine” drift).

--- a/docs/downstream/setup-with-claude.md
+++ b/docs/downstream/setup-with-claude.md
@@ -1,0 +1,144 @@
+# Setting up your portfolio site with Claude
+
+A step-by-step runbook. Open this file alongside Claude Code and paste each prompt when you reach that step. Steps 3, 5, and 6 are short Vercel dashboard tasks you do yourself — no Claude needed.
+
+---
+
+## Before you start
+
+You need these four things installed and accounts created:
+
+|                    |                                                 |
+| ------------------ | ----------------------------------------------- |
+| **Node.js 22**     | [nodejs.org](https://nodejs.org)                |
+| **pnpm**           | Run `npm install -g pnpm` after installing Node |
+| **GitHub account** | [github.com](https://github.com)                |
+| **Vercel account** | [vercel.com](https://vercel.com)                |
+| **Claude Code**    | [claude.ai/code](https://claude.ai/code)        |
+
+Create a new empty folder on your computer. Open it in Claude Code. You're ready.
+
+---
+
+## Step 1 — Scaffold your site
+
+Fill in your details and paste this into Claude Code:
+
+```
+I'm setting up a new personal portfolio site using @portfolio-engine/editorial-theme from npm.
+Read the full setup guide at:
+https://github.com/rainonej/portfolio-engine/blob/main/docs/downstream/new-site-setup.md
+
+My details:
+  Name:        [YOUR FULL NAME]
+  Role:        [WHAT YOU DO — e.g. "product designer", "educator", "software engineer"]
+  Tagline:     [SHORT PUNCHY LINE — e.g. "designs for clarity"]
+  Description: [ONE SENTENCE — your work and who you do it for]
+  Location:    [CITY, COUNTRY]
+  Tone:        [HOW YOU WRITE — e.g. "warm and direct", "precise and minimal"]
+  Audience:    [WHO READS YOUR SITE — e.g. "hiring managers in education nonprofits"]
+  Pages I want: Work / Writing / About / Contact (remove any you don't need)
+
+Create placeholder entries in src/content/ that I can swap out for real work later.
+Fill in src/context/ using my details above.
+When you're done, list exactly which files I still need to edit myself.
+```
+
+Claude will scaffold the full project structure, install dependencies, and tell you what's left for you to fill in.
+
+---
+
+## Step 2 — Push to GitHub
+
+Once the scaffold is done, paste this:
+
+```
+Please push this project to GitHub.
+  1. Run git init if there's no repo here yet.
+  2. Create a new GitHub repo called [YOUR-REPO-NAME] — use the GitHub CLI (gh repo create)
+     if it's available, otherwise walk me through creating it manually.
+  3. Commit everything and push to main.
+```
+
+---
+
+## Step 3 — Connect to Vercel _(manual — ~2 minutes)_
+
+Do this yourself in the Vercel dashboard:
+
+1. **Add New → Project** → import your GitHub repo
+2. **Root Directory:** leave as `.`
+3. **Build Command:** `pnpm build`
+4. **Node.js:** set to **22.x** (Settings → General)
+5. Click **Deploy** and wait for it to go green
+
+Note the URL Vercel gives you (e.g. `your-repo.vercel.app`). You'll use it in the next step.
+
+---
+
+## Step 4 — Make it real
+
+Once the site is live, paste this:
+
+```
+My site is live at [https://your-site.vercel.app].
+
+Please:
+  1. Update src/config/site.json baseUrl to that URL.
+  2. Help me add my first real project to src/content/projects/.
+  3. Help me add my first real writing piece to src/content/writing/.
+  4. Ask me the questions needed to fill in src/context/brand-voice.json
+     with my actual tone, audience, and what language I want to avoid.
+```
+
+---
+
+## Step 5 — Set your production URL in Vercel _(manual)_
+
+In Vercel: **Project → Settings → Environment Variables**, add:
+
+- **Name:** `SITE_URL`
+- **Value:** your production URL (e.g. `https://your-repo.vercel.app` or your custom domain)
+- **Environment:** Production only
+
+Trigger a redeploy after saving.
+
+---
+
+## Step 6 — Add a custom domain _(optional, manual)_
+
+In Vercel: **Project → Settings → Domains** → add your domain, follow the DNS instructions.
+
+Once the domain is live, come back and paste this:
+
+```
+My custom domain is now live at [https://yourname.com].
+
+Please:
+  1. Update src/config/site.json baseUrl to the new domain.
+  2. Remind me to update the SITE_URL env var in Vercel to match.
+```
+
+Then in Vercel update `SITE_URL` to the new domain and redeploy.
+
+---
+
+## Adding content later
+
+Any time you want to add new work, writing, or update your profile, open Claude Code in your site folder and paste:
+
+```
+I want to add [a new project / a new blog post / update my about page].
+Here are the details: [describe what you want]
+
+Please create the right file in src/content/ and make sure the frontmatter is correct.
+```
+
+---
+
+## Keeping the theme up to date
+
+```
+Please update @portfolio-engine/editorial-theme to the latest version,
+check the changelog for any breaking changes, and make sure the build still passes.
+```

--- a/docs/downstream/setup-with-claude.md
+++ b/docs/downstream/setup-with-claude.md
@@ -1,144 +1,143 @@
-# Setting up your portfolio site with Claude
+# Portfolio site setup — paste this into Claude Code
 
-A step-by-step runbook. Open this file alongside Claude Code and paste each prompt when you reach that step. Steps 3, 5, and 6 are short Vercel dashboard tasks you do yourself — no Claude needed.
-
----
-
-## Before you start
-
-You need these four things installed and accounts created:
-
-|                    |                                                 |
-| ------------------ | ----------------------------------------------- |
-| **Node.js 22**     | [nodejs.org](https://nodejs.org)                |
-| **pnpm**           | Run `npm install -g pnpm` after installing Node |
-| **GitHub account** | [github.com](https://github.com)                |
-| **Vercel account** | [vercel.com](https://vercel.com)                |
-| **Claude Code**    | [claude.ai/code](https://claude.ai/code)        |
-
-Create a new empty folder on your computer. Open it in Claude Code. You're ready.
+Copy the entire contents of this file and paste it into Claude Code as your first message. Claude will guide you through everything from there — asking for your details, building the site, and telling you exactly when to go click something in Vercel.
 
 ---
 
-## Step 1 — Scaffold your site
+You are helping me set up a new personal portfolio site from scratch using
+`@portfolio-engine/editorial-theme` (published on npm, source at
+https://github.com/rainonej/portfolio-engine).
 
-Fill in your details and paste this into Claude Code:
+Work through the phases below in order. Do not move to the next phase until
+the current one is finished. At each phase, tell me clearly what you're doing
+and what — if anything — you need from me or need me to do manually.
 
-```
-I'm setting up a new personal portfolio site using @portfolio-engine/editorial-theme from npm.
-Read the full setup guide at:
+---
+
+## Phase 1 — Learn about me
+
+Before touching any files, ask me for everything you need. Collect it all at
+once rather than one question at a time:
+
+- **Name** — as it should appear on the site
+- **Role** — what I do (e.g. "product designer", "educator", "software engineer")
+- **Tagline** — one short punchy line
+- **Description** — one sentence: my work and who I do it for
+- **Location** — city and country
+- **Tone** — how I write (e.g. "warm and direct", "precise and minimal")
+- **Audience** — who reads my site (e.g. "hiring managers at education nonprofits")
+- **Pages** — which of these I want: Work, Writing, About, Contact (default: all four)
+- **Repo name** — what to call my GitHub repository (e.g. "jordan-site")
+
+If any answer is vague, ask one follow-up before moving on.
+
+---
+
+## Phase 2 — Build the project
+
+Using my answers, follow the technical setup guide at:
 https://github.com/rainonej/portfolio-engine/blob/main/docs/downstream/new-site-setup.md
 
-My details:
-  Name:        [YOUR FULL NAME]
-  Role:        [WHAT YOU DO — e.g. "product designer", "educator", "software engineer"]
-  Tagline:     [SHORT PUNCHY LINE — e.g. "designs for clarity"]
-  Description: [ONE SENTENCE — your work and who you do it for]
-  Location:    [CITY, COUNTRY]
-  Tone:        [HOW YOU WRITE — e.g. "warm and direct", "precise and minimal"]
-  Audience:    [WHO READS YOUR SITE — e.g. "hiring managers in education nonprofits"]
-  Pages I want: Work / Writing / About / Contact (remove any you don't need)
+Do all of the following:
 
-Create placeholder entries in src/content/ that I can swap out for real work later.
-Fill in src/context/ using my details above.
-When you're done, list exactly which files I still need to edit myself.
-```
+- Scaffold the Astro project and install `@portfolio-engine/editorial-theme`
+- Create `src/config/site.json`, `navigation.json`, `theme.json`, `features.json`
+  with my real details
+- Create `src/content.config.ts` and placeholder content in `src/content/`
+  (I'll replace placeholders with real work later)
+- Fill in `src/context/site-owner.json` and `src/context/brand-voice.json`
+  from my Phase 1 answers; leave `agent-rules.md` as a template I can edit
+- Create `src/overrides/README.md`
 
-Claude will scaffold the full project structure, install dependencies, and tell you what's left for you to fill in.
+When done, tell me what was created and list any files I should come back and
+edit myself.
 
 ---
 
-## Step 2 — Push to GitHub
+## Phase 3 — Push to GitHub
 
-Once the scaffold is done, paste this:
+1. Initialize a git repo here if one doesn't exist yet
+2. Create a new GitHub repo called the name I gave in Phase 1 — use
+   `gh repo create` if the GitHub CLI is available, otherwise walk me through
+   creating it at github.com
+3. Commit everything and push to `main`
 
-```
-Please push this project to GitHub.
-  1. Run git init if there's no repo here yet.
-  2. Create a new GitHub repo called [YOUR-REPO-NAME] — use the GitHub CLI (gh repo create)
-     if it's available, otherwise walk me through creating it manually.
-  3. Commit everything and push to main.
-```
+Tell me the GitHub URL when it's pushed.
 
 ---
 
-## Step 3 — Connect to Vercel _(manual — ~2 minutes)_
+## Phase 4 — Vercel (you'll guide me through this manually)
 
-Do this yourself in the Vercel dashboard:
+You can't click buttons, so your job here is to give me exact instructions.
+Tell me:
 
-1. **Add New → Project** → import your GitHub repo
-2. **Root Directory:** leave as `.`
-3. **Build Command:** `pnpm build`
-4. **Node.js:** set to **22.x** (Settings → General)
-5. Click **Deploy** and wait for it to go green
+> Go to vercel.com and log in. Click **Add New → Project** and import your
+> **[repo name]** repository. Set:
+>
+> - Root Directory: `.` (leave it as-is)
+> - Build Command: `pnpm build`
+> - Output Directory: leave as default
+>
+> Click **Deploy** and wait for it to go green. Then go to
+> **Settings → General** and set Node.js to **22.x**. Come back here and
+> paste the URL it gave you (it looks like `your-repo.vercel.app`).
 
-Note the URL Vercel gives you (e.g. `your-repo.vercel.app`). You'll use it in the next step.
-
----
-
-## Step 4 — Make it real
-
-Once the site is live, paste this:
-
-```
-My site is live at [https://your-site.vercel.app].
-
-Please:
-  1. Update src/config/site.json baseUrl to that URL.
-  2. Help me add my first real project to src/content/projects/.
-  3. Help me add my first real writing piece to src/content/writing/.
-  4. Ask me the questions needed to fill in src/context/brand-voice.json
-     with my actual tone, audience, and what language I want to avoid.
-```
+Wait for me to come back with the URL before doing anything else.
 
 ---
 
-## Step 5 — Set your production URL in Vercel _(manual)_
+## Phase 5 — Wire up the live URL
 
-In Vercel: **Project → Settings → Environment Variables**, add:
+Once I give you the Vercel URL:
 
-- **Name:** `SITE_URL`
-- **Value:** your production URL (e.g. `https://your-repo.vercel.app` or your custom domain)
-- **Environment:** Production only
-
-Trigger a redeploy after saving.
-
----
-
-## Step 6 — Add a custom domain _(optional, manual)_
-
-In Vercel: **Project → Settings → Domains** → add your domain, follow the DNS instructions.
-
-Once the domain is live, come back and paste this:
-
-```
-My custom domain is now live at [https://yourname.com].
-
-Please:
-  1. Update src/config/site.json baseUrl to the new domain.
-  2. Remind me to update the SITE_URL env var in Vercel to match.
-```
-
-Then in Vercel update `SITE_URL` to the new domain and redeploy.
+1. Update `src/config/site.json` `baseUrl` to that URL
+2. Commit and push the change
+3. Ask me: do I want to add my first real project now, or leave the placeholder?
+4. Ask me: do I want to add my first real writing piece now, or leave the placeholder?
+5. Walk me through filling in `src/context/brand-voice.json` properly — ask
+   me questions and write it from my answers rather than leaving it generic
 
 ---
 
-## Adding content later
+## Phase 6 — Production URL env var (you'll guide me)
 
-Any time you want to add new work, writing, or update your profile, open Claude Code in your site folder and paste:
+Tell me:
 
-```
-I want to add [a new project / a new blog post / update my about page].
-Here are the details: [describe what you want]
-
-Please create the right file in src/content/ and make sure the frontmatter is correct.
-```
+> Go to your Vercel project → **Settings → Environment Variables**. Add a
+> new variable:
+>
+> - Name: `SITE_URL`
+> - Value: `[the URL from Phase 5]`
+> - Environment: **Production** only (uncheck Preview and Development)
+>
+> Save it, then go to **Deployments**, open the latest deployment's menu
+> (three dots), and click **Redeploy**. Come back when it's done.
 
 ---
 
-## Keeping the theme up to date
+## Phase 7 — Custom domain (ask me first)
 
-```
-Please update @portfolio-engine/editorial-theme to the latest version,
-check the changelog for any breaking changes, and make sure the build still passes.
-```
+Ask me: "Do you have a custom domain you want to use, like yourname.com?"
+
+**If yes:** tell me to go to Vercel → **Settings → Domains** → add the
+domain, and walk me through the DNS records I need to set. Once I confirm the
+domain is live:
+
+1. Update `src/config/site.json` `baseUrl` to the new domain
+2. Commit and push
+3. Tell me to go back to Vercel and update the `SITE_URL` env var to the new
+   domain, then redeploy
+
+**If no:** skip to the wrap-up.
+
+---
+
+## Wrap-up
+
+Give me a short summary:
+
+- Where the site is live
+- The three folders that are mine to edit: `src/content/`, `src/config/`,
+  `src/context/`
+- One line on how to add new work later
+- One line on how to update the theme when a new version is out


### PR DESCRIPTION
## Summary

- Restructures the README around a six-step consumer setup journey (scaffold → GitHub → Vercel → content → env vars → custom domain)
- Each step is either a ready-to-paste Claude prompt with fill-in-the-blank fields, or a short Vercel dashboard checklist
- Moves all technical contributor content (packages table, CI, publishing) into a collapsible `<details>` block so it doesn't crowd the page for non-technical users
- Step 1 prompt points Claude at `docs/downstream/new-site-setup.md` for the full technical reference

## Test plan

- [ ] Read the README cold as a non-technical person — can you follow the six steps without prior context?
- [ ] Verify all links resolve (github.com, vercel.com, nodejs.org, claude.ai/code, internal doc links)
- [ ] Confirm contributor `<details>` block still contains packages table, install commands, CI info, and project board link
- [ ] Prettier check: `pnpm format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)