### PR TITLE
feat(phase3): override bridge — static imports, demo Hero override, surface docs

### DIFF
--- a/docs/downstream/consumption.md
+++ b/docs/downstream/consumption.md
@@ -152,33 +152,47 @@ To switch from semver back to workspace-link:
 
 Overrides are **not** picked up from disk automatically. Pass an `overrides` object to `editorialTheme()` with paths **relative to the consumer project root**. Only named surfaces declared by the engine are valid; unsupported names fail at build time.
 
-**Supported component surfaces (v1):** `Hero`, `FeaturedWriting`, `TestimonialSection`, `CollaborationSection`. You may also pass `styles` for extra CSS files merged after the theme’s global styles.
+### Supported surfaces
+
+| Surface name | Upstream implementation | Props passed |
+|---|---|---|
+| `Hero` | `HeroSection.astro` | `person`, `bookingUrl`, `pillars`, `base`, `tagline?` |
+| `FeaturedWriting` | `FeaturedWritingSection.astro` | `writings`, `base` |
+| `TestimonialSection` | `TestimonialSection.astro` | `testimonials` |
+| `CollaborationSection` | `CollaborationSection.astro` | `bookingUrl`, `base` |
+| `Footer` | `Footer.astro` | `base` |
+
+The surface **name** (e.g. `Hero`) is the stable contract key. The upstream implementation file it replaces (e.g. `HeroSection.astro`) is an internal detail that may be renamed. Your override file receives the props listed above and is rendered in place of the default implementation.
+
+You may also pass `styles` (array of CSS file paths) to append extra CSS after the theme’s global styles — useful for custom properties or utility overrides without replacing a component.
+
+### Wiring overrides
 
 **Example — `astro.config.mjs`:**
 
 ```js
-import { defineConfig } from 'astro/config';
-import { editorialTheme } from '@portfolio-engine/editorial-theme';
+import { defineConfig } from ‘astro/config’;
+import { editorialTheme } from ‘@portfolio-engine/editorial-theme’;
 
 export default defineConfig({
   integrations: [
     editorialTheme({
-      siteConfigPath: './src/config/site.json',
-      navigationConfigPath: './src/config/navigation.json',
-      themeConfigPath: './src/config/theme.json',
-      featuresConfigPath: './src/config/features.json',
+      siteConfigPath: ‘./src/config/site.json’,
+      navigationConfigPath: ‘./src/config/navigation.json’,
+      themeConfigPath: ‘./src/config/theme.json’,
+      featuresConfigPath: ‘./src/config/features.json’,
       overrides: {
         components: {
-          Hero: './src/overrides/Hero.astro',
+          Hero: ‘./src/overrides/Hero.astro’,
         },
-        styles: ['./src/overrides/custom.css'],
+        styles: [‘./src/overrides/custom.css’],
       },
     }),
   ],
 });
 ```
 
-By convention, keep those files under `src/overrides/` (any layout under that folder is fine as long as the paths in `overrides` match). Do not point at arbitrary internal theme files—only the supported surface keys above are stable.
+By convention, keep those files under `src/overrides/`. Do not point at arbitrary internal theme files — only the surface keys in the table above are stable.
 
 ```
 your-site/
@@ -187,3 +201,5 @@ your-site/
       Hero.astro        ← example: wired via overrides.components.Hero
       custom.css        ← example: wired via overrides.styles
 ```
+
+A working demo override for `Hero` lives at [`examples/demo-site/src/overrides/Hero.astro`](../../examples/demo-site/src/overrides/Hero.astro).

