### PR TITLE
Add analysis of Claude conversation failures and recommended prompt fixes

### DIFF
--- a/docs/claude_convo_analysis.md
+++ b/docs/claude_convo_analysis.md
@@ -1,0 +1,205 @@
+# Analysis of Claude Conversation Errors and Prompt Improvements
+
+## What happened at a glance
+The setup prompt asks Claude to strictly execute a **7-phase workflow**. In the shown transcript, Claude starts well, but then introduces avoidable confusion by mixing internal reasoning into user-facing replies, using environment-specific actions that are not relevant to the user, and not fully aligning with the “single follow-up only when needed” and “clear phase control” constraints.
+
+---
+
+## Mistakes Claude made
+
+## 1) Leaked internal chain-of-thought / process notes to the user
+**Observed behavior:** Claude outputs lines like:
+- “The user has pasted a portfolio site setup prompt. I need to follow the phases…”
+- “Let me check my memory…”
+- Detailed internal extraction/inference notes (Name/Role/Tagline derivation strategy, etc.)
+
+**Why this is a mistake:**
+- This is meta-reasoning intended for internal planning, not user-facing guidance.
+- It creates noise and makes Claude appear uncertain/confused.
+- It violates best practices for concise, confident assistant UX.
+
+**How to improve:**
+- Keep internal reasoning private.
+- Respond directly with actionable questions/decisions.
+- If context lookup is needed, summarize result in one clean sentence (“No prior project context found; proceeding with Phase 1”).
+
+---
+
+## 2) Non-portable local memory path surfaced to user
+**Observed behavior:**
+- “Read C:\Users\raino\.claude\projects\...\MEMORY.md” appears in transcript.
+
+**Why this is a mistake:**
+- Leaks implementation details and local filesystem paths.
+- Not useful to the user.
+- Can reduce trust and feel “glitchy.”
+
+**How to improve:**
+- Never expose raw tool/file paths unless user explicitly asks.
+- Convert to user-relevant status: “I don’t have prior context for this project, so I’ll start fresh.”
+
+---
+
+## 3) Did not cleanly enforce “collect all at once” while still handling ambiguity
+**Observed behavior:**
+- Claude asked for all fields at once initially (good), but after user supplied a PDF and one audience override, Claude proceeded by inferring many fields and then asked three separate confirmations in a multi-part way.
+
+**Why this can be problematic:**
+- Prompt says: if any answer is vague, ask **one follow-up** before moving on.
+- Claude’s follow-up is effectively three independent confirmations (role/tagline/description), which can feel like a phase slip and increase friction.
+
+**How to improve:**
+- Ask one tightly scoped follow-up message with structured options and defaults, e.g.:
+  - “I inferred A/B/C; reply ‘approve’ or edit these three lines.”
+- Keep it as a single confirmation step.
+
+---
+
+## 4) Tone handling was acknowledged but not operationalized
+**Observed behavior:**
+- User said “Ignore the Tone stuff for now.” Claude accepted implicitly but continued generating copy options without explicitly recording a fallback tone strategy.
+
+**Why this is a mistake:**
+- Prompt requires tone as an input field.
+- If user declines a required input, assistant should store a temporary default and explicitly mark it for later refinement.
+
+**How to improve:**
+- Confirm fallback: “Using default tone = ‘clear, professional, direct’ for now; we’ll refine in Phase 5 brand-voice step.”
+
+---
+
+## 5) Over-verbose self-narration reduced clarity
+**Observed behavior:**
+- Multiple “Let me…” and planning narration before substantive output.
+
+**Why this is a mistake:**
+- The prompt explicitly asks for clear phase-by-phase communication.
+- Excess meta narration makes phase status less obvious.
+
+**How to improve:**
+- Use consistent phase headers and terse status blocks:
+  - “Phase 1 (in progress): collecting profile inputs.”
+  - “Needed from you: confirm 3 items below.”
+
+---
+
+## 6) Missed opportunity to validate user-provided artifact format
+**Observed behavior:**
+- User pasted a PDF filename only (`Jordan_Rainone_Fundamental_standard_dense_resume (2).pdf`), and Claude proceeded as though resume contents were available.
+
+**Why this is a mistake:**
+- If the assistant cannot actually parse the file content in current interface, assumptions may be wrong.
+- Leads to silent hallucinated extraction.
+
+**How to improve:**
+- Explicitly verify access:
+  - “I can use the resume if you upload/attach it here or paste key sections.”
+- If accessible, state extracted fields with confidence labels.
+
+---
+
+## 7) Spelling/quality control miss in user-derived text
+**Observed behavior:**
+- User input had typo (“descision makers”); assistant did not normalize or silently correct in its summary.
+
+**Why this is a mistake:**
+- For a professional setup flow, assistant should improve obvious typos in generated site copy while preserving intent.
+
+**How to improve:**
+- Normalize user text in confirmation draft:
+  - “decision-makers”
+- Ask only if correction changes meaning.
+
+---
+
+## 8) Weak constraint reinforcement around phase boundaries
+**Observed behavior:**
+- Claude generally stayed in Phase 1, but the internal narration suggested future decisions and copy generation before user confirmation.
+
+**Why this is a mistake:**
+- Prompt requires strict sequential completion.
+- Any appearance of “pre-building” can confuse users about what has/hasn’t been done.
+
+**How to improve:**
+- End each phase with an explicit completion gate:
+  - “Once you confirm these 3 fields, Phase 1 is complete and I’ll begin Phase 2 file creation.”
+
+---
+
+## Prompt/instruction weaknesses that contributed
+
+## A) No explicit prohibition against exposing internal reasoning
+The prompt tells Claude *what to do* but not *how to communicate safely*.
+
+**Add:**
+- “Do not expose internal reasoning, tool logs, memory file paths, or planning notes. Provide only user-relevant outputs.”
+
+## B) “Ask one follow-up” is ambiguous when multiple fields are unresolved
+It does not clarify whether one follow-up can bundle multiple unresolved fields.
+
+**Add:**
+- “If multiple fields remain unclear, ask a **single consolidated follow-up message** listing all unresolved items with suggested defaults.”
+
+## C) No artifact-access rule for attached files
+Prompt assumes Claude can read provided files.
+
+**Add:**
+- “If a referenced file is not accessible in-session, say so and request upload or pasted excerpts before inferring details.”
+
+## D) No default policy for skipped required fields
+User can say “ignore X for now,” but prompt doesn’t specify fallback behavior.
+
+**Add:**
+- “When a required field is deferred, apply a temporary default, label it clearly, and revisit at the designated later phase.”
+
+## E) No response format template per phase
+Without a rigid template, assistants may over-narrate.
+
+**Add:**
+- Require this structure each phase:
+  1. `Phase N status`
+  2. `What I did`
+  3. `What I need from you`
+  4. `Completion gate`
+
+---
+
+## Recommended revised instruction block (drop-in)
+Use this as an addendum near the top of your master prompt:
+
+1. **Communication discipline**
+   - Do not output internal reasoning, planning notes, memory/tool logs, or filesystem paths.
+   - Be concise and user-facing.
+
+2. **Phase protocol**
+   - Stay in the current phase until completion criteria are met.
+   - End every message with: “Phase X complete/incomplete” + exact next user action.
+
+3. **Follow-up rule**
+   - If any required fields are unclear, send one consolidated follow-up message with all unresolved fields and proposed defaults.
+
+4. **File access rule**
+   - If a file is referenced but not readable in-session, explicitly request upload/paste before extracting details.
+
+5. **Deferred field rule**
+   - If user defers a required field (e.g., tone), set a temporary default and mark it for revisit in the specified phase.
+
+6. **Normalization rule**
+   - Silently fix obvious spelling/grammar in proposed copy unless ambiguity requires confirmation.
+
+---
+
+## Example of a better Phase 1 response to this exact user turn
+“Great — I can use your resume details plus your audience note. I still need one confirmation bundle before Phase 2.
+
+Please approve or edit these:
+1) **Role:** Applied ML Scientist
+2) **Tagline:** PhD mathematician turned applied ML scientist — I help research ideas survive messy enterprise data.
+3) **Description:** I build multimodal ML systems and evaluation frameworks for teams that need research-grade rigor and production-ready software.
+4) **Pages:** Work, Writing, About, Contact (default)
+5) **Tone (temporary default):** Clear, professional, direct (we’ll refine in Phase 5)
+6) **Repo name:** jordan-site
+
+Reply with ‘approve’ or send edits inline. **Phase 1 incomplete** until this is confirmed.”
+
+This keeps strict phase control, one consolidated follow-up, and clear completion criteria.

