### PR TITLE
fix(ci): add pull-requests: write to Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

The Changesets release action needs `pull-requests: write` to create the version PR. The previous release workflow only had `contents: write`, causing the release to fail with "Resource not accessible by integration" when it tried to open the version bump PR.

## Test plan

- [x] Merge this → Release workflow re-runs on main → Changesets creates the version PR for v0.1.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)