--- a/docs/downstream/consumption.md
+++ b/docs/downstream/consumption.md
@@ -63,7 +63,7 @@ Use this when the consumer site is its **own Git repository** (for example `agre
    | **Build Command**    | `pnpm build`                                                                                                                                                                                                                                                                 |
    | **Output Directory** | Leave default when using [`@astrojs/vercel`](https://docs.astro.build/en/guides/integrations-guide/vercel/) — the adapter emits the correct serverless output. Do **not** point only at `dist` unless you know you are shipping a fully static export with no server routes. |
 
-4. **Node.js version:** **22.x** in **Project → Settings → General** (matches common Vercel serverless runtimes and reduces “works on my machine” drift).
+4. **Node.js version:** **22.x** in **Project → Settings → General** (matches common Vercel serverless runtimes and reduces "works on my machine" drift).
 
 ### Production on `main`, previews on `dev`
 
@@ -73,7 +73,7 @@ Use this when the consumer site is its **own Git repository** (for example `agre
 
 ### Canonical site URL (`SITE_URL`)
 
-Astro’s top-level `site` option drives canonical URLs and Open Graph metadata. Recommended pattern in the consumer’s `astro.config.mjs`:
+Astro's top-level `site` option drives canonical URLs and Open Graph metadata. Recommended pattern in the consumer's `astro.config.mjs`:
 
 ```js
 const site =
@@ -91,7 +91,7 @@ Redeploy after changing environment variables so builds pick them up.
 
 ### OAuth and server routes
 
-If the consumer exposes **GitHub OAuth**, **session cookies**, or **API routes** under `/api/*` or `/admin`, add [`@astrojs/vercel`](https://docs.astro.build/en/guides/integrations-guide/vercel/) (or your host’s adapter) and configure `output` / adapter per Astro’s hybrid/server docs.
+If the consumer exposes **GitHub OAuth**, **session cookies**, or **API routes** under `/api/*` or `/admin`, add [`@astrojs/vercel`](https://docs.astro.build/en/guides/integrations-guide/vercel/) (or your host's adapter) and configure `output` / adapter per Astro's hybrid/server docs.
 
 **GitHub OAuth app:** register **authorization callback URLs** for every origin users will hit—at minimum production **and** preview origins (each preview deployment has its own hostname unless you use a stable preview domain). Without preview callbacks, sign-in from a Preview deployment will fail after redirect.
 
@@ -102,7 +102,7 @@ If your site uses environment variables such as `CONTENT_BRANCH` for GitHub Cont
 - **Production** env → branch that backs the live site (often `main`).
 - **Preview** env → staging branch (often `dev`) so preview deployments do not edit production-tracked files.
 
-Your consumer repo’s own `README` or `docs/setup.md` should list the exact secrets and names for that deployment.
+Your consumer repo's own `README` or `docs/setup.md` should list the exact secrets and names for that deployment.
 
 ## Workspace-link mode (monorepo contributor)
 
@@ -154,38 +154,38 @@ Overrides are **not** picked up from disk automatically. Pass an `overrides` obj
 
 ### Supported surfaces
 
-| Surface name | Upstream implementation | Props passed |
-|---|---|---|
-| `Hero` | `HeroSection.astro` | `person`, `bookingUrl`, `pillars`, `base`, `tagline?` |
-| `FeaturedWriting` | `FeaturedWritingSection.astro` | `writings`, `base` |
-| `TestimonialSection` | `TestimonialSection.astro` | `testimonials` |
-| `CollaborationSection` | `CollaborationSection.astro` | `bookingUrl`, `base` |
-| `Footer` | `Footer.astro` | `base` |
+| Surface name           | Upstream implementation        | Props passed                                          |
+| ---------------------- | ------------------------------ | ----------------------------------------------------- |
+| `Hero`                 | `HeroSection.astro`            | `person`, `bookingUrl`, `pillars`, `base`, `tagline?` |
+| `FeaturedWriting`      | `FeaturedWritingSection.astro` | `posts`, `base`                                       |
+| `TestimonialSection`   | `TestimonialSection.astro`     | `testimonials`                                        |
+| `CollaborationSection` | `CollaborationSection.astro`   | `base`, `ctaBody?`                                    |
+| `Footer`               | `Footer.astro`                 | `adminHref`, `siteTitle`                              |
 
 The surface **name** (e.g. `Hero`) is the stable contract key. The upstream implementation file it replaces (e.g. `HeroSection.astro`) is an internal detail that may be renamed. Your override file receives the props listed above and is rendered in place of the default implementation.
 
-You may also pass `styles` (array of CSS file paths) to append extra CSS after the theme’s global styles — useful for custom properties or utility overrides without replacing a component.
+You may also pass `styles` (array of CSS file paths) to append extra CSS after the theme's global styles — useful for custom properties or utility overrides without replacing a component.
 
 ### Wiring overrides
 
 **Example — `astro.config.mjs`:**
 
 ```js
-import { defineConfig } from ‘astro/config’;
-import { editorialTheme } from ‘@portfolio-engine/editorial-theme’;
+import { defineConfig } from 'astro/config';
+import { editorialTheme } from '@portfolio-engine/editorial-theme';
 
 export default defineConfig({
   integrations: [
     editorialTheme({
-      siteConfigPath: ‘./src/config/site.json’,
-      navigationConfigPath: ‘./src/config/navigation.json’,
-      themeConfigPath: ‘./src/config/theme.json’,
-      featuresConfigPath: ‘./src/config/features.json’,
+      siteConfigPath: './src/config/site.json',
+      navigationConfigPath: './src/config/navigation.json',
+      themeConfigPath: './src/config/theme.json',
+      featuresConfigPath: './src/config/features.json',
       overrides: {
         components: {
-          Hero: ‘./src/overrides/Hero.astro’,
+          Hero: './src/overrides/Hero.astro',
         },
-        styles: [‘./src/overrides/custom.css’],
+        styles: ['./src/overrides/custom.css'],
       },
     }),
   ],

--- a/examples/demo-site/astro.config.mjs
+++ b/examples/demo-site/astro.config.mjs
@@ -9,6 +9,11 @@ export default defineConfig({
       navigationConfigPath: './src/config/navigation.json',
       themeConfigPath: './src/config/theme.json',
       featuresConfigPath: './src/config/features.json',
+      overrides: {
+        components: {
+          Hero: './src/overrides/Hero.astro',
+        },
+      },
     }),
   ],
 });

--- a/examples/demo-site/src/env.d.ts
+++ b/examples/demo-site/src/env.d.ts
@@ -15,3 +15,22 @@ declare module '@portfolio-engine:routes' {
 declare module '@portfolio-engine:overrides' {
   export const overrides: import('@portfolio-engine/engine-core').OverrideMap;
 }
+
+// Per-surface override modules — export the consumer component or null
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type OverrideComponent = ((...args: any[]) => any) | null;
+declare module '@portfolio-engine:override/Hero' {
+  const Override: OverrideComponent; export default Override;
+}
+declare module '@portfolio-engine:override/FeaturedWriting' {
+  const Override: OverrideComponent; export default Override;
+}
+declare module '@portfolio-engine:override/TestimonialSection' {
+  const Override: OverrideComponent; export default Override;
+}
+declare module '@portfolio-engine:override/CollaborationSection' {
+  const Override: OverrideComponent; export default Override;
+}
+declare module '@portfolio-engine:override/Footer' {
+  const Override: OverrideComponent; export default Override;
+}

--- a/examples/demo-site/src/overrides/Hero.astro
+++ b/examples/demo-site/src/overrides/Hero.astro
@@ -1,0 +1,48 @@
+---
+/**
+ * Demo override for the Hero surface.
+ *
+ * This file exists to prove the override bridge works end-to-end.
+ * Replace or remove it in a real consumer site.
+ *
+ * Props mirror the HeroSection contract — all are optional to call,
+ * required to declare if you want type safety.
+ */
+interface Pillar {
+  heading: string;
+  body: string;
+  image?: string;
+}
+
+interface Person {
+  name: string;
+  bio: string;
+  photo?: string;
+}
+
+interface Props {
+  person: Person;
+  bookingUrl: string | null;
+  pillars: Pillar[];
+  base: string;
+  tagline?: string;
+}
+
+const { person, tagline } = Astro.props;
+---
+
+<section
+  class="mx-auto flex min-h-screen max-w-6xl flex-col justify-center px-6 pb-16 pt-24"
+  data-override="Hero"
+>
+  <div class="max-w-2xl">
+    <p class="mb-3 font-mono text-xs uppercase tracking-widest text-[var(--copper)]">
+      override active
+    </p>
+    <h1 class="mb-6 font-serif text-5xl font-bold leading-tight text-[var(--ink)]">
+      {person.name}
+      {tagline && <span class="block text-3xl font-normal text-[var(--stone-soft)]">{tagline}</span>}
+    </h1>
+    <p class="text-lg leading-relaxed text-[var(--stone-soft)]">{person.bio}</p>
+  </div>
+</section>

--- a/examples/demo-site/src/overrides/README.md
+++ b/examples/demo-site/src/overrides/README.md
@@ -2,6 +2,8 @@
 
 Put optional override components and styles here, then **wire them in `astro.config.mjs`** via `editorialTheme({ overrides: { components, styles } })`. Files in this folder are not auto-discovered.
 
-Supported component surfaces: `Hero`, `FeaturedWriting`, `TestimonialSection`, `CollaborationSection`.
+Supported component surfaces: `Hero`, `FeaturedWriting`, `TestimonialSection`, `CollaborationSection`, `Footer`.
 
-See `docs/downstream/consumption.md` for a full `editorialTheme({ overrides })` example.
+`Hero.astro` in this folder is a live demo override — it proves the override bridge works end-to-end and shows the expected props contract. Remove or replace it in a real consumer site.
+
+See `docs/downstream/consumption.md` for the full surface table, props, and wiring example.

--- a/packages/editorial-theme/src/components/Footer.astro
+++ b/packages/editorial-theme/src/components/Footer.astro
@@ -1,6 +1,6 @@
 ---
 import { config } from '@portfolio-engine:config';
-import { overrides } from '@portfolio-engine:overrides';
+import Override from '@portfolio-engine:override/Footer';
 import { getBase } from '../lib/utils';
 
 const base = getBase();
@@ -9,9 +9,6 @@ const adminOriginEnv =
 const adminOrigin = adminOriginEnv || (base !== '' ? config.site.baseUrl : '');
 const adminHref = adminOrigin ? `${adminOrigin}/admin` : `${base}/admin`;
 
-const Override = overrides.Footer
-  ? ((await import(/* @vite-ignore */ overrides.Footer)) as any).default
-  : null;
 ---
 
 {

--- a/packages/editorial-theme/src/components/sections/CollaborationSection.astro
+++ b/packages/editorial-theme/src/components/sections/CollaborationSection.astro
@@ -1,5 +1,5 @@
 ---
-import { overrides } from '@portfolio-engine:overrides';
+import Override from '@portfolio-engine:override/CollaborationSection';
 import Reveal from '../Reveal.astro';
 import CollaborationCTA from '../CollaborationCTA.astro';
 
@@ -9,10 +9,6 @@ interface Props {
 }
 
 const { base, ctaBody } = Astro.props;
-
-const Override = overrides.CollaborationSection
-  ? ((await import(/* @vite-ignore */ overrides.CollaborationSection)) as any).default
-  : null;
 ---
 
 {Override ? (

--- a/packages/editorial-theme/src/components/sections/FeaturedWritingSection.astro
+++ b/packages/editorial-theme/src/components/sections/FeaturedWritingSection.astro
@@ -1,5 +1,5 @@
 ---
-import { overrides } from '@portfolio-engine:overrides';
+import Override from '@portfolio-engine:override/FeaturedWriting';
 import Reveal from '../Reveal.astro';
 import SectionIntro from '../SectionIntro.astro';
 import WritingList from '../WritingList.astro';
@@ -19,10 +19,6 @@ interface Props {
 }
 
 const { posts, base } = Astro.props;
-
-const Override = overrides.FeaturedWriting
-  ? ((await import(/* @vite-ignore */ overrides.FeaturedWriting)) as any).default
-  : null;
 ---
 
 {Override ? (

--- a/packages/editorial-theme/src/components/sections/HeroSection.astro
+++ b/packages/editorial-theme/src/components/sections/HeroSection.astro
@@ -1,5 +1,5 @@
 ---
-import { overrides } from '@portfolio-engine:overrides';
+import Override from '@portfolio-engine:override/Hero';
 import Reveal from '../Reveal.astro';
 import SectionIntro from '../SectionIntro.astro';
 import FeaturePillars from '../FeaturePillars.astro';
@@ -26,10 +26,6 @@ interface Props {
 }
 
 const { person, bookingUrl, pillars, base, tagline } = Astro.props;
-
-const Override = overrides.Hero
-  ? ((await import(/* @vite-ignore */ overrides.Hero)) as any).default
-  : null;
 ---
 
 {Override ? (

--- a/packages/editorial-theme/src/components/sections/TestimonialSection.astro
+++ b/packages/editorial-theme/src/components/sections/TestimonialSection.astro
@@ -1,5 +1,5 @@
 ---
-import { overrides } from '@portfolio-engine:overrides';
+import Override from '@portfolio-engine:override/TestimonialSection';
 import Reveal from '../Reveal.astro';
 import SectionIntro from '../SectionIntro.astro';
 import TestimonialBlock from '../TestimonialBlock.astro';
@@ -15,10 +15,6 @@ interface Props {
 }
 
 const { testimonials } = Astro.props;
-
-const Override = overrides.TestimonialSection
-  ? ((await import(/* @vite-ignore */ overrides.TestimonialSection)) as any).default
-  : null;
 ---
 
 {Override ? (

--- a/packages/editorial-theme/src/env.d.ts
+++ b/packages/editorial-theme/src/env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="astro/client" />
+/// <reference types="@portfolio-engine/engine-core/client" />

--- a/packages/engine-core/src/client.d.ts
+++ b/packages/engine-core/src/client.d.ts
@@ -20,3 +20,29 @@ declare module '@portfolio-engine:routes' {
 declare module '@portfolio-engine:overrides' {
   export const overrides: OverrideMap;
 }
+
+// Per-surface override modules. Each exports the consumer's override component,
+// or null when no override is configured for that surface.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type OverrideComponent = ((...args: any[]) => any) | null;
+
+declare module '@portfolio-engine:override/Hero' {
+  const Override: OverrideComponent;
+  export default Override;
+}
+declare module '@portfolio-engine:override/FeaturedWriting' {
+  const Override: OverrideComponent;
+  export default Override;
+}
+declare module '@portfolio-engine:override/TestimonialSection' {
+  const Override: OverrideComponent;
+  export default Override;
+}
+declare module '@portfolio-engine:override/CollaborationSection' {
+  const Override: OverrideComponent;
+  export default Override;
+}
+declare module '@portfolio-engine:override/Footer' {
+  const Override: OverrideComponent;
+  export default Override;
+}

--- a/packages/engine-core/src/override-resolution.ts
+++ b/packages/engine-core/src/override-resolution.ts
@@ -1,4 +1,5 @@
 import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import type { OverrideMap } from './types.js';
 
 export interface OverrideConfig {
@@ -50,7 +51,7 @@ export function resolveOverrides(config: OverrideConfig, projectRootDir: string)
           `  Supported surfaces: ${SUPPORTED_COMPONENT_SURFACES.size > 0 ? [...SUPPORTED_COMPONENT_SURFACES].join(', ') : '(none declared yet — override surfaces are defined in Task 4.4)'}`,
       );
     }
-    overrideMap[surface] = resolve(projectRootDir, relativePath);
+    overrideMap[surface] = pathToFileURL(resolve(projectRootDir, relativePath)).href;
   }
 
   const styles = config.styles ?? [];

--- a/packages/engine-core/src/virtual-modules.ts
+++ b/packages/engine-core/src/virtual-modules.ts
@@ -17,6 +17,11 @@ const VIRTUAL_MODULE_IDS = [
   '@portfolio-engine:context',
   '@portfolio-engine:routes',
   '@portfolio-engine:overrides',
+  '@portfolio-engine:override/Hero',
+  '@portfolio-engine:override/FeaturedWriting',
+  '@portfolio-engine:override/TestimonialSection',
+  '@portfolio-engine:override/CollaborationSection',
+  '@portfolio-engine:override/Footer',
 ] as const;
 
 type VirtualModuleId = (typeof VIRTUAL_MODULE_IDS)[number];
@@ -65,6 +70,26 @@ export function createVirtualModulesPlugin(options: VirtualModulePluginOptions):
           return `export const routes = ${JSON.stringify(routes)};`;
         case '@portfolio-engine:overrides':
           return `export const overrides = ${JSON.stringify(overrides)};`;
+        case '@portfolio-engine:override/Hero':
+          return overrides.Hero
+            ? `import _default from ${JSON.stringify(overrides.Hero)}; export default _default;`
+            : `export default null;`;
+        case '@portfolio-engine:override/FeaturedWriting':
+          return overrides.FeaturedWriting
+            ? `import _default from ${JSON.stringify(overrides.FeaturedWriting)}; export default _default;`
+            : `export default null;`;
+        case '@portfolio-engine:override/TestimonialSection':
+          return overrides.TestimonialSection
+            ? `import _default from ${JSON.stringify(overrides.TestimonialSection)}; export default _default;`
+            : `export default null;`;
+        case '@portfolio-engine:override/CollaborationSection':
+          return overrides.CollaborationSection
+            ? `import _default from ${JSON.stringify(overrides.CollaborationSection)}; export default _default;`
+            : `export default null;`;
+        case '@portfolio-engine:override/Footer':
+          return overrides.Footer
+            ? `import _default from ${JSON.stringify(overrides.Footer)}; export default _default;`
+            : `export default null;`;
       }
     },
   };


### PR DESCRIPTION
## Summary

- **Fix Windows SSG build failure**: replace `@vite-ignore` dynamic imports (which bypass Vite and break Node's ESM loader on Windows) with per-surface virtual modules that emit static imports — Vite now compiles override `.astro` files through its normal pipeline
- **Add per-surface virtual modules** in `engine-core`: `@portfolio-engine:override/Hero`, `.../FeaturedWriting`, `.../TestimonialSection`, `.../CollaborationSection`, `.../Footer` — each exports the consumer component or `null`
- **Demo Hero override** at `examples/demo-site/src/overrides/Hero.astro` — wired in `astro.config.mjs`, proves the bridge works end-to-end
- **Updated surface docs** in `docs/downstream/consumption.md`: full props table, surface-name vs. upstream-file explanation, link to demo example
- **Type declarations**: new `env.d.ts` in editorial-theme; per-surface module declarations in `engine-core/client.d.ts` and `demo-site/src/env.d.ts`

## Test plan

- [x] `pnpm check` — 0 errors across all packages + demo-site (31 files)
- [x] `pnpm lint` — 0 ESLint errors
- [x] `pnpm --filter demo-site run build` — 8 pages built, Hero override renders
- [x] `pnpm --filter @portfolio-engine/engine-core build` — dist emitted cleanly

Closes Phase 3 epic: override-bridge

🤖 Generated with [Claude Code](https://claude.com/claude-code)