--- a/docs/claude_convo_analysis.md
+++ b/docs/claude_convo_analysis.md
@@ -7,7 +7,7 @@ The setup prompt asks Claude to strictly execute a **7-phase workflow**. In the 
 
 ## Mistakes Claude made
 
-## 1) Leaked internal chain-of-thought / process notes to the user
+### 1) Leaked internal chain-of-thought / process notes to the user
 **Observed behavior:** Claude outputs lines like:
 - “The user has pasted a portfolio site setup prompt. I need to follow the phases…”
 - “Let me check my memory…”
@@ -25,9 +25,9 @@ The setup prompt asks Claude to strictly execute a **7-phase workflow**. In the 
 
 ---
 
-## 2) Non-portable local memory path surfaced to user
+### 2) Non-portable local memory path surfaced to user
 **Observed behavior:**
-- “Read C:\Users\raino\.claude\projects\...\MEMORY.md” appears in transcript.
+- "Read `C:\Users\raino\.claude\projects\...\MEMORY.md`" appears in transcript.
 
 **Why this is a mistake:**
 - Leaks implementation details and local filesystem paths.
@@ -40,7 +40,7 @@ The setup prompt asks Claude to strictly execute a **7-phase workflow**. In the 
 
 ---
 
-## 3) Did not cleanly enforce “collect all at once” while still handling ambiguity
+### 3) Did not cleanly enforce “collect all at once” while still handling ambiguity
 **Observed behavior:**
 - Claude asked for all fields at once initially (good), but after user supplied a PDF and one audience override, Claude proceeded by inferring many fields and then asked three separate confirmations in a multi-part way.
 
