### PR TITLE
docs(phase3): README — required vs optional packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ src/
                                        Zod schemas
 ```
 
-The engine packages are published to npm. Your repo just installs them.
+The three **required** packages are published to npm — your repo installs them. `admin-tools` and `workflow-kit` are optional add-ons built on top.
 
 ---
 
@@ -83,13 +83,20 @@ pnpm format   # Prettier check
 
 ### Packages
 
+**Required runtime** (every consumer installs these):
+
 | Package                                                          | Description                                                         |
 | ---------------------------------------------------------------- | ------------------------------------------------------------------- |
 | [`@portfolio-engine/editorial-theme`](packages/editorial-theme/) | Astro theme: layouts, components, page routes                       |
 | [`@portfolio-engine/engine-core`](packages/engine-core/)         | Config loader, virtual modules, route registry, override resolution |
 | [`@portfolio-engine/schema`](packages/schema/)                   | Shared Zod schemas for content and configuration                    |
-| [`@portfolio-engine/admin-tools`](packages/admin-tools/)         | Admin/reviewer UI _(Epic 7)_                                        |
-| [`@portfolio-engine/workflow-kit`](packages/workflow-kit/)       | Reusable GitHub workflows and AI classifier _(Epic 8)_              |
+
+**Optional** (post-MVP add-ons, not required to run a site):
+
+| Package                                                    | Description                                              |
+| ---------------------------------------------------------- | -------------------------------------------------------- |
+| [`@portfolio-engine/admin-tools`](packages/admin-tools/)   | Admin/reviewer UI for nontechnical site owners           |
+| [`portfolio-engine-workflow-kit`](packages/workflow-kit/)  | Python/MCP tools for AI-assisted consumer workflows      |
 
 ### CI
 

--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ pnpm format   # Prettier check
 
 **Optional** (post-MVP add-ons, not required to run a site):
 
-| Package                                                    | Description                                              |
-| ---------------------------------------------------------- | -------------------------------------------------------- |
-| [`@portfolio-engine/admin-tools`](packages/admin-tools/)   | Admin/reviewer UI for nontechnical site owners           |
-| [`portfolio-engine-workflow-kit`](packages/workflow-kit/)  | Python/MCP tools for AI-assisted consumer workflows      |
+| Package                                                   | Description                                         |
+| --------------------------------------------------------- | --------------------------------------------------- |
+| [`@portfolio-engine/admin-tools`](packages/admin-tools/)  | Admin/reviewer UI for nontechnical site owners      |
+| [`portfolio-engine-workflow-kit`](packages/workflow-kit/) | Python/MCP tools for AI-assisted consumer workflows |
 
 ### CI
 


### PR DESCRIPTION
## Summary

- The `@portfolio-engine/editorial-theme` integration injects `design-tokens.css` (which sets `--color-accent-primary: #9a5a2e`, amber) **after** the consumer's `custom.css` in the cascade. This makes `theme.json` semantic color overrides and `custom.css` declarations both lose to the theme defaults — the opposite of intended precedence.
- `custom.css` defines the site's brand palette (teal `#0f766e` for accent) but those declarations were being overridden by the theme's defaults on every page.
- Fix: add `!important` to all `:root` token declarations in `src/overrides/custom.css` so the site palette wins regardless of stylesheet load order.

## Root cause

In `Layout.astro` (portfolio-engine), `import '../styles/global.css'` (which chains to `design-tokens.css`) ends up **later** in the CSS cascade than the inline `<style>` blocks from `ThemeTokenOverrides` and `extraCss`. This is a cascade ordering bug in the upstream integration.

Upstream issue filed: https://github.com/rainonej/portfolio-engine/issues/140

The `!important` declarations are the correct consumer-side workaround until the upstream ordering is fixed.

## Test plan

- [ ] Dev server at `localhost:4322` — eyebrow labels, metric numbers, bullet dots all render teal (`#0f766e`), not amber
- [ ] Screenshot the homepage — "Track record", "THE THREE GUARANTEES", achievement metric numbers should all be teal
- [ ] `curl http://localhost:4322/ | grep -o "\-\-color-accent-primary:[^;]*"` — our `!important` value appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)