### PR TITLE
feat(admin-tools): integration, OAuth routes, demo-site SSR admin

### DIFF
--- a/docs/packages/admin-tools.md
+++ b/docs/packages/admin-tools.md
@@ -10,7 +10,6 @@ Admin and reviewer UI for portfolio-engine sites.
 
 ## Status
 
-Deferred — Epic 7. Requires:
+**Shipped (v0):** `adminTools()` Astro integration — `/admin` read-only dashboard (engine virtual modules + content collections) and `/api/auth/*` GitHub OAuth. See [`packages/admin-tools/README.md`](../../packages/admin-tools/README.md) and `examples/demo-site/astro.config.mjs`.
 
-- Epic 5 (agreni-site consumer working, auth/admin behaviour preserved)
-- Epic 3 (route registry contract — Task 3.6)
+**Next:** Port GitHub Contents `/api/content` and in-browser editors from `professional_site` (Epic 7).

--- a/examples/demo-site/.env.example
+++ b/examples/demo-site/.env.example
@@ -1,0 +1,6 @@
+# Optional — admin OAuth (see @portfolio-engine/admin-tools README)
+# GITHUB_CLIENT_ID=
+# GITHUB_CLIENT_SECRET=
+# SESSION_SECRET=
+# ADMIN_TOOLS_GITHUB_REPO_OWNER=
+# ADMIN_TOOLS_GITHUB_REPO_NAME=

--- a/examples/demo-site/README.md
+++ b/examples/demo-site/README.md
@@ -4,11 +4,11 @@ Reference **Astro consumer** for [`@portfolio-engine/editorial-theme`](../../pac
 
 ## What you own vs the theme
 
-| Yours (edit freely)                       | From the theme (via integration)                         |
-| ----------------------------------------- | -------------------------------------------------------- |
-| `config/*.json`                           | Layouts, pages, components, `global.css`                 |
-| `src/content/**`, `src/content.config.ts` | Routes injected by `@portfolio-engine/engine-core`       |
-| `public/**`                               | Tailwind + PostCSS setup inside `editorialTheme()`       |
+| Yours (edit freely)                       | From the theme (via integration)                                                  |
+| ----------------------------------------- | --------------------------------------------------------------------------------- |
+| `config/*.json`                           | Layouts, pages, components, `global.css`                                          |
+| `src/content/**`, `src/content.config.ts` | Routes injected by `@portfolio-engine/engine-core`                                |
+| `public/**`                               | Tailwind + PostCSS setup inside `editorialTheme()`                                |
 | `astro.config.mjs`                        | Virtual modules `@portfolio-engine:config`, `:overrides`, optional `adminTools()` |
 
 Architecture detail: [`docs/packages/editorial-theme.md`](../../docs/packages/editorial-theme.md).

--- a/examples/demo-site/README.md
+++ b/examples/demo-site/README.md
@@ -9,7 +9,7 @@ Reference **Astro consumer** for [`@portfolio-engine/editorial-theme`](../../pac
 | `config/*.json`                           | Layouts, pages, components, `global.css`                 |
 | `src/content/**`, `src/content.config.ts` | Routes injected by `@portfolio-engine/engine-core`       |
 | `public/**`                               | Tailwind + PostCSS setup inside `editorialTheme()`       |
-| `astro.config.mjs`                        | Virtual modules `@portfolio-engine:config`, `:overrides` |
+| `astro.config.mjs`                        | Virtual modules `@portfolio-engine:config`, `:overrides`, optional `adminTools()` |
 
 Architecture detail: [`docs/packages/editorial-theme.md`](../../docs/packages/editorial-theme.md).
 
@@ -29,7 +29,7 @@ pnpm --filter demo-site dev
 pnpm --filter demo-site run build
 ```
 
-Output static site: `examples/demo-site/dist/`.
+Build output: `examples/demo-site/dist/` (**SSR** via `@astrojs/node` so `/admin` and `/api/auth/*` work). Open `http://localhost:4321/admin` after `pnpm --filter demo-site dev` (dev bypass skips GitHub; see `.env.example` for OAuth).
 
 ## Checks
 
@@ -45,7 +45,7 @@ Recommended **Option A** (pnpm workspace–friendly):
 2. **Root Directory:** repository root (`.`), _not_ only `examples/demo-site`, so `workspace:*` resolves during install.
 3. **Install Command:** `pnpm install`
 4. **Build Command:** `pnpm --filter demo-site run build`
-5. **Output Directory:** `examples/demo-site/dist`
+5. **Output Directory:** `examples/demo-site/dist` (Node server bundle — ensure the Vercel project runtime matches Astro’s Node adapter, or swap the adapter for `@astrojs/vercel` if you deploy there.)
 6. **Production branch:** `main` (or your release branch). **Preview:** all other branches and PRs (including `dev`) so every push gets a URL.
 
 If you instead set Root Directory to `examples/demo-site`, you must run install from the monorepo root (e.g. custom install command); Option A avoids that foot-gun.

--- a/examples/demo-site/astro.config.mjs
+++ b/examples/demo-site/astro.config.mjs
@@ -1,8 +1,12 @@
 // @ts-check
+import node from '@astrojs/node';
 import { defineConfig } from 'astro/config';
+import { adminTools } from '@portfolio-engine/admin-tools';
 import { editorialTheme } from '@portfolio-engine/editorial-theme';
 
 export default defineConfig({
+  output: 'server',
+  adapter: node({ mode: 'standalone' }),
   integrations: [
     editorialTheme({
       siteConfigPath: './src/config/site.json',
@@ -15,5 +19,6 @@ export default defineConfig({
         },
       },
     }),
+    adminTools({ devBypass: true }),
   ],
 });

--- a/examples/demo-site/package.json
+++ b/examples/demo-site/package.json
@@ -10,6 +10,8 @@
     "check": "astro check"
   },
   "dependencies": {
+    "@astrojs/node": "^9.2.0",
+    "@portfolio-engine/admin-tools": "workspace:*",
     "@portfolio-engine/editorial-theme": "workspace:*",
     "@portfolio-engine/engine-core": "workspace:*",
     "@portfolio-engine/schema": "workspace:*"

--- a/packages/admin-tools/CHANGELOG.md
+++ b/packages/admin-tools/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @portfolio-engine/admin-tools
 
+## 0.0.5
+
+### Minor Changes
+
+- Ship `adminTools()` Astro integration: injects `/admin` read-only dashboard (engine virtual modules + content collections) and `/api/auth/*` GitHub OAuth routes. Optional `devBypass` for local `astro dev` without OAuth.
+
 ## 0.0.4
 
 ### Patch Changes

--- a/packages/admin-tools/CHANGELOG.md
+++ b/packages/admin-tools/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 - Ship `adminTools()` Astro integration: injects `/admin` read-only dashboard (engine virtual modules + content collections) and `/api/auth/*` GitHub OAuth routes. Optional `devBypass` for local `astro dev` without OAuth.
 
+### Patch Changes
+
+- Enforce authentication in `/admin` server render before emitting dashboard HTML; remove client-only gate.
+- OAuth: use `read:user repo`; validate token exchange responses; respect Astro `base` for callback, post-login redirect, and logout.
+- Logout is `POST` only (`GET` returns 405) to avoid cross-site forced logout.
+- Harden `getCollection` usage when optional collections are missing; expand `tsconfig` `include` for route TypeScript.
+
 ## 0.0.4
 
 ### Patch Changes

--- a/packages/admin-tools/README.md
+++ b/packages/admin-tools/README.md
@@ -1,13 +1,52 @@
 # @portfolio-engine/admin-tools
 
-Admin and reviewer UI for portfolio-engine sites. Provides:
+Optional Astro integration that injects a **private `/admin` dashboard** and **GitHub OAuth** API routes (`/api/auth/*`).
 
-- Admin/reviewer interface components
-- Site map generated from the route registry
-- Content and config inspection panels
+## Requirements
 
-See [`docs/packages/admin-tools.md`](../../docs/packages/admin-tools.md) for architecture detail.
+- Use together with `@portfolio-engine/editorial-theme` (or any setup that registers `@portfolio-engine/engine-core` virtual modules: `config`, `routes`, …).
+- **`adminTools()` must appear after `editorialTheme([...])`** in `astro.config` so injected routes resolve engine virtual modules and your content collections.
+- **SSR**: set `output: 'server'` (or hybrid) and add a Node (or other) adapter. Admin API routes do not run in static export.
+
+## Quick start (local)
+
+```js
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+import node from '@astrojs/node';
+import { editorialTheme } from '@portfolio-engine/editorial-theme';
+import { adminTools } from '@portfolio-engine/admin-tools';
+
+export default defineConfig({
+  output: 'server',
+  adapter: node({ mode: 'standalone' }),
+  integrations: [
+    editorialTheme({ /* engine paths */ }),
+    adminTools({ devBypass: true }),
+  ],
+});
+```
+
+With `devBypass: true`, `pnpm astro dev` skips GitHub login and opens a **read-only** overview (site config, route tree, content counts). Remove `devBypass` for real OAuth.
+
+## Production OAuth
+
+Set:
+
+| Variable | Purpose |
+|----------|---------|
+| `GITHUB_CLIENT_ID` | OAuth app |
+| `GITHUB_CLIENT_SECRET` | OAuth app |
+| `SESSION_SECRET` | HMAC key for session cookie |
+| `ADMIN_TOOLS_GITHUB_REPO_OWNER` | Repo for collaborator check |
+| `ADMIN_TOOLS_GITHUB_REPO_NAME` | Repo name (falls back to `REPO_*` if set) |
+
+Register the OAuth callback URL: `https://<your-host>/api/auth/callback`.
+
+## Content collections
+
+The default dashboard expects collections named **`writing`**, **`projects`**, **`testimonials`**, and **`profile`** (same shape as `examples/demo-site`). Sites with different names will need a tailored admin page in a follow-up.
 
 ## Status
 