@@ -55,7 +55,7 @@ The setup prompt asks Claude to strictly execute a **7-phase workflow**. In the 
 
 ---
 
-## 4) Tone handling was acknowledged but not operationalized
+### 4) Tone handling was acknowledged but not operationalized
 **Observed behavior:**
 - User said “Ignore the Tone stuff for now.” Claude accepted implicitly but continued generating copy options without explicitly recording a fallback tone strategy.
 
@@ -68,7 +68,7 @@ The setup prompt asks Claude to strictly execute a **7-phase workflow**. In the 
 
 ---
 
-## 5) Over-verbose self-narration reduced clarity
+### 5) Over-verbose self-narration reduced clarity
 **Observed behavior:**
 - Multiple “Let me…” and planning narration before substantive output.
 
@@ -83,7 +83,7 @@ The setup prompt asks Claude to strictly execute a **7-phase workflow**. In the 
 
 ---
 
-## 6) Missed opportunity to validate user-provided artifact format
+### 6) Missed opportunity to validate user-provided artifact format
 **Observed behavior:**
 - User pasted a PDF filename only (`Jordan_Rainone_Fundamental_standard_dense_resume (2).pdf`), and Claude proceeded as though resume contents were available.
 
@@ -98,7 +98,7 @@ The setup prompt asks Claude to strictly execute a **7-phase workflow**. In the 
 
 ---
 
-## 7) Spelling/quality control miss in user-derived text
+### 7) Spelling/quality control miss in user-derived text
 **Observed behavior:**
 - User input had typo (“descision makers”); assistant did not normalize or silently correct in its summary.
 
@@ -112,7 +112,7 @@ The setup prompt asks Claude to strictly execute a **7-phase workflow**. In the 
 
 ---
 
-## 8) Weak constraint reinforcement around phase boundaries
+### 8) Weak constraint reinforcement around phase boundaries
 **Observed behavior:**
 - Claude generally stayed in Phase 1, but the internal narration suggested future decisions and copy generation before user confirmation.
 
@@ -128,31 +128,31 @@ The setup prompt asks Claude to strictly execute a **7-phase workflow**. In the 
 
 ## Prompt/instruction weaknesses that contributed
 
-## A) No explicit prohibition against exposing internal reasoning
+### A) No explicit prohibition against exposing internal reasoning
 The prompt tells Claude *what to do* but not *how to communicate safely*.
 
 **Add:**
 - “Do not expose internal reasoning, tool logs, memory file paths, or planning notes. Provide only user-relevant outputs.”
 
-## B) “Ask one follow-up” is ambiguous when multiple fields are unresolved
+### B) “Ask one follow-up” is ambiguous when multiple fields are unresolved
 It does not clarify whether one follow-up can bundle multiple unresolved fields.
 
 **Add:**
 - “If multiple fields remain unclear, ask a **single consolidated follow-up message** listing all unresolved items with suggested defaults.”
 
-## C) No artifact-access rule for attached files
+### C) No artifact-access rule for attached files
 Prompt assumes Claude can read provided files.
 
 **Add:**
 - “If a referenced file is not accessible in-session, say so and request upload or pasted excerpts before inferring details.”
 
-## D) No default policy for skipped required fields
+### D) No default policy for skipped required fields
 User can say “ignore X for now,” but prompt doesn’t specify fallback behavior.
 
 **Add:**
 - “When a required field is deferred, apply a temporary default, label it clearly, and revisit at the designated later phase.”
 
-## E) No response format template per phase
+### E) No response format template per phase
 Without a rigid template, assistants may over-narrate.
 
 **Add:**
@@ -190,16 +190,16 @@ Use this as an addendum near the top of your master prompt:
 ---
 
 ## Example of a better Phase 1 response to this exact user turn
-“Great — I can use your resume details plus your audience note. I still need one confirmation bundle before Phase 2.
-
-Please approve or edit these:
-1) **Role:** Applied ML Scientist
-2) **Tagline:** PhD mathematician turned applied ML scientist — I help research ideas survive messy enterprise data.
-3) **Description:** I build multimodal ML systems and evaluation frameworks for teams that need research-grade rigor and production-ready software.
-4) **Pages:** Work, Writing, About, Contact (default)
-5) **Tone (temporary default):** Clear, professional, direct (we’ll refine in Phase 5)
-6) **Repo name:** jordan-site
-
-Reply with ‘approve’ or send edits inline. **Phase 1 incomplete** until this is confirmed.”
+> Great — I can use your resume details plus your audience note. I still need one confirmation bundle before Phase 2.
+>
+> Please approve or edit these:
+> 1) **Role:** Applied ML Scientist
+> 2) **Tagline:** PhD mathematician turned applied ML scientist — I help research ideas survive messy enterprise data.
+> 3) **Description:** I build multimodal ML systems and evaluation frameworks for teams that need research-grade rigor and production-ready software.
+> 4) **Pages:** Work, Writing, About, Contact (default)
+> 5) **Tone (temporary default):** Clear, professional, direct (we’ll refine in Phase 5)
+> 6) **Repo name:** jordan-site
+>
+> Reply with ‘approve’ or send edits inline. **Phase 1 incomplete** until this is confirmed.
 
 This keeps strict phase control, one consolidated follow-up, and clear completion criteria.


### PR DESCRIPTION
### Motivation
- Capture and document where the assistant misstepped while following the 7‑phase portfolio site setup workflow so the flow can be hardened. 
- Provide concrete, actionable prompt and behavior changes to prevent future confusion, leaks of internal state, and phase-control errors.

### Description
- Add `docs/claude_convo_analysis.md` containing a detailed breakdown of observed assistant mistakes (internal reasoning leakage, exposing local paths, multi-step follow-ups, tone handling, artifact-access assumptions, spelling normalization, and weak phase gating). 
- Include a section enumerating prompt/instruction weaknesses (A–E) and a drop‑in revised instruction block implementing communication discipline, a phase protocol, a consolidated follow‑up rule, file access handling, deferred-field defaults, and normalization behavior. 
- Provide a concrete example of a cleaner Phase 1 response tailored to the transcript to use as an immediate replacement in the setup prompt. 
- Add the new analysis document to the repository.

### Testing
- Inspected the original transcript with `sed -n '1,220p' docs/claude_convo_example.txt` to confirm examples used in the analysis, and the command succeeded. 
- Searched the workspace for `AGENTS.md` with `rg --files -g 'AGENTS.md'` to validate context assumptions, and the command succeeded. 
- Displayed and paginated the newly created analysis with `nl -ba docs/claude_convo_analysis.md | sed -n '1,260p'` to verify file contents, and the command succeeded. 
- Verified repository status and added the new analysis file to the repo, and the repository update steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6d0d518ac83208b2d7c902809208b)