-Deferred — Epic 7 (after Epics 3–6 complete).
+Read-only overview and auth plumbing ship first; GitHub Contents editing (drawers, `/api/content`) is the next extraction step from `professional_site`.

--- a/packages/admin-tools/README.md
+++ b/packages/admin-tools/README.md
@@ -21,7 +21,9 @@ export default defineConfig({
   output: 'server',
   adapter: node({ mode: 'standalone' }),
   integrations: [
-    editorialTheme({ /* engine paths */ }),
+    editorialTheme({
+      /* engine paths */
+    }),
     adminTools({ devBypass: true }),
   ],
 });
@@ -33,15 +35,21 @@ With `devBypass: true`, `pnpm astro dev` skips GitHub login and opens a **read-o
 
 Set:
 
-| Variable | Purpose |
-|----------|---------|
-| `GITHUB_CLIENT_ID` | OAuth app |
-| `GITHUB_CLIENT_SECRET` | OAuth app |
-| `SESSION_SECRET` | HMAC key for session cookie |
-| `ADMIN_TOOLS_GITHUB_REPO_OWNER` | Repo for collaborator check |
-| `ADMIN_TOOLS_GITHUB_REPO_NAME` | Repo name (falls back to `REPO_*` if set) |
+| Variable                        | Purpose                                   |
+| ------------------------------- | ----------------------------------------- |
+| `GITHUB_CLIENT_ID`              | OAuth app                                 |
+| `GITHUB_CLIENT_SECRET`          | OAuth app                                 |
+| `SESSION_SECRET`                | HMAC key for session cookie               |
+| `ADMIN_TOOLS_GITHUB_REPO_OWNER` | Repo for collaborator check               |
+| `ADMIN_TOOLS_GITHUB_REPO_NAME`  | Repo name (falls back to `REPO_*` if set) |
 
-Register the OAuth callback URL: `https://<your-host>/api/auth/callback`.
+Register the OAuth **callback URL** to match your deployed origin **and** Astro `base` (if any), e.g. `https://<host>/api/auth/callback` or `https://<host>/<base>/api/auth/callback`.
+
+The authorize request uses scope **`read:user repo`** so the collaborator check and future GitHub Contents API calls work on private repositories.
+
+### Session cookie
+
+The signed session cookie follows the same MVP shape as `professional_site` (GitHub access token is embedded in the signed payload). Prefer an opaque server-side session if you need stronger protection against cookie leakage.
 
 ## Content collections
 

--- a/packages/admin-tools/package.json
+++ b/packages/admin-tools/package.json
@@ -1,16 +1,16 @@
 {
   "name": "@portfolio-engine/admin-tools",
   "private": true,
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Admin and reviewer UI components for portfolio-engine sites",
   "type": "module",
   "exports": {
     ".": "./src/index.ts"
   },
   "scripts": {
-    "build": "echo 'build not yet configured'",
-    "dev": "echo 'dev not yet configured'",
-    "check": "tsc --noEmit"
+    "build": "echo 'no build emit — TypeScript sources consumed directly'",
+    "dev": "echo 'use a consumer site: pnpm --filter demo-site dev'",
+    "check": "tsc --noEmit -p tsconfig.json"
   },
   "peerDependencies": {
     "astro": ">=5.0.0"

--- a/packages/admin-tools/src/components/SiteMapTree.astro
+++ b/packages/admin-tools/src/components/SiteMapTree.astro
@@ -1,0 +1,170 @@
+---
+import type { RouteRecord } from '@portfolio-engine/engine-core';
+
+interface Props {
+  routes: RouteRecord[];
+}
+
+const { routes } = Astro.props;
+const currentPath = Astro.url.pathname;
+
+const root = routes.find((r) => r.resolved === '/');
+const topLevel = routes.filter((r) => r.resolved !== '/' && !r.resolved.includes('['));
+
+function detailOf(parent: RouteRecord): RouteRecord | undefined {
+  return routes.find(
+    (r) => r.resolved.startsWith(parent.resolved + '/') && r.resolved.includes('['),
+  );
+}
+
+function isCurrent(route: RouteRecord): boolean {
+  return currentPath === route.resolved || currentPath.startsWith(route.resolved + '/');
+}
+---
+
+<div class="tree">
+  {
+    root && (
+      <a
+        href={root.resolved}
+        class:list={['tree-node tree-node-home', isCurrent(root) && 'tree-node-current']}
+      >
+        {root.resolved} — {root.label}
+      </a>
+    )
+  }
+
+  <div class="tree-stem" />
+
+  <div class="tree-branches">
+    {
+      topLevel.map((route) => {
+        const detail = detailOf(route);
+        return (
+          <div class="tree-branch">
+            <div class="tree-stem" />
+            <a
+              href={route.resolved}
+              class:list={['tree-node', isCurrent(route) && 'tree-node-current']}
+            >
+              {route.resolved} — {route.label}
+            </a>
+            {detail && (
+              <>
+                <div class="tree-stem" />
+                <span class="tree-node tree-node-dynamic">{detail.resolved}</span>
+              </>
+            )}
+          </div>
+        );
+      })
+    }
+  </div>
+</div>
+
+<style>
+  .tree {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    min-width: max-content;
+  }
+
+  .tree-stem {
+    width: 2px;
+    height: 32px;
+    background: var(--adm-stone, #94a3b8);
+    opacity: 0.4;
+    flex-shrink: 0;
+  }
+
+  .tree-branches {
+    display: flex;
+    align-items: flex-start;
+    position: relative;
+  }
+
+  .tree-branches::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 50%;
+    right: 50%;
+    height: 2px;
+    background: var(--adm-stone, #94a3b8);
+    opacity: 0.35;
+  }
+
+  .tree-branch {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 0 20px;
+    position: relative;
+  }
+
+  .tree-branch::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: var(--adm-stone, #94a3b8);
+    opacity: 0.35;
+  }
+
+  .tree-branch:first-child::before {
+    left: 50%;
+  }
+  .tree-branch:last-child::before {
+    right: 50%;
+  }
+
+  .tree-node {
+    display: block;
+    padding: 10px 20px;
+    border-radius: 12px;
+    border: 1px solid var(--adm-border, #e2e8f0);
+    background: var(--adm-paper, #fff);
+    font-size: 0.875rem;
+    color: var(--adm-muted, #64748b);
+    white-space: nowrap;
+    text-decoration: none;
+    transition:
+      color 0.15s,
+      border-color 0.15s;
+  }
+
+  a.tree-node:hover {
+    color: var(--adm-ink, #0f172a);
+    border-color: var(--adm-muted, #64748b);
+  }
+
+  .tree-node-home {
+    font-size: 0.9375rem;
+    font-weight: 600;
+    color: var(--adm-ink, #0f172a);
+    border-color: var(--adm-muted, #64748b);
+    background: var(--adm-paper-2, #f8fafc);
+  }
+
+  .tree-node-current {
+    color: var(--adm-accent, #b45309);
+    border-color: var(--adm-accent, #b45309);
+    background: var(--adm-paper-2, #f8fafc);
+  }
+
+  a.tree-node-current:hover {
+    color: var(--adm-accent, #b45309);
+    border-color: var(--adm-accent, #b45309);
+  }
+
+  .tree-node-dynamic {
+    font-style: italic;
+    opacity: 0.6;
+    font-size: 0.75rem;
+    border-style: dashed;
+    cursor: default;
+  }
+</style>

--- a/packages/admin-tools/src/index.ts
+++ b/packages/admin-tools/src/index.ts
@@ -1,4 +1,2 @@
-// @portfolio-engine/admin-tools
-// Admin/reviewer UI and route-registry-backed site map.
-// Implementation follows in Epic 7.
-export {};
+export { adminTools } from './integration.js';
+export type { AdminToolsOptions } from './integration.js';

--- a/packages/admin-tools/src/integration.ts
+++ b/packages/admin-tools/src/integration.ts
@@ -1,0 +1,37 @@
+import type { AstroIntegration } from 'astro';
+import { fileURLToPath } from 'node:url';
+
+export interface AdminToolsOptions {
+  /**
+   * When true with `astro dev`, `/api/auth/session` reports authenticated without GitHub.
+   * Dashboard is read-only until the GitHub Contents API is wired for this site.
+   */
+  devBypass?: boolean;
+}
+
+export function adminTools(options: AdminToolsOptions = {}): AstroIntegration {
+  const devBypass = options.devBypass === true;
+
+  return {
+    name: '@portfolio-engine/admin-tools',
+    hooks: {
+      'astro:config:setup': ({ injectRoute, command }) => {
+        if (devBypass && command === 'dev') {
+          process.env.ADMIN_TOOLS_DEV_BYPASS = '1';
+        }
+
+        const route = (pattern: string, relative: string) =>
+          injectRoute({
+            pattern,
+            entrypoint: fileURLToPath(new URL(relative, import.meta.url)),
+          });
+
+        route('/admin', './routes/admin.astro');
+        route('/api/auth/session', './routes/api/auth/session.ts');
+        route('/api/auth/logout', './routes/api/auth/logout.ts');
+        route('/api/auth/github', './routes/api/auth/github.ts');
+        route('/api/auth/callback', './routes/api/auth/callback.ts');
+      },
+    },
+  };
+}

--- a/packages/admin-tools/src/routes/admin.astro
+++ b/packages/admin-tools/src/routes/admin.astro
@@ -5,11 +5,39 @@ import { getCollection } from 'astro:content';
 import { config } from '@portfolio-engine:config';
 import { routes } from '@portfolio-engine:routes';
 import SiteMapTree from '../components/SiteMapTree.astro';
+import { parseCookies, verifySession } from '../server/session.js';
+import { siteHomeUrl, sitePathUrl } from '../server/paths.js';
 
-const writing = await getCollection('writing');
-const projects = await getCollection('projects');
-const testimonials = await getCollection('testimonials');
-const profile = await getCollection('profile');
+let readOnly = false;
+
+if (process.env.ADMIN_TOOLS_DEV_BYPASS === '1' && import.meta.env.DEV) {
+  readOnly = true;
+} else {
+  const token = parseCookies(Astro.request.headers.get('cookie'))['session'];
+  const secret = process.env.SESSION_SECRET;
+  if (!secret || !token) {
+    return Astro.redirect(sitePathUrl(Astro.request, 'api/auth/github'));
+  }
+  const session = await verifySession(token, secret);
+  if (!session) {
+    return Astro.redirect(sitePathUrl(Astro.request, 'api/auth/github'));
+  }
+}
+
+type KnownCollection = 'writing' | 'projects' | 'testimonials' | 'profile';
+
+async function tryCollection(name: KnownCollection) {
+  try {
+    return await getCollection(name);
+  } catch {
+    return [];
+  }
+}
+
+const writing = await tryCollection('writing');
+const projects = await tryCollection('projects');
+const testimonials = await tryCollection('testimonials');
+const profile = await tryCollection('profile');
 
 const personEntry = profile.find((e) => 'name' in e.data && 'bio' in e.data);
 const shortBio =
@@ -25,6 +53,9 @@ const writingSorted = [...writing].sort(
 const projectsSorted = [...projects].sort(
   (a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime(),
 );
+
+const logoutUrl = sitePathUrl(Astro.request, 'api/auth/logout');
+const homeUrl = siteHomeUrl(Astro.request);
 ---
 
 <!doctype html>
@@ -56,125 +87,109 @@ const projectsSorted = [...projects].sort(
     </style>
   </head>
   <body>
-    <div id="gate" class="adm-gate">
-      <div class="adm-gate-inner">
-        <span class="adm-gate-title">Admin</span>
-        <span id="gate-status" class="adm-gate-status">Checking session…</span>
-      </div>
-    </div>
-
-    <div id="admin-content" class="adm-hidden">
-      <div class="adm-wrap">
-        <header class="adm-header">
-          <p class="adm-kicker">Private</p>
-          <h1 class="adm-h1">Site overview</h1>
-          <p class="adm-lead">
-            {config.site.title} — design, routes, and content at a glance (read-only for now).
-          </p>
-          <button type="button" id="logout-btn" class="adm-logout">Log out</button>
-        </header>
-
-        <p id="read-only-banner" class="adm-banner adm-hidden">
-          Read-only session: configure GitHub OAuth and <code>SESSION_SECRET</code> for full sign-in. In production, set
-          <code>ADMIN_TOOLS_GITHUB_REPO_OWNER</code> and <code>ADMIN_TOOLS_GITHUB_REPO_NAME</code> for collaborator checks.
+    <div class="adm-wrap">
+      <header class="adm-header">
+        <p class="adm-kicker">Private</p>
+        <h1 class="adm-h1">Site overview</h1>
+        <p class="adm-lead">
+          {config.site.title} — design, routes, and content at a glance (read-only for now).
         </p>
+        <button
+          type="button"
+          id="logout-btn"
+          class="adm-logout"
+          data-logout-url={logoutUrl}
+          data-home-url={homeUrl}>Log out</button>
+      </header>
 
-        <section class="adm-section">
-          <h2 class="adm-h2">Site</h2>
-          <div class="adm-card">
-            <dl class="adm-dl">
-              <div>
-                <dt class="adm-dt">Title</dt>
-                <dd class="adm-dd">{config.site.title}</dd>
-              </div>
-              <div>
-                <dt class="adm-dt">Description</dt>
-                <dd class="adm-dd">{config.site.description ?? '—'}</dd>
-              </div>
-            </dl>
-          </div>
-        </section>
+      {
+        readOnly && (
+          <p class="adm-banner">
+            Read-only session: configure GitHub OAuth and <code>SESSION_SECRET</code> for full sign-in. In production, set
+            <code>ADMIN_TOOLS_GITHUB_REPO_OWNER</code> and <code>ADMIN_TOOLS_GITHUB_REPO_NAME</code> for collaborator checks.
+          </p>
+        )
+      }
 
-        {
-          personEntry && 'name' in personEntry.data && (
-            <section class="adm-section">
-              <h2 class="adm-h2">Profile</h2>
-              <div class="adm-card">
-                <p class="adm-profile-name">{personEntry.data.name}</p>
-                <p class="adm-profile-bio">{shortBio}</p>
-              </div>
-            </section>
+      {
+        writing.length === 0 &&
+          projects.length === 0 &&
+          testimonials.length === 0 &&
+          profile.length === 0 && (
+            <p class="adm-banner adm-banner--info">
+              No content collections matched the default admin set (<code>writing</code>, <code>projects</code>,{' '}
+              <code>testimonials</code>, <code>profile</code>). Add them or customize this page for your site.
+            </p>
           )
-        }
+      }
 
-        <section class="adm-section">
-          <h2 class="adm-h2">Routes</h2>
-          <div class="adm-card adm-card--wide">
-            <SiteMapTree routes={routes} />
-          </div>
-        </section>
+      <section class="adm-section">
+        <h2 class="adm-h2">Site</h2>
+        <div class="adm-card">
+          <dl class="adm-dl">
+            <div>
+              <dt class="adm-dt">Title</dt>
+              <dd class="adm-dd">{config.site.title}</dd>
+            </div>
+            <div>
+              <dt class="adm-dt">Description</dt>
+              <dd class="adm-dd">{config.site.description ?? '—'}</dd>
+            </div>
+          </dl>
+        </div>
+      </section>
 
-        <section class="adm-section">
-          <h2 class="adm-h2">Content</h2>
-          <div class="adm-grid">
+      {
+        personEntry && 'name' in personEntry.data && (
+          <section class="adm-section">
+            <h2 class="adm-h2">Profile</h2>
             <div class="adm-card">
-              <h3 class="adm-h3">Writing</h3>
-              <p class="adm-count">{writing.length}</p>
-              <ul class="adm-list">
-                {writingSorted.slice(0, 8).map((w) => <li>{w.data.title}</li>)}
-                {writing.length > 8 && <li>…</li>}
-              </ul>
+              <p class="adm-profile-name">{personEntry.data.name}</p>
+              <p class="adm-profile-bio">{shortBio}</p>
             </div>
-            <div class="adm-card">
-              <h3 class="adm-h3">Projects</h3>
-              <p class="adm-count">{projects.length}</p>
-              <ul class="adm-list">
-                {projectsSorted.slice(0, 8).map((p) => <li>{p.data.title}</li>)}
-                {projects.length > 8 && <li>…</li>}
-              </ul>
-            </div>
-            <div class="adm-card">
-              <h3 class="adm-h3">Testimonials</h3>
-              <p class="adm-count">{testimonials.length}</p>
-              <ul class="adm-list">
-                {testimonials.slice(0, 8).map((t) => <li>{t.data.author}</li>)}
-                {testimonials.length > 8 && <li>…</li>}
-              </ul>
-            </div>
+          </section>
+        )
+      }
+
+      <section class="adm-section">
+        <h2 class="adm-h2">Routes</h2>
+        <div class="adm-card adm-card--wide">
+          <SiteMapTree routes={routes} />
+        </div>
+      </section>
+
+      <section class="adm-section">
+        <h2 class="adm-h2">Content</h2>
+        <div class="adm-grid">
+          <div class="adm-card">
+            <h3 class="adm-h3">Writing</h3>
+            <p class="adm-count">{writing.length}</p>
+            <ul class="adm-list">
+              {writingSorted.slice(0, 8).map((w) => <li>{w.data.title}</li>)}
+              {writing.length > 8 && <li>…</li>}
+            </ul>
           </div>
-        </section>
-      </div>
+          <div class="adm-card">
+            <h3 class="adm-h3">Projects</h3>
+            <p class="adm-count">{projects.length}</p>
+            <ul class="adm-list">
+              {projectsSorted.slice(0, 8).map((p) => <li>{p.data.title}</li>)}
+              {projects.length > 8 && <li>…</li>}
+            </ul>
+          </div>
+          <div class="adm-card">
+            <h3 class="adm-h3">Testimonials</h3>
+            <p class="adm-count">{testimonials.length}</p>
+            <ul class="adm-list">
+              {testimonials.slice(0, 8).map((t) => <li>{t.data.author}</li>)}
+              {testimonials.length > 8 && <li>…</li>}
+            </ul>
+          </div>
+        </div>
+      </section>
     </div>
 
     <style>
-      .adm-hidden {
-        display: none !important;
-      }
-      .adm-gate {
-        position: fixed;
-        inset: 0;
-        z-index: 50;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        background: var(--adm-paper-2);
-      }
-      .adm-gate-inner {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        gap: 1rem;
-        text-align: center;
-      }
-      .adm-gate-title {
-        font-size: 1.5rem;
-        font-weight: 600;
-        color: var(--adm-ink);
-      }
-      .adm-gate-status {
-        font-size: 0.875rem;
-        color: var(--adm-muted);
-      }
       .adm-wrap {
         max-width: 64rem;
         margin: 0 auto;
@@ -225,11 +240,19 @@ const projectsSorted = [...projects].sort(
         font-size: 0.875rem;
         color: #422006;
       }
+      .adm-banner--info {
+        border-color: #bae6fd;
+        background: #f0f9ff;
+        color: #0c4a6e;
+      }
       .adm-banner code {
         padding: 0.1em 0.35em;
         border-radius: 0.25rem;
         background: #fef3c7;
         font-size: 0.85em;
+      }
+      .adm-banner--info code {
+        background: #e0f2fe;
       }
       .adm-section {
         margin-bottom: 3.5rem;
@@ -313,41 +336,13 @@ const projectsSorted = [...projects].sort(
     </style>
 
     <script>
-      const gate = document.getElementById('gate')!;
-      const gateStatus = document.getElementById('gate-status')!;
-      const content = document.getElementById('admin-content')!;
       const logoutBtn = document.getElementById('logout-btn')!;
-      const readOnlyBanner = document.getElementById('read-only-banner')!;
-
-      function unlock(readOnly: boolean) {
-        gate.classList.add('adm-hidden');
-        content.classList.remove('adm-hidden');
-        if (readOnly) readOnlyBanner.classList.remove('adm-hidden');
-      }
-
-      async function checkSession() {
-        try {
-          const res = await fetch('/api/auth/session');
-          if (!res.ok) throw new Error('session');
-          const data = (await res.json()) as {
-            authenticated?: boolean;
-            readOnly?: boolean;
-          };
-          if (data.authenticated) {
-            unlock(!!data.readOnly);
-          } else {
-            gateStatus.textContent = 'Redirecting to GitHub…';
-            window.location.href = '/api/auth/github';
-          }
-        } catch {
-          gateStatus.textContent = 'Admin needs server mode (SSR). Use demo-site with output: server.';
-        }
-      }
-
-      checkSession();
-
-      logoutBtn.addEventListener('click', () => {
-        window.location.href = '/api/auth/logout';
+      logoutBtn.addEventListener('click', async () => {
+        const url = logoutBtn.getAttribute('data-logout-url');
+        const home = logoutBtn.getAttribute('data-home-url');
+        if (!url || !home) return;
+        await fetch(url, { method: 'POST', credentials: 'include' });
+        window.location.href = home;
       });
     </script>
   </body>

--- a/packages/admin-tools/src/routes/admin.astro
+++ b/packages/admin-tools/src/routes/admin.astro
@@ -1,0 +1,354 @@
+---
+export const prerender = false;
+
+import { getCollection } from 'astro:content';
+import { config } from '@portfolio-engine:config';
+import { routes } from '@portfolio-engine:routes';
+import SiteMapTree from '../components/SiteMapTree.astro';
+
+const writing = await getCollection('writing');
+const projects = await getCollection('projects');
+const testimonials = await getCollection('testimonials');
+const profile = await getCollection('profile');
+
+const personEntry = profile.find((e) => 'name' in e.data && 'bio' in e.data);
+const shortBio =
+  personEntry && 'bio' in personEntry.data && typeof personEntry.data.bio === 'string'
+    ? personEntry.data.bio.length > 120
+      ? personEntry.data.bio.slice(0, 120).trimEnd() + '…'
+      : personEntry.data.bio
+    : '';
+
+const writingSorted = [...writing].sort(
+  (a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime(),
+);
+const projectsSorted = [...projects].sort(
+  (a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime(),
+);
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex,nofollow" />
+    <title>Admin — Site overview</title>
+    <style is:global>
+      :root {
+        --adm-ink: #0f172a;
+        --adm-muted: #64748b;
+        --adm-border: #e2e8f0;
+        --adm-paper: #ffffff;
+        --adm-paper-2: #f8fafc;
+        --adm-accent: #b45309;
+      }
+      body {
+        margin: 0;
+        font-family:
+          ui-sans-serif,
+          system-ui,
+          sans-serif;
+        background: var(--adm-paper-2);
+        color: var(--adm-ink);
+        line-height: 1.5;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="gate" class="adm-gate">
+      <div class="adm-gate-inner">
+        <span class="adm-gate-title">Admin</span>
+        <span id="gate-status" class="adm-gate-status">Checking session…</span>
+      </div>
+    </div>
+
+    <div id="admin-content" class="adm-hidden">
+      <div class="adm-wrap">
+        <header class="adm-header">
+          <p class="adm-kicker">Private</p>
+          <h1 class="adm-h1">Site overview</h1>
+          <p class="adm-lead">
+            {config.site.title} — design, routes, and content at a glance (read-only for now).
+          </p>
+          <button type="button" id="logout-btn" class="adm-logout">Log out</button>
+        </header>
+
+        <p id="read-only-banner" class="adm-banner adm-hidden">
+          Read-only session: configure GitHub OAuth and <code>SESSION_SECRET</code> for full sign-in. In production, set
+          <code>ADMIN_TOOLS_GITHUB_REPO_OWNER</code> and <code>ADMIN_TOOLS_GITHUB_REPO_NAME</code> for collaborator checks.
+        </p>
+
+        <section class="adm-section">
+          <h2 class="adm-h2">Site</h2>
+          <div class="adm-card">
+            <dl class="adm-dl">
+              <div>
+                <dt class="adm-dt">Title</dt>
+                <dd class="adm-dd">{config.site.title}</dd>
+              </div>
+              <div>
+                <dt class="adm-dt">Description</dt>
+                <dd class="adm-dd">{config.site.description ?? '—'}</dd>
+              </div>
+            </dl>
+          </div>
+        </section>
+
+        {
+          personEntry && 'name' in personEntry.data && (
+            <section class="adm-section">
+              <h2 class="adm-h2">Profile</h2>
+              <div class="adm-card">
+                <p class="adm-profile-name">{personEntry.data.name}</p>
+                <p class="adm-profile-bio">{shortBio}</p>
+              </div>
+            </section>
+          )
+        }
+
+        <section class="adm-section">
+          <h2 class="adm-h2">Routes</h2>
+          <div class="adm-card adm-card--wide">
+            <SiteMapTree routes={routes} />
+          </div>
+        </section>
+
+        <section class="adm-section">
+          <h2 class="adm-h2">Content</h2>
+          <div class="adm-grid">
+            <div class="adm-card">
+              <h3 class="adm-h3">Writing</h3>
+              <p class="adm-count">{writing.length}</p>
+              <ul class="adm-list">
+                {writingSorted.slice(0, 8).map((w) => <li>{w.data.title}</li>)}
+                {writing.length > 8 && <li>…</li>}
+              </ul>
+            </div>
+            <div class="adm-card">
+              <h3 class="adm-h3">Projects</h3>
+              <p class="adm-count">{projects.length}</p>
+              <ul class="adm-list">
+                {projectsSorted.slice(0, 8).map((p) => <li>{p.data.title}</li>)}
+                {projects.length > 8 && <li>…</li>}
+              </ul>
+            </div>
+            <div class="adm-card">
+              <h3 class="adm-h3">Testimonials</h3>
+              <p class="adm-count">{testimonials.length}</p>
+              <ul class="adm-list">
+                {testimonials.slice(0, 8).map((t) => <li>{t.data.author}</li>)}
+                {testimonials.length > 8 && <li>…</li>}
+              </ul>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+
+    <style>
+      .adm-hidden {
+        display: none !important;
+      }
+      .adm-gate {
+        position: fixed;
+        inset: 0;
+        z-index: 50;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: var(--adm-paper-2);
+      }
+      .adm-gate-inner {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 1rem;
+        text-align: center;
+      }
+      .adm-gate-title {
+        font-size: 1.5rem;
+        font-weight: 600;
+        color: var(--adm-ink);
+      }
+      .adm-gate-status {
+        font-size: 0.875rem;
+        color: var(--adm-muted);
+      }
+      .adm-wrap {
+        max-width: 64rem;
+        margin: 0 auto;
+        padding: 3rem 1.5rem 6rem;
+      }
+      .adm-header {
+        margin-bottom: 3rem;
+        padding-bottom: 2rem;
+        border-bottom: 1px solid var(--adm-border);
+      }
+      .adm-kicker {
+        margin: 0 0 0.5rem;
+        font-size: 0.6875rem;
+        font-weight: 600;
+        letter-spacing: 0.2em;
+        text-transform: uppercase;
+        color: var(--adm-accent);
+      }
+      .adm-h1 {
+        margin: 0;
+        font-size: 2.25rem;
+        font-weight: 700;
+        letter-spacing: -0.02em;
+      }
+      .adm-lead {
+        margin: 0.5rem 0 0;
+        color: var(--adm-muted);
+      }
+      .adm-logout {
+        margin-top: 1rem;
+        padding: 0;
+        border: none;
+        background: none;
+        font-size: 0.75rem;
+        color: var(--adm-muted);
+        text-decoration: underline;
+        cursor: pointer;
+      }
+      .adm-logout:hover {
+        color: var(--adm-ink);
+      }
+      .adm-banner {
+        margin-bottom: 2rem;
+        padding: 0.75rem 1rem;
+        border: 1px solid #fde68a;
+        border-radius: 0.5rem;
+        background: #fffbeb;
+        font-size: 0.875rem;
+        color: #422006;
+      }
+      .adm-banner code {
+        padding: 0.1em 0.35em;
+        border-radius: 0.25rem;
+        background: #fef3c7;
+        font-size: 0.85em;
+      }
+      .adm-section {
+        margin-bottom: 3.5rem;
+      }
+      .adm-h2 {
+        margin: 0 0 1rem;
+        font-size: 0.6875rem;
+        font-weight: 600;
+        letter-spacing: 0.15em;
+        text-transform: uppercase;
+        color: var(--adm-muted);
+      }
+      .adm-h3 {
+        margin: 0;
+        font-size: 0.875rem;
+        font-weight: 600;
+      }
+      .adm-card {
+        border: 1px solid var(--adm-border);
+        border-radius: 0.75rem;
+        background: var(--adm-paper);
+        padding: 1.5rem;
+        box-shadow: 0 1px 2px rgb(15 23 42 / 0.04);
+      }
+      .adm-card--wide {
+        overflow-x: auto;
+        padding: 2rem;
+      }
+      .adm-dl {
+        display: grid;
+        gap: 0.75rem;
+        margin: 0;
+        font-size: 0.875rem;
+      }
+      @media (min-width: 640px) {
+        .adm-dl {
+          grid-template-columns: 1fr 1fr;
+        }
+      }
+      .adm-dt {
+        margin: 0;
+        color: var(--adm-muted);
+        font-size: 0.875rem;
+      }
+      .adm-dd {
+        margin: 0.25rem 0 0;
+        font-weight: 500;
+      }
+      .adm-profile-name {
+        margin: 0;
+        font-size: 1.125rem;
+        font-weight: 600;
+      }
+      .adm-profile-bio {
+        margin: 0.5rem 0 0;
+        font-size: 0.875rem;
+        color: var(--adm-muted);
+      }
+      .adm-grid {
+        display: grid;
+        gap: 1.5rem;
+      }
+      @media (min-width: 768px) {
+        .adm-grid {
+          grid-template-columns: repeat(3, 1fr);
+        }
+      }
+      .adm-count {
+        margin: 0.25rem 0 0;
+        font-size: 1.5rem;
+        font-weight: 700;
+      }
+      .adm-list {
+        margin: 0.75rem 0 0;
+        padding-left: 1.1rem;
+        max-height: 10rem;
+        overflow-y: auto;
+        font-size: 0.75rem;
+        color: var(--adm-muted);
+      }
+    </style>
+
+    <script>
+      const gate = document.getElementById('gate')!;
+      const gateStatus = document.getElementById('gate-status')!;
+      const content = document.getElementById('admin-content')!;
+      const logoutBtn = document.getElementById('logout-btn')!;
+      const readOnlyBanner = document.getElementById('read-only-banner')!;
+
+      function unlock(readOnly: boolean) {
+        gate.classList.add('adm-hidden');
+        content.classList.remove('adm-hidden');
+        if (readOnly) readOnlyBanner.classList.remove('adm-hidden');
+      }
+
+      async function checkSession() {
+        try {
+          const res = await fetch('/api/auth/session');
+          if (!res.ok) throw new Error('session');
+          const data = (await res.json()) as {
+            authenticated?: boolean;
+            readOnly?: boolean;
+          };
+          if (data.authenticated) {
+            unlock(!!data.readOnly);
+          } else {
+            gateStatus.textContent = 'Redirecting to GitHub…';
+            window.location.href = '/api/auth/github';
+          }
+        } catch {
+          gateStatus.textContent = 'Admin needs server mode (SSR). Use demo-site with output: server.';
+        }
+      }
+
+      checkSession();
+
+      logoutBtn.addEventListener('click', () => {
+        window.location.href = '/api/auth/logout';
+      });
+    </script>
+  </body>
+</html>

--- a/packages/admin-tools/src/routes/api/auth/callback.ts
+++ b/packages/admin-tools/src/routes/api/auth/callback.ts
@@ -1,5 +1,6 @@
 import type { APIRoute } from 'astro';
 import { parseCookies, buildSessionToken, sessionCookieFlags } from '../../../server/session.js';
+import { sitePathUrl } from '../../../server/paths.js';
 
 export const prerender = false;
 
@@ -35,13 +36,22 @@ export const GET: APIRoute = async ({ request, url }) => {
     }),
   });
 
-  const tokenData = (await tokenRes.json()) as {
-    access_token?: string;
-    error?: string;
-  };
+  const rawText = await tokenRes.text();
+  let tokenData: { access_token?: string; error?: string; error_description?: string };
+  try {
+    tokenData = JSON.parse(rawText) as typeof tokenData;
+  } catch {
+    return new Response('OAuth token response was not valid JSON', { status: 502, headers: NO_STORE });
+  }
+
+  if (!tokenRes.ok) {
+    const detail = tokenData.error_description ?? tokenData.error ?? `HTTP ${tokenRes.status}`;
+    return new Response(`OAuth token exchange failed: ${detail}`, { status: 400, headers: NO_STORE });
+  }
 
   if (!tokenData.access_token) {
-    return new Response('OAuth token exchange failed', { status: 400, headers: NO_STORE });
+    const detail = tokenData.error_description ?? tokenData.error ?? 'no access_token';
+    return new Response(`OAuth token exchange failed: ${detail}`, { status: 400, headers: NO_STORE });
   }
 
   const { access_token } = tokenData;
@@ -54,7 +64,14 @@ export const GET: APIRoute = async ({ request, url }) => {
     },
   });
 
-  const user = (await userRes.json()) as { login?: string };
+  const userRaw = await userRes.text();
+  let user: { login?: string };
+  try {
+    user = JSON.parse(userRaw) as { login?: string };
+  } catch {
+    return new Response('GitHub user response was not valid JSON', { status: 502, headers: NO_STORE });
+  }
+
   if (!userRes.ok || !user.login) {
     return new Response('GitHub user request failed', { status: 502, headers: NO_STORE });
   }
@@ -95,7 +112,7 @@ export const GET: APIRoute = async ({ request, url }) => {
   const flags = sessionCookieFlags();
 
   const headers = new Headers({
-    Location: `${url.origin}/admin`,
+    Location: sitePathUrl(request, 'admin'),
     ...NO_STORE,
   });
   headers.append('Set-Cookie', `session=${sessionToken}; ${flags}; Max-Age=${maxAge}`);

--- a/packages/admin-tools/src/routes/api/auth/callback.ts
+++ b/packages/admin-tools/src/routes/api/auth/callback.ts
@@ -1,0 +1,104 @@
+import type { APIRoute } from 'astro';
+import { parseCookies, buildSessionToken, sessionCookieFlags } from '../../../server/session.js';
+
+export const prerender = false;
+
+const NO_STORE = { 'Cache-Control': 'no-store' } as const;
+
+const repoOwner = () => process.env.ADMIN_TOOLS_GITHUB_REPO_OWNER ?? process.env.REPO_OWNER ?? '';
+const repoName = () => process.env.ADMIN_TOOLS_GITHUB_REPO_NAME ?? process.env.REPO_NAME ?? '';
+
+export const GET: APIRoute = async ({ request, url }) => {
+  const code = url.searchParams.get('code');
+  const stateParam = url.searchParams.get('state');
+
+  const cookies = parseCookies(request.headers.get('cookie'));
+  const storedState = cookies['oauth_state'];
+  if (!stateParam || !storedState || stateParam !== storedState) {
+    return new Response('Invalid state parameter', { status: 400, headers: NO_STORE });
+  }
+
+  if (!code) {
+    return new Response('Missing OAuth code', { status: 400, headers: NO_STORE });
+  }
+
+  const tokenRes = await fetch('https://github.com/login/oauth/access_token', {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      client_id: process.env.GITHUB_CLIENT_ID,
+      client_secret: process.env.GITHUB_CLIENT_SECRET,
+      code,
+    }),
+  });
+
+  const tokenData = (await tokenRes.json()) as {
+    access_token?: string;
+    error?: string;
+  };
+
+  if (!tokenData.access_token) {
+    return new Response('OAuth token exchange failed', { status: 400, headers: NO_STORE });
+  }
+
+  const { access_token } = tokenData;
+
+  const userRes = await fetch('https://api.github.com/user', {
+    headers: {
+      Authorization: `Bearer ${access_token}`,
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'portfolio-engine-admin-tools',
+    },
+  });
+
+  const user = (await userRes.json()) as { login?: string };
+  if (!userRes.ok || !user.login) {
+    return new Response('GitHub user request failed', { status: 502, headers: NO_STORE });
+  }
+
+  const { login } = user;
+  const owner = repoOwner();
+  const name = repoName();
+
+  if (!owner || !name) {
+    return new Response(
+      'Missing ADMIN_TOOLS_GITHUB_REPO_OWNER / ADMIN_TOOLS_GITHUB_REPO_NAME (or REPO_OWNER / REPO_NAME) for collaborator verification',
+      { status: 500, headers: NO_STORE },
+    );
+  }
+
+  const collabRes = await fetch(
+    `https://api.github.com/repos/${owner}/${name}/collaborators/${login}`,
+    {
+      headers: {
+        Authorization: `Bearer ${access_token}`,
+        Accept: 'application/vnd.github+json',
+        'User-Agent': 'portfolio-engine-admin-tools',
+      },
+    },
+  );
+  if (collabRes.status !== 204) {
+    return new Response('Access denied — not a repo collaborator', { status: 403, headers: NO_STORE });
+  }
+
+  const secret = process.env.SESSION_SECRET;
+  if (!secret) {
+    return new Response('Server misconfiguration', { status: 500, headers: NO_STORE });
+  }
+
+  const issuedAt = Date.now();
+  const sessionToken = await buildSessionToken(login, issuedAt, access_token, secret);
+  const maxAge = 24 * 60 * 60;
+  const flags = sessionCookieFlags();
+
+  const headers = new Headers({
+    Location: `${url.origin}/admin`,
+    ...NO_STORE,
+  });
+  headers.append('Set-Cookie', `session=${sessionToken}; ${flags}; Max-Age=${maxAge}`);
+  headers.append('Set-Cookie', `oauth_state=; ${flags}; Max-Age=0`);
+  return new Response(null, { status: 302, headers });
+};

--- a/packages/admin-tools/src/routes/api/auth/github.ts
+++ b/packages/admin-tools/src/routes/api/auth/github.ts
@@ -1,9 +1,13 @@
 import type { APIRoute } from 'astro';
 import { sessionCookieFlags } from '../../../server/session.js';
+import { sitePathUrl } from '../../../server/paths.js';
 
 export const prerender = false;
 
 const NO_STORE = { 'Cache-Control': 'no-store' } as const;
+
+/** `repo` is required for collaborator checks and future Contents API writes on private repos. */
+const OAUTH_SCOPE = 'read:user repo';
 
 export const GET: APIRoute = ({ request }) => {
   const clientId = process.env.GITHUB_CLIENT_ID;
@@ -14,12 +18,12 @@ export const GET: APIRoute = ({ request }) => {
     });
   }
 
-  const origin = new URL(request.url).origin;
+  const redirect_uri = sitePathUrl(request, 'api/auth/callback');
   const state = crypto.randomUUID();
   const params = new URLSearchParams({
     client_id: clientId,
-    redirect_uri: `${origin}/api/auth/callback`,
-    scope: 'read:user public_repo',
+    redirect_uri,
+    scope: OAUTH_SCOPE,
     state,
   });
   const flags = sessionCookieFlags();

--- a/packages/admin-tools/src/routes/api/auth/github.ts
+++ b/packages/admin-tools/src/routes/api/auth/github.ts
@@ -1,0 +1,32 @@
+import type { APIRoute } from 'astro';
+import { sessionCookieFlags } from '../../../server/session.js';
+
+export const prerender = false;
+
+const NO_STORE = { 'Cache-Control': 'no-store' } as const;
+
+export const GET: APIRoute = ({ request }) => {
+  const clientId = process.env.GITHUB_CLIENT_ID;
+  if (!clientId) {
+    return new Response('Server misconfiguration', {
+      status: 500,
+      headers: NO_STORE,
+    });
+  }
+
+  const origin = new URL(request.url).origin;
+  const state = crypto.randomUUID();
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: `${origin}/api/auth/callback`,
+    scope: 'read:user public_repo',
+    state,
+  });
+  const flags = sessionCookieFlags();
+  const headers = new Headers({
+    Location: `https://github.com/login/oauth/authorize?${params}`,
+    'Set-Cookie': `oauth_state=${state}; ${flags}; Max-Age=600`,
+  });
+  headers.set('Cache-Control', 'no-store');
+  return new Response(null, { status: 302, headers });
+};

--- a/packages/admin-tools/src/routes/api/auth/logout.ts
+++ b/packages/admin-tools/src/routes/api/auth/logout.ts
@@ -3,15 +3,23 @@ import { sessionCookieFlags } from '../../../server/session.js';
 
 export const prerender = false;
 
-export const GET: APIRoute = ({ url }) => {
-  const { origin } = url;
+const NO_STORE = { 'Cache-Control': 'no-store' } as const;
+
+/** Clear session cookie; client navigates home (avoids fetch+redirect edge cases with `base`). */
+export const POST: APIRoute = () => {
   const flags = sessionCookieFlags();
   return new Response(null, {
-    status: 302,
+    status: 204,
     headers: {
-      Location: `${origin}/`,
+      ...NO_STORE,
       'Set-Cookie': `session=; ${flags}; Max-Age=0`,
-      'Cache-Control': 'no-store',
     },
+  });
+};
+
+export const GET: APIRoute = () => {
+  return new Response('Method Not Allowed — use POST to log out', {
+    status: 405,
+    headers: { ...NO_STORE, Allow: 'POST' },
   });
 };

--- a/packages/admin-tools/src/routes/api/auth/logout.ts
+++ b/packages/admin-tools/src/routes/api/auth/logout.ts
@@ -1,0 +1,17 @@
+import type { APIRoute } from 'astro';
+import { sessionCookieFlags } from '../../../server/session.js';
+
+export const prerender = false;
+
+export const GET: APIRoute = ({ url }) => {
+  const { origin } = url;
+  const flags = sessionCookieFlags();
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: `${origin}/`,
+      'Set-Cookie': `session=; ${flags}; Max-Age=0`,
+      'Cache-Control': 'no-store',
+    },
+  });
+};

--- a/packages/admin-tools/src/routes/api/auth/session.ts
+++ b/packages/admin-tools/src/routes/api/auth/session.ts
@@ -1,0 +1,37 @@
+import type { APIRoute } from 'astro';
+import { parseCookies, verifySession } from '../../../server/session.js';
+
+export const prerender = false;
+
+const NO_STORE = { 'Cache-Control': 'no-store' } as const;
+
+export const GET: APIRoute = async ({ request }) => {
+  if (process.env.ADMIN_TOOLS_DEV_BYPASS === '1' && import.meta.env.DEV) {
+    return Response.json(
+      { authenticated: true, username: 'dev', readOnly: true },
+      { headers: NO_STORE },
+    );
+  }
+
+  const cookies = parseCookies(request.headers.get('cookie'));
+  const token = cookies['session'];
+
+  if (!token) {
+    return Response.json({ authenticated: false }, { headers: NO_STORE });
+  }
+
+  const secret = process.env.SESSION_SECRET;
+  if (!secret) {
+    return Response.json({ error: 'Server misconfiguration' }, { status: 500, headers: NO_STORE });
+  }
+
+  const session = await verifySession(token, secret);
+  if (!session) {
+    return Response.json({ authenticated: false }, { headers: NO_STORE });
+  }
+
+  return Response.json(
+    { authenticated: true, username: session.login, readOnly: false },
+    { headers: NO_STORE },
+  );
+};

--- a/packages/admin-tools/src/server/paths.ts
+++ b/packages/admin-tools/src/server/paths.ts
@@ -1,0 +1,15 @@
+/**
+ * URLs that respect Astro `base` / `import.meta.env.BASE_URL` (subpath deployments).
+ */
+export function siteRootUrl(request: Request): URL {
+  return new URL(import.meta.env.BASE_URL, request.url);
+}
+
+export function sitePathUrl(request: Request, relativePath: string): string {
+  const rel = relativePath.replace(/^\//, '');
+  return new URL(rel, siteRootUrl(request)).href;
+}
+
+export function siteHomeUrl(request: Request): string {
+  return siteRootUrl(request).href;
+}

--- a/packages/admin-tools/src/server/session.ts
+++ b/packages/admin-tools/src/server/session.ts
@@ -1,0 +1,84 @@
+/**
+ * Signed session cookie for GitHub-backed admin (same model as professional_site).
+ */
+
+const SESSION_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+export function parseCookies(header: string | null): Record<string, string> {
+  if (!header) return {};
+  return Object.fromEntries(
+    header.split(';').map((c) => {
+      const eq = c.indexOf('=');
+      return eq === -1
+        ? [c.trim(), '']
+        : [c.slice(0, eq).trim(), c.slice(eq + 1).trim()];
+    }),
+  );
+}
+
+function timingSafeEqualHex(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let result = 0;
+  for (let i = 0; i < a.length; i++) {
+    result |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return result === 0;
+}
+
+async function hmacHex(data: string, secret: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(data));
+  return Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export interface SessionData {
+  login: string;
+  accessToken: string;
+}
+
+export async function verifySession(token: string, secret: string): Promise<SessionData | null> {
+  const lastDot = token.lastIndexOf('.');
+  if (lastDot === -1) return null;
+
+  const payload = token.slice(0, lastDot);
+  const sig = token.slice(lastDot + 1);
+
+  const expectedHex = await hmacHex(payload, secret);
+  if (!timingSafeEqualHex(sig, expectedHex)) return null;
+
+  const parts = payload.split('.');
+  if (parts.length < 3) return null;
+
+  const login = parts[0];
+  const issuedAt = parseInt(parts[1], 10);
+  const accessToken = parts.slice(2).join('.');
+
+  if (!login || Number.isNaN(issuedAt) || !accessToken) return null;
+  if (Date.now() - issuedAt > SESSION_MAX_AGE_MS) return null;
+
+  return { login, accessToken };
+}
+
+export async function buildSessionToken(
+  login: string,
+  issuedAt: number,
+  accessToken: string,
+  secret: string,
+): Promise<string> {
+  const payload = `${login}.${issuedAt}.${accessToken}`;
+  const sig = await hmacHex(payload, secret);
+  return `${payload}.${sig}`;
+}
+
+export function sessionCookieFlags(): string {
+  const secure = process.env.NODE_ENV === 'production' ? '; Secure' : '';
+  return `HttpOnly${secure}; SameSite=Lax; Path=/`;
+}

--- a/packages/admin-tools/src/server/session.ts
+++ b/packages/admin-tools/src/server/session.ts
@@ -1,5 +1,9 @@
 /**
  * Signed session cookie for GitHub-backed admin (same model as professional_site).
+ *
+ * The cookie value includes the GitHub access token (HMAC-signed). Anyone with the
+ * cookie can use the token until expiry — prefer an opaque server-side session id
+ * if you need stronger isolation from cookie leakage.
  */
 
 const SESSION_MAX_AGE_MS = 24 * 60 * 60 * 1000;

--- a/packages/admin-tools/tsconfig.json
+++ b/packages/admin-tools/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src"],
+  "include": ["src/index.ts", "src/integration.ts", "src/server/**/*.ts"],
   "compilerOptions": {
-    "types": ["astro/client"]
+    "types": ["astro/client"],
+    "noEmit": true
   }
 }

--- a/packages/admin-tools/tsconfig.json
+++ b/packages/admin-tools/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/index.ts", "src/integration.ts", "src/server/**/*.ts"],
+  "include": ["src/**/*.ts"],
   "compilerOptions": {
     "types": ["astro/client"],
     "noEmit": true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,12 @@ importers:
 
   examples/demo-site:
     dependencies:
+      '@astrojs/node':
+        specifier: ^9.2.0
+        version: 9.5.5(astro@5.18.1(@types/node@22.19.17)(jiti@1.21.7)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3))
+      '@portfolio-engine/admin-tools':
+        specifier: workspace:*
+        version: link:../../packages/admin-tools
       '@portfolio-engine/editorial-theme':
         specifier: workspace:*
         version: link:../../packages/editorial-theme
@@ -163,6 +169,11 @@ packages:
 
   '@astrojs/markdown-remark@6.3.11':
     resolution: {integrity: sha512-hcaxX/5aC6lQgHeGh1i+aauvSwIT6cfyFjKWvExYSxUhZZBBdvCliOtu06gbQyhbe0pGJNoNmqNlQZ5zYUuIyQ==}
+
+  '@astrojs/node@9.5.5':
+    resolution: {integrity: sha512-rtU2BGU5u3SfGURpANfMxVzCIoR86MkaN05ncza9rbtuMKJ/XnRJt/BbyVknDbOJ71hoci0SIsJwKcJR8vvi/A==}
+    peerDependencies:
+      astro: ^5.17.3
 
   '@astrojs/prism@3.3.0':
     resolution: {integrity: sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==}
@@ -1404,6 +1415,10 @@ packages:
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -1460,6 +1475,9 @@ packages:
     resolution: {integrity: sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==}
     engines: {node: '>=4'}
 
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   electron-to-chromium@1.5.345:
     resolution: {integrity: sha512-F9JXQGiMrz6yVNPI2qOVPvB9HzjH5cGzhs8oJ6A28V5L/YnzN/0KsuiibqF+F1Fd9qxFzD1BUnYSd8JfULxTwg==}
 
@@ -1471,6 +1489,10 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
@@ -1504,6 +1526,9 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -1575,6 +1600,10 @@ packages:
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
@@ -1652,6 +1681,10 @@ packages:
 
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
@@ -1749,6 +1782,10 @@ packages:
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
 
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
   human-id@4.1.3:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
     hasBin: true
@@ -1775,6 +1812,9 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
@@ -2067,6 +2107,14 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -2138,6 +2186,10 @@ packages:
 
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   oniguruma-parser@0.12.2:
     resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
@@ -2343,6 +2395,10 @@ packages:
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
 
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
   read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
 
@@ -2462,6 +2518,16 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  server-destroy@1.0.1:
+    resolution: {integrity: sha512-rb+9B5YBIEzYcD6x2VKidaa+cqYBJQKnU4oe4E3ANwRRN56yk/ua1YCJT1n21NTS8w6CcOclAKNP3PhdCXKYtQ==}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -2508,6 +2574,10 @@ packages:
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -2587,6 +2657,10 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -3094,6 +3168,15 @@ snapshots:
       unist-util-visit: 5.1.0
       unist-util-visit-parents: 6.0.2
       vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@astrojs/node@9.5.5(astro@5.18.1(@types/node@22.19.17)(jiti@1.21.7)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3))':
+    dependencies:
+      '@astrojs/internal-helpers': 0.7.6
+      astro: 5.18.1(@types/node@22.19.17)(jiti@1.21.7)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3)
+      send: 1.2.1
+      server-destroy: 1.0.1
     transitivePeerDependencies:
       - supports-color
 
@@ -4322,6 +4405,8 @@ snapshots:
 
   defu@6.1.7: {}
 
+  depd@2.0.0: {}
+
   dequal@2.0.3: {}
 
   destr@2.0.5: {}
@@ -4371,6 +4456,8 @@ snapshots:
 
   dset@3.1.4: {}
 
+  ee-first@1.1.1: {}
+
   electron-to-chromium@1.5.345: {}
 
   emmet@2.4.11:
@@ -4381,6 +4468,8 @@ snapshots:
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
+
+  encodeurl@2.0.0: {}
 
   enquirer@2.4.1:
     dependencies:
@@ -4454,6 +4543,8 @@ snapshots:
       '@esbuild/win32-x64': 0.27.7
 
   escalade@3.2.0: {}
+
+  escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -4541,6 +4632,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
   eventemitter3@5.0.4: {}
 
   extend@3.0.2: {}
@@ -4613,6 +4706,8 @@ snapshots:
       tiny-inflate: 1.0.3
 
   fraction.js@5.3.4: {}
+
+  fresh@2.0.0: {}
 
   fs-extra@7.0.1:
     dependencies:
@@ -4769,6 +4864,14 @@ snapshots:
 
   http-cache-semantics@4.2.0: {}
 
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
   human-id@4.1.3: {}
 
   iconv-lite@0.7.2:
@@ -4787,6 +4890,8 @@ snapshots:
   import-meta-resolve@4.2.0: {}
 
   imurmurhash@0.1.4: {}
+
+  inherits@2.0.4: {}
 
   iron-webcrypto@1.2.1: {}
 
@@ -5228,6 +5333,12 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
@@ -5290,6 +5401,10 @@ snapshots:
       ufo: 1.6.3
 
   ohash@2.0.11: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
 
   oniguruma-parser@0.12.2: {}
 
@@ -5460,6 +5575,8 @@ snapshots:
   queue-microtask@1.2.3: {}
 
   radix3@1.1.2: {}
+
+  range-parser@1.2.1: {}
 
   read-cache@1.0.0:
     dependencies:
@@ -5643,6 +5760,26 @@ snapshots:
 
   semver@7.7.4: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  server-destroy@1.0.1: {}
+
+  setprototypeof@1.2.0: {}
+
   sharp@0.34.5:
     dependencies:
       '@img/colour': 1.1.0
@@ -5712,6 +5849,8 @@ snapshots:
       signal-exit: 4.1.0
 
   sprintf-js@1.0.3: {}
+
+  statuses@2.0.2: {}
 
   string-width@4.2.3:
     dependencies:
@@ -5820,6 +5959,8 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  toidentifier@1.0.1: {}
 
   tree-kill@1.2.2: {}
 


### PR DESCRIPTION
## Summary

Ship \dminTools()\ as an Astro integration: injects \/admin\ (read-only site overview using \@portfolio-engine:config\, \:routes\, and content collections) and \/api/auth/*\ GitHub OAuth handlers (session model aligned with professional_site).

## demo-site

- \output: 'server'\ + \@astrojs/node\ so admin and APIs run.
- \dminTools({ devBypass: true })\ for local \stro dev\ without OAuth.
- \.env.example\ for production OAuth variables.

## Follow-up

Port \/api/content\ and in-browser editors from professional_site for full CMS parity.

## Checklist

- [x] \pnpm check\ and \pnpm build\ pass locally.