### PR TITLE
admin-tools: add content editor, file audit UI, and `/api/content` endpoint with GitHub/local writes

### DIFF
--- a/docs/packages/admin-tools.md
+++ b/docs/packages/admin-tools.md
@@ -10,6 +10,9 @@ Admin and reviewer UI for portfolio-engine sites.
 
 ## Status
 
-**Shipped (v0):** `adminTools()` Astro integration — `/admin` read-only dashboard (engine virtual modules + route tree + filesystem audit for config/content/context/assets/registry + manifest status), `/api/auth/*` GitHub OAuth, and read-only `/api/content` file listing endpoint. See [`packages/admin-tools/README.md`](../../packages/admin-tools/README.md) and `examples/demo-site/astro.config.mjs`.
+**Shipped (v0):** `adminTools()` Astro integration — `/admin` read-only dashboard (engine virtual modules + route tree + filesystem audit for config/content/context/assets/registry + manifest status), `/api/auth/*` GitHub OAuth, plus editable `/api/content` endpoint (inventory/read/save) and drag-and-drop public asset uploads. See [`packages/admin-tools/README.md`](../../packages/admin-tools/README.md) and `examples/demo-site/astro.config.mjs`.
 
-**Next:** Port GitHub Contents `/api/content` and in-browser editors from `professional_site` (Epic 7).
+**Next:** Add schema-aware editors, file move/rename/delete flows, and richer non-technical UX from `professional_site` extraction (Epic 7).
+
+
+- Admin asset uploads: use the `/admin` **Public assets uploader** to drop files into `public/` or a nested folder (e.g. `media/uploads`).

--- a/docs/packages/admin-tools.md
+++ b/docs/packages/admin-tools.md
@@ -10,6 +10,6 @@ Admin and reviewer UI for portfolio-engine sites.
 
 ## Status
 
-**Shipped (v0):** `adminTools()` Astro integration — `/admin` read-only dashboard (engine virtual modules + content collections) and `/api/auth/*` GitHub OAuth. See [`packages/admin-tools/README.md`](../../packages/admin-tools/README.md) and `examples/demo-site/astro.config.mjs`.
+**Shipped (v0):** `adminTools()` Astro integration — `/admin` read-only dashboard (engine virtual modules + route tree + filesystem audit for config/content/context/assets/registry + manifest status), `/api/auth/*` GitHub OAuth, and read-only `/api/content` file listing endpoint. See [`packages/admin-tools/README.md`](../../packages/admin-tools/README.md) and `examples/demo-site/astro.config.mjs`.
 
 **Next:** Port GitHub Contents `/api/content` and in-browser editors from `professional_site` (Epic 7).

--- a/docs/packages/admin-tools.md
+++ b/docs/packages/admin-tools.md
@@ -10,9 +10,17 @@ Admin and reviewer UI for portfolio-engine sites.
 
 ## Status
 
-**Shipped (v0):** `adminTools()` Astro integration — `/admin` read-only dashboard (engine virtual modules + route tree + filesystem audit for config/content/context/assets/registry + manifest status), `/api/auth/*` GitHub OAuth, plus editable `/api/content` endpoint (inventory/read/save) and drag-and-drop public asset uploads. See [`packages/admin-tools/README.md`](../../packages/admin-tools/README.md) and `examples/demo-site/astro.config.mjs`.
+**Shipped (v0):** `adminTools()` Astro integration — `/admin` dashboard with read/write capabilities
+(engine virtual modules + route tree + filesystem audit for config/content/context/assets/registry +
+manifest status + in-browser content editor + public asset uploader), `/api/auth/*` GitHub OAuth, and
+`/api/content` endpoint (inventory/read/save — local writes in `devBypass`, GitHub Contents API writes in
+OAuth mode). Requires a **Node.js adapter** (`@astrojs/node` or equivalent) — `node:fs` is used by the
+filesystem audit and `/api/content`; these features are unavailable on edge runtimes. See
+[`packages/admin-tools/README.md`](../../packages/admin-tools/README.md) and
+`examples/demo-site/astro.config.mjs`.
 
-**Next:** Add schema-aware editors, file move/rename/delete flows, and richer non-technical UX from `professional_site` extraction (Epic 7).
+**Next:** Add schema-aware editors, file move/rename/delete flows, and richer non-technical UX from
+`professional_site` extraction (Epic 7).
 
-
-- Admin asset uploads: use the `/admin` **Public assets uploader** to drop files into `public/` or a nested folder (e.g. `media/uploads`).
+- Admin asset uploads: use the `/admin` **Public assets uploader** to drop files into `public/` or a
+  nested folder (e.g. `media/uploads`).

--- a/packages/admin-tools/README.md
+++ b/packages/admin-tools/README.md
@@ -57,4 +57,4 @@ The default dashboard expects collections named **`writing`**, **`projects`**, *
 
 ## Status
 
-Read-only overview and auth plumbing ship first; GitHub Contents editing (drawers, `/api/content`) is the next extraction step from `professional_site`.
+MVP overview, auth plumbing, and a basic in-browser file editor are shipped. `/api/content` now supports inventory + file reads and saves (local writes in `devBypass`, GitHub Contents API writes in OAuth mode) across content/config/context/registry/public paths. Rich schema-aware drawers and polished editing UX remain a follow-up extraction step from `professional_site`.

--- a/packages/admin-tools/README.md
+++ b/packages/admin-tools/README.md
@@ -29,7 +29,7 @@ export default defineConfig({
 });
 ```
 
-With `devBypass: true`, `pnpm astro dev` skips GitHub login and opens a **read-only** overview (site config, route tree, content counts). Remove `devBypass` for real OAuth.
+With `devBypass: true`, `pnpm astro dev` skips GitHub login and opens the dashboard with **local file writes enabled** — you can load/save files in `src/content`, `src/config`, `src/context`, `src/registry`, and `public/` directly. Remove `devBypass` for real OAuth (writes go through the GitHub Contents API in that mode).
 
 ## Production OAuth
 

--- a/packages/admin-tools/README.md
+++ b/packages/admin-tools/README.md
@@ -57,4 +57,4 @@ The default dashboard expects collections named **`writing`**, **`projects`**, *
 
 ## Status
 
-MVP overview, auth plumbing, and a basic in-browser file editor are shipped. `/api/content` now supports inventory + file reads and saves (local writes in `devBypass`, GitHub Contents API writes in OAuth mode) across content/config/context/registry/public paths. Rich schema-aware drawers and polished editing UX remain a follow-up extraction step from `professional_site`.
+MVP overview, auth plumbing, and a basic in-browser file editor are shipped. `/api/content` now supports inventory + file reads and saves (local writes in `devBypass`, GitHub Contents API writes in OAuth mode) across content/config/context/registry/public paths. Includes drag-and-drop/browse upload for `public/` assets (with optional subfolder target) so non-technical users can add images/files and reference them in pages. Rich schema-aware drawers and polished editing UX remain a follow-up extraction step from `professional_site`.

--- a/packages/admin-tools/src/integration.ts
+++ b/packages/admin-tools/src/integration.ts
@@ -31,6 +31,7 @@ export function adminTools(options: AdminToolsOptions = {}): AstroIntegration {
         route('/api/auth/logout', './routes/api/auth/logout.ts');
         route('/api/auth/github', './routes/api/auth/github.ts');
         route('/api/auth/callback', './routes/api/auth/callback.ts');
+        route('/api/content', './routes/api/content.ts');
       },
     },
   };

--- a/packages/admin-tools/src/routes/admin.astro
+++ b/packages/admin-tools/src/routes/admin.astro
@@ -8,6 +8,40 @@ import SiteMapTree from '../components/SiteMapTree.astro';
 import { parseCookies, verifySession } from '../server/session.js';
 import { siteHomeUrl, sitePathUrl } from '../server/paths.js';
 
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+interface DirAudit { exists: boolean; files: string[]; }
+async function listFilesSafe(relativeDir: string): Promise<DirAudit> {
+  const root = process.cwd();
+  const start = path.join(root, relativeDir);
+  async function walk(dir: string): Promise<string[]> {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    const out: string[] = [];
+    for (const entry of entries) {
+      const abs = path.join(dir, entry.name);
+      if (entry.isDirectory()) out.push(...(await walk(abs)));
+      else out.push(path.relative(root, abs).replaceAll(path.sep, '/'));
+    }
+    return out;
+  }
+
+  try {
+    return { exists: true, files: await walk(start) };
+  } catch {
+    return { exists: false, files: [] };
+  }
+}
+
+async function readJsonSafe(relativePath: string): Promise<Record<string, unknown> | null> {
+  try {
+    const raw = await fs.readFile(path.join(process.cwd(), relativePath), 'utf8');
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
 let readOnly = false;
 
 if (process.env.ADMIN_TOOLS_DEV_BYPASS === '1' && import.meta.env.DEV) {
@@ -56,6 +90,22 @@ const projectsSorted = [...projects].sort(
 
 const logoutUrl = sitePathUrl(Astro.request, 'api/auth/logout');
 const homeUrl = siteHomeUrl(Astro.request);
+
+const configAudit = await listFilesSafe('src/config');
+const contentAudit = await listFilesSafe('src/content');
+const contextAudit = await listFilesSafe('src/context');
+const publicAudit = await listFilesSafe('public');
+const registryAudit = await listFilesSafe('src/registry');
+const manifestJson = await readJsonSafe('.portfolio-engine/manifest.json');
+const hasManifest = manifestJson !== null;
+const missingAreas = [
+  !configAudit.exists && 'src/config',
+  !contentAudit.exists && 'src/content',
+  !contextAudit.exists && 'src/context',
+  !publicAudit.exists && 'public',
+  !registryAudit.exists && 'src/registry',
+  !hasManifest && '.portfolio-engine/manifest.json',
+].filter(Boolean);
 ---
 
 <!doctype html>
@@ -155,6 +205,38 @@ const homeUrl = siteHomeUrl(Astro.request);
         <h2 class="adm-h2">Routes</h2>
         <div class="adm-card adm-card--wide">
           <SiteMapTree routes={routes} />
+        </div>
+      </section>
+
+
+      <section class="adm-section">
+        <h2 class="adm-h2">Admin tools audit</h2>
+        <div class="adm-card adm-card--wide">
+          <p class="adm-lead">Coverage of planned admin areas: config, content, context, assets, registry, and manifest.</p>
+          <ul class="adm-list">
+            <li>Config files: {configAudit.files.length}</li>
+            <li>Content files: {contentAudit.files.length}</li>
+            <li>Context files: {contextAudit.files.length}</li>
+            <li>Public assets: {publicAudit.files.length}</li>
+            <li>Registry files: {registryAudit.files.length}</li>
+            <li>Manifest detected: {hasManifest ? 'yes' : 'no'}</li>
+          </ul>
+          {missingAreas.length > 0 ? <p class="adm-banner adm-banner--info">Missing expected paths: {missingAreas.join(', ')}</p> : <p class="adm-profile-bio">No structural blockers detected.</p>}
+        </div>
+      </section>
+
+
+      <section class="adm-section">
+        <h2 class="adm-h2">Content editor (MVP)</h2>
+        <div class="adm-card adm-card--wide">
+          <p class="adm-profile-bio">Read/write editor for files in src/content, src/config, src/context, src/registry, and public.</p>
+          <div class="adm-editor-row">
+            <input id="adm-file" class="adm-input" placeholder="src/content/writing/post.md" />
+            <button id="adm-load" class="adm-btn">Load</button>
+            <button id="adm-save" class="adm-btn adm-btn--primary">Save</button>
+          </div>
+          <textarea id="adm-content" class="adm-textarea" spellcheck="false"></textarea>
+          <p id="adm-status" class="adm-profile-bio"></p>
         </div>
       </section>
 
@@ -325,6 +407,11 @@ const homeUrl = siteHomeUrl(Astro.request);
         font-size: 1.5rem;
         font-weight: 700;
       }
+      .adm-editor-row { display:flex; gap:.5rem; margin:.75rem 0; flex-wrap:wrap; }
+      .adm-input { flex:1; min-width:20rem; border:1px solid var(--adm-border); border-radius:.5rem; padding:.5rem .65rem; }
+      .adm-btn { border:1px solid var(--adm-border); border-radius:.5rem; background:#fff; padding:.45rem .75rem; cursor:pointer; }
+      .adm-btn--primary { background:#0f172a; color:#fff; border-color:#0f172a; }
+      .adm-textarea { width:100%; min-height:18rem; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size:.8rem; border:1px solid var(--adm-border); border-radius:.5rem; padding:.75rem; }
       .adm-list {
         margin: 0.75rem 0 0;
         padding-left: 1.1rem;
@@ -344,6 +431,29 @@ const homeUrl = siteHomeUrl(Astro.request);
         await fetch(url, { method: 'POST', credentials: 'include' });
         window.location.href = home;
       });
+
+      const fileInput = document.getElementById('adm-file');
+      const contentArea = document.getElementById('adm-content');
+      const status = document.getElementById('adm-status');
+      document.getElementById('adm-load')?.addEventListener('click', async () => {
+        const file = fileInput?.value?.trim();
+        if (!file) return;
+        status.textContent = 'Loading…';
+        const res = await fetch(`/api/content?file=${encodeURIComponent(file)}`, { credentials: 'include' });
+        const data = await res.json();
+        if (!res.ok) { status.textContent = `Load failed: ${data.error ?? res.status}`; return; }
+        contentArea.value = data.content ?? '';
+        status.textContent = `Loaded ${file}`;
+      });
+      document.getElementById('adm-save')?.addEventListener('click', async () => {
+        const file = fileInput?.value?.trim();
+        if (!file) return;
+        status.textContent = 'Saving…';
+        const res = await fetch('/api/content', { method: 'PUT', credentials: 'include', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ file, content: contentArea.value }) });
+        const data = await res.json();
+        status.textContent = res.ok ? `Saved ${file} (${data.mode})` : `Save failed: ${data.error ?? res.status}`;
+      });
+
     </script>
   </body>
 </html>

--- a/packages/admin-tools/src/routes/admin.astro
+++ b/packages/admin-tools/src/routes/admin.astro
@@ -42,10 +42,10 @@ async function readJsonSafe(relativePath: string): Promise<Record<string, unknow
   }
 }
 
-let readOnly = false;
+let devBypass = false;
 
 if (process.env.ADMIN_TOOLS_DEV_BYPASS === '1' && import.meta.env.DEV) {
-  readOnly = true;
+  devBypass = true;
 } else {
   const token = parseCookies(Astro.request.headers.get('cookie'))['session'];
   const secret = process.env.SESSION_SECRET;
@@ -90,6 +90,7 @@ const projectsSorted = [...projects].sort(
 
 const logoutUrl = sitePathUrl(Astro.request, 'api/auth/logout');
 const homeUrl = siteHomeUrl(Astro.request);
+const contentApiUrl = sitePathUrl(Astro.request, 'api/content');
 
 const configAudit = await listFilesSafe('src/config');
 const contentAudit = await listFilesSafe('src/content');
@@ -153,10 +154,11 @@ const missingAreas = [
       </header>
 
       {
-        readOnly && (
+        devBypass && (
           <p class="adm-banner">
-            Read-only session: configure GitHub OAuth and <code>SESSION_SECRET</code> for full sign-in. In production, set
-            <code>ADMIN_TOOLS_GITHUB_REPO_OWNER</code> and <code>ADMIN_TOOLS_GITHUB_REPO_NAME</code> for collaborator checks.
+            Dev bypass mode: local file writes enabled. Configure GitHub OAuth and <code>SESSION_SECRET</code> for full
+            sign-in. In production, set <code>ADMIN_TOOLS_GITHUB_REPO_OWNER</code> and{' '}
+            <code>ADMIN_TOOLS_GITHUB_REPO_NAME</code> for collaborator checks.
           </p>
         )
       }
@@ -226,7 +228,7 @@ const missingAreas = [
       </section>
 
 
-      <section class="adm-section">
+      <section class="adm-section" id="adm-editor-section" data-content-api-url={contentApiUrl}>
         <h2 class="adm-h2">Content editor (MVP)</h2>
         <div class="adm-card adm-card--wide">
           <p class="adm-profile-bio">Read/write editor for files in src/content, src/config, src/context, src/registry, and public.</p>
@@ -450,36 +452,37 @@ const missingAreas = [
         window.location.href = home;
       });
 
-      const fileInput = document.getElementById('adm-file');
-      const contentArea = document.getElementById('adm-content');
+      const contentApiUrl = (document.getElementById('adm-editor-section') as HTMLElement)?.dataset.contentApiUrl ?? '/api/content';
+      const fileInput = document.getElementById('adm-file') as HTMLInputElement | null;
+      const contentArea = document.getElementById('adm-content') as HTMLTextAreaElement | null;
       const status = document.getElementById('adm-status');
       document.getElementById('adm-load')?.addEventListener('click', async () => {
         const file = fileInput?.value?.trim();
-        if (!file) return;
+        if (!file || !status) return;
         status.textContent = 'Loading…';
-        const res = await fetch(`/api/content?file=${encodeURIComponent(file)}`, { credentials: 'include' });
+        const res = await fetch(`${contentApiUrl}?file=${encodeURIComponent(file)}`, { credentials: 'include' });
         const data = await res.json();
         if (!res.ok) { status.textContent = `Load failed: ${data.error ?? res.status}`; return; }
-        contentArea.value = data.content ?? '';
+        if (contentArea) contentArea.value = data.content ?? '';
         status.textContent = `Loaded ${file}`;
       });
       document.getElementById('adm-save')?.addEventListener('click', async () => {
         const file = fileInput?.value?.trim();
-        if (!file) return;
+        if (!file || !status) return;
         status.textContent = 'Saving…';
-        const res = await fetch('/api/content', { method: 'PUT', credentials: 'include', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ file, content: contentArea.value }) });
+        const res = await fetch(contentApiUrl, { method: 'PUT', credentials: 'include', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ file, content: contentArea?.value ?? '' }) });
         const data = await res.json();
         status.textContent = res.ok ? `Saved ${file} (${data.mode})` : `Save failed: ${data.error ?? res.status}`;
       });
 
-    
       const dropzone = document.getElementById('adm-dropzone');
-      const uploadInput = document.getElementById('adm-upload-input');
+      const uploadInput = document.getElementById('adm-upload-input') as HTMLInputElement | null;
       const uploadList = document.getElementById('adm-upload-list');
       const uploadStatus = document.getElementById('adm-upload-status');
-      const targetDirInput = document.getElementById('adm-target-dir');
+      const targetDirInput = document.getElementById('adm-target-dir') as HTMLInputElement | null;
 
-      const renderFiles = (files) => {
+      const renderFiles = (files: FileList) => {
+        if (!uploadList) return;
         uploadList.innerHTML = '';
         [...files].forEach((f) => {
           const li = document.createElement('li');
@@ -488,21 +491,21 @@ const missingAreas = [
         });
       };
 
-      const doUpload = async (fileList) => {
+      const doUpload = async (fileList: FileList | null) => {
         if (!fileList || fileList.length === 0) return;
         renderFiles(fileList);
-        uploadStatus.textContent = 'Uploading…';
+        if (uploadStatus) uploadStatus.textContent = 'Uploading…';
         const fd = new FormData();
         const dir = targetDirInput?.value?.trim() || '';
         fd.append('targetDir', dir);
         [...fileList].forEach((f) => fd.append('files', f));
-        const res = await fetch('/api/content', { method: 'POST', credentials: 'include', body: fd });
+        const res = await fetch(contentApiUrl, { method: 'POST', credentials: 'include', body: fd });
         const data = await res.json();
-        uploadStatus.textContent = res.ok ? `Uploaded: ${(data.saved || []).join(', ')}` : `Upload failed: ${data.error || res.status}`;
+        if (uploadStatus) uploadStatus.textContent = res.ok ? `Uploaded: ${(data.saved || []).join(', ')}` : `Upload failed: ${data.error || res.status}`;
       };
 
       dropzone?.addEventListener('click', () => uploadInput?.click());
-      uploadInput?.addEventListener('change', () => doUpload(uploadInput.files));
+      uploadInput?.addEventListener('change', () => doUpload(uploadInput?.files ?? null));
       ['dragenter', 'dragover'].forEach((evt) => dropzone?.addEventListener(evt, (e) => { e.preventDefault(); dropzone.classList.add('is-over'); }));
       ['dragleave', 'drop'].forEach((evt) => dropzone?.addEventListener(evt, (e) => { e.preventDefault(); dropzone.classList.remove('is-over'); }));
       dropzone?.addEventListener('drop', (e) => {

--- a/packages/admin-tools/src/routes/admin.astro
+++ b/packages/admin-tools/src/routes/admin.astro
@@ -240,6 +240,21 @@ const missingAreas = [
         </div>
       </section>
 
+
+      <section class="adm-section">
+        <h2 class="adm-h2">Public assets uploader</h2>
+        <div class="adm-card adm-card--wide">
+          <p class="adm-profile-bio">Drag & drop files to upload into <code>public/</code>. Use a subfolder path if desired (example: <code>media/projects</code>).</p>
+          <div class="adm-editor-row">
+            <input id="adm-target-dir" class="adm-input" placeholder="media/uploads" />
+          </div>
+          <div id="adm-dropzone" class="adm-dropzone">Drop files here or click to choose files.</div>
+          <input id="adm-upload-input" type="file" multiple class="adm-hidden-input" />
+          <ul id="adm-upload-list" class="adm-list"></ul>
+          <p id="adm-upload-status" class="adm-profile-bio"></p>
+        </div>
+      </section>
+
       <section class="adm-section">
         <h2 class="adm-h2">Content</h2>
         <div class="adm-grid">
@@ -412,6 +427,9 @@ const missingAreas = [
       .adm-btn { border:1px solid var(--adm-border); border-radius:.5rem; background:#fff; padding:.45rem .75rem; cursor:pointer; }
       .adm-btn--primary { background:#0f172a; color:#fff; border-color:#0f172a; }
       .adm-textarea { width:100%; min-height:18rem; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size:.8rem; border:1px solid var(--adm-border); border-radius:.5rem; padding:.75rem; }
+      .adm-dropzone { border:2px dashed var(--adm-border); border-radius:.75rem; padding:1.25rem; text-align:center; color:var(--adm-muted); cursor:pointer; margin:.5rem 0; }
+      .adm-dropzone.is-over { border-color:#0f172a; color:#0f172a; background:#f8fafc; }
+      .adm-hidden-input { display:none; }
       .adm-list {
         margin: 0.75rem 0 0;
         padding-left: 1.1rem;
@@ -452,6 +470,45 @@ const missingAreas = [
         const res = await fetch('/api/content', { method: 'PUT', credentials: 'include', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ file, content: contentArea.value }) });
         const data = await res.json();
         status.textContent = res.ok ? `Saved ${file} (${data.mode})` : `Save failed: ${data.error ?? res.status}`;
+      });
+
+    
+      const dropzone = document.getElementById('adm-dropzone');
+      const uploadInput = document.getElementById('adm-upload-input');
+      const uploadList = document.getElementById('adm-upload-list');
+      const uploadStatus = document.getElementById('adm-upload-status');
+      const targetDirInput = document.getElementById('adm-target-dir');
+
+      const renderFiles = (files) => {
+        uploadList.innerHTML = '';
+        [...files].forEach((f) => {
+          const li = document.createElement('li');
+          li.textContent = `${f.name} (${f.type || 'binary'}, ${f.size} bytes)`;
+          uploadList.appendChild(li);
+        });
+      };
+
+      const doUpload = async (fileList) => {
+        if (!fileList || fileList.length === 0) return;
+        renderFiles(fileList);
+        uploadStatus.textContent = 'Uploading…';
+        const fd = new FormData();
+        const dir = targetDirInput?.value?.trim() || '';
+        fd.append('targetDir', dir);
+        [...fileList].forEach((f) => fd.append('files', f));
+        const res = await fetch('/api/content', { method: 'POST', credentials: 'include', body: fd });
+        const data = await res.json();
+        uploadStatus.textContent = res.ok ? `Uploaded: ${(data.saved || []).join(', ')}` : `Upload failed: ${data.error || res.status}`;
+      };
+
+      dropzone?.addEventListener('click', () => uploadInput?.click());
+      uploadInput?.addEventListener('change', () => doUpload(uploadInput.files));
+      ['dragenter', 'dragover'].forEach((evt) => dropzone?.addEventListener(evt, (e) => { e.preventDefault(); dropzone.classList.add('is-over'); }));
+      ['dragleave', 'drop'].forEach((evt) => dropzone?.addEventListener(evt, (e) => { e.preventDefault(); dropzone.classList.remove('is-over'); }));
+      dropzone?.addEventListener('drop', (e) => {
+        const dt = e.dataTransfer;
+        if (!dt?.files) return;
+        doUpload(dt.files);
       });
 
     </script>

--- a/packages/admin-tools/src/routes/api/content.ts
+++ b/packages/admin-tools/src/routes/api/content.ts
@@ -16,6 +16,7 @@ async function walk(dir: string, root: string): Promise<FileEntry[]> {
   const entries = await fs.readdir(dir, { withFileTypes: true });
   const out: FileEntry[] = [];
   for (const entry of entries) {
+    if (entry.isSymbolicLink()) continue;
     const abs = path.join(dir, entry.name);
     if (entry.isDirectory()) out.push(...(await walk(abs, root)));
     else {
@@ -27,12 +28,14 @@ async function walk(dir: string, root: string): Promise<FileEntry[]> {
 }
 
 function resolveAllowed(cwd: string, relativePath: string): string | null {
-  const clean = relativePath.replace(/^\/+/, '');
-  const allowedRoots = ['src/content/', 'src/config/', 'src/context/', 'src/registry/', 'public/'];
-  if (!allowedRoots.some((r) => clean.startsWith(r))) return null;
-  const abs = path.resolve(cwd, clean);
-  if (!abs.startsWith(path.resolve(cwd) + path.sep)) return null;
-  return abs;
+  const abs = path.resolve(cwd, relativePath.replace(/^\/+/, ''));
+  const cwdAbs = path.resolve(cwd);
+  const allowedRoots = ['src/content', 'src/config', 'src/context', 'src/registry', 'public'];
+  const allowed = allowedRoots.some((r) => {
+    const rootAbs = path.join(cwdAbs, r);
+    return abs === rootAbs || abs.startsWith(rootAbs + path.sep);
+  });
+  return allowed ? abs : null;
 }
 
 
@@ -64,12 +67,27 @@ export const GET: APIRoute = async ({ request, url }) => {
   if (file) {
     const abs = resolveAllowed(cwd, file);
     if (!abs) return Response.json({ error: 'Invalid file path' }, { status: 400, headers: NO_STORE });
-    try {
-      const content = await fs.readFile(abs, 'utf8');
-      return Response.json({ file, content }, { headers: NO_STORE });
-    } catch {
-      return Response.json({ error: 'Not found' }, { status: 404, headers: NO_STORE });
+    if (authed.devBypass) {
+      try {
+        const lstat = await fs.lstat(abs);
+        if (lstat.isSymbolicLink()) return Response.json({ error: 'Invalid file path' }, { status: 400, headers: NO_STORE });
+        const content = await fs.readFile(abs, 'utf8');
+        return Response.json({ file, content }, { headers: NO_STORE });
+      } catch {
+        return Response.json({ error: 'Not found' }, { status: 404, headers: NO_STORE });
+      }
     }
+    // OAuth mode: read from GitHub Contents API so this works on deployed servers
+    const owner = repoOwner(); const repo = repoName(); const branch = repoBranch();
+    if (!owner || !repo || !authed.accessToken) return Response.json({ error: 'Repo/auth misconfiguration' }, { status: 500, headers: NO_STORE });
+    const ghPath = file.replace(/^\/+/, '');
+    const ghUrl = `https://api.github.com/repos/${owner}/${repo}/contents/${encodeURIComponent(ghPath).replace(/%2F/g, '/')}?ref=${encodeURIComponent(branch)}`;
+    const ghRes = await fetch(ghUrl, { headers: { Authorization: `Bearer ${authed.accessToken}`, Accept: 'application/vnd.github+json', 'User-Agent': 'portfolio-engine-admin-tools' } });
+    if (!ghRes.ok) return Response.json({ error: 'Not found' }, { status: 404, headers: NO_STORE });
+    const ghData = await ghRes.json() as { content?: string; encoding?: string };
+    if (!ghData.content || ghData.encoding !== 'base64') return Response.json({ error: 'Unexpected GitHub response' }, { status: 502, headers: NO_STORE });
+    const content = Buffer.from(ghData.content.replace(/\n/g, ''), 'base64').toString('utf8');
+    return Response.json({ file, content }, { headers: NO_STORE });
   }
 
   const section = url.searchParams.get('section') ?? 'content';
@@ -90,6 +108,8 @@ export const PUT: APIRoute = async ({ request }) => {
 
   if (authed.devBypass) {
     await fs.mkdir(path.dirname(abs), { recursive: true });
+    const lstat = await fs.lstat(abs).catch(() => null);
+    if (lstat?.isSymbolicLink()) return Response.json({ error: 'Invalid file path' }, { status: 400, headers: NO_STORE });
     await fs.writeFile(abs, body.content, 'utf8');
     return Response.json({ ok: true, mode: 'local-dev' }, { headers: NO_STORE });
   }

--- a/packages/admin-tools/src/routes/api/content.ts
+++ b/packages/admin-tools/src/routes/api/content.ts
@@ -1,0 +1,109 @@
+import type { APIRoute } from 'astro';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { parseCookies, verifySession } from '../../server/session.js';
+
+export const prerender = false;
+const NO_STORE = { 'Cache-Control': 'no-store' } as const;
+
+interface FileEntry { path: string; size: number; ext: string }
+
+const repoOwner = () => process.env.ADMIN_TOOLS_GITHUB_REPO_OWNER ?? process.env.REPO_OWNER ?? '';
+const repoName = () => process.env.ADMIN_TOOLS_GITHUB_REPO_NAME ?? process.env.REPO_NAME ?? '';
+const repoBranch = () => process.env.ADMIN_TOOLS_GITHUB_REPO_BRANCH ?? process.env.REPO_BRANCH ?? 'main';
+
+async function walk(dir: string, root: string): Promise<FileEntry[]> {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const out: FileEntry[] = [];
+  for (const entry of entries) {
+    const abs = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...(await walk(abs, root)));
+    else {
+      const stat = await fs.stat(abs);
+      out.push({ path: path.relative(root, abs).replaceAll(path.sep, '/'), size: stat.size, ext: path.extname(entry.name) });
+    }
+  }
+  return out;
+}
+
+function resolveAllowed(cwd: string, relativePath: string): string | null {
+  const clean = relativePath.replace(/^\/+/, '');
+  const allowedRoots = ['src/content/', 'src/config/', 'src/context/', 'src/registry/', 'public/'];
+  if (!allowedRoots.some((r) => clean.startsWith(r))) return null;
+  const abs = path.resolve(cwd, clean);
+  if (!abs.startsWith(path.resolve(cwd) + path.sep)) return null;
+  return abs;
+}
+
+async function auth(request: Request): Promise<{ devBypass: boolean; accessToken: string | null; error?: Response }> {
+  const devBypass = process.env.ADMIN_TOOLS_DEV_BYPASS === '1' && import.meta.env.DEV;
+  if (devBypass) return { devBypass, accessToken: null };
+  const token = parseCookies(request.headers.get('cookie'))['session'];
+  const secret = process.env.SESSION_SECRET;
+  if (!token || !secret) return { devBypass, accessToken: null, error: Response.json({ error: 'Unauthorized' }, { status: 401, headers: NO_STORE }) };
+  const session = await verifySession(token, secret);
+  if (!session) return { devBypass, accessToken: null, error: Response.json({ error: 'Unauthorized' }, { status: 401, headers: NO_STORE }) };
+  return { devBypass, accessToken: session.accessToken };
+}
+
+export const GET: APIRoute = async ({ request, url }) => {
+  const authed = await auth(request); if (authed.error) return authed.error;
+  const cwd = process.cwd();
+  const file = url.searchParams.get('file');
+  if (file) {
+    const abs = resolveAllowed(cwd, file);
+    if (!abs) return Response.json({ error: 'Invalid file path' }, { status: 400, headers: NO_STORE });
+    try {
+      const content = await fs.readFile(abs, 'utf8');
+      return Response.json({ file, content }, { headers: NO_STORE });
+    } catch {
+      return Response.json({ error: 'Not found' }, { status: 404, headers: NO_STORE });
+    }
+  }
+
+  const section = url.searchParams.get('section') ?? 'content';
+  const roots: Record<string, string> = { content: 'src/content', config: 'src/config', context: 'src/context', assets: 'public', registry: 'src/registry' };
+  const relative = roots[section];
+  if (!relative) return Response.json({ error: 'Unknown section' }, { status: 400, headers: NO_STORE });
+  try { return Response.json({ section, files: await walk(path.join(cwd, relative), cwd) }, { headers: NO_STORE }); }
+  catch { return Response.json({ section, files: [] }, { headers: NO_STORE }); }
+};
+
+export const PUT: APIRoute = async ({ request }) => {
+  const authed = await auth(request); if (authed.error) return authed.error;
+  const body = await request.json().catch(() => null) as { file?: string; content?: string; message?: string } | null;
+  if (!body?.file || typeof body.content !== 'string') return Response.json({ error: 'Missing file or content' }, { status: 400, headers: NO_STORE });
+  const cwd = process.cwd();
+  const abs = resolveAllowed(cwd, body.file);
+  if (!abs) return Response.json({ error: 'Invalid file path' }, { status: 400, headers: NO_STORE });
+
+  if (authed.devBypass) {
+    await fs.mkdir(path.dirname(abs), { recursive: true });
+    await fs.writeFile(abs, body.content, 'utf8');
+    return Response.json({ ok: true, mode: 'local-dev' }, { headers: NO_STORE });
+  }
+
+  const owner = repoOwner(); const repo = repoName(); const branch = repoBranch();
+  if (!owner || !repo || !authed.accessToken) return Response.json({ error: 'Repo/auth misconfiguration' }, { status: 500, headers: NO_STORE });
+
+  const ghPath = body.file.replace(/^\/+/, '');
+  const base = `https://api.github.com/repos/${owner}/${repo}/contents/${encodeURIComponent(ghPath).replace(/%2F/g, '/')}`;
+  const headers = { Authorization: `Bearer ${authed.accessToken}`, Accept: 'application/vnd.github+json', 'User-Agent': 'portfolio-engine-admin-tools' };
+  const currentRes = await fetch(`${base}?ref=${encodeURIComponent(branch)}`, { headers });
+  let sha: string | undefined;
+  if (currentRes.ok) {
+    const current = await currentRes.json() as { sha?: string };
+    sha = current.sha;
+  }
+
+  const upRes = await fetch(base, {
+    method: 'PUT',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ message: body.message ?? `admin-tools: update ${ghPath}`, content: Buffer.from(body.content, 'utf8').toString('base64'), sha, branch }),
+  });
+  if (!upRes.ok) {
+    const detail = await upRes.text();
+    return Response.json({ error: 'GitHub write failed', detail }, { status: 502, headers: NO_STORE });
+  }
+  return Response.json({ ok: true, mode: 'github' }, { headers: NO_STORE });
+};

--- a/packages/admin-tools/src/routes/api/content.ts
+++ b/packages/admin-tools/src/routes/api/content.ts
@@ -35,6 +35,17 @@ function resolveAllowed(cwd: string, relativePath: string): string | null {
   return abs;
 }
 
+
+
+function resolvePublicDirectory(cwd: string, relativeDir: string): string | null {
+  const clean = relativeDir.replace(/^\/+/, '');
+  const prefixed = clean ? `public/${clean}`.replace(/\/+/g, '/') : 'public';
+  const abs = path.resolve(cwd, prefixed);
+  const publicRoot = path.resolve(cwd, 'public');
+  if (abs !== publicRoot && !abs.startsWith(publicRoot + path.sep)) return null;
+  return abs;
+}
+
 async function auth(request: Request): Promise<{ devBypass: boolean; accessToken: string | null; error?: Response }> {
   const devBypass = process.env.ADMIN_TOOLS_DEV_BYPASS === '1' && import.meta.env.DEV;
   if (devBypass) return { devBypass, accessToken: null };
@@ -106,4 +117,57 @@ export const PUT: APIRoute = async ({ request }) => {
     return Response.json({ error: 'GitHub write failed', detail }, { status: 502, headers: NO_STORE });
   }
   return Response.json({ ok: true, mode: 'github' }, { headers: NO_STORE });
+};
+
+
+export const POST: APIRoute = async ({ request }) => {
+  const authed = await auth(request); if (authed.error) return authed.error;
+  const form = await request.formData().catch(() => null);
+  if (!form) return Response.json({ error: 'Expected multipart form data' }, { status: 400, headers: NO_STORE });
+
+  const targetDir = String(form.get('targetDir') ?? '').trim();
+  const files = form.getAll('files').filter((v): v is File => v instanceof File);
+  if (files.length === 0) return Response.json({ error: 'No files uploaded' }, { status: 400, headers: NO_STORE });
+
+  const cwd = process.cwd();
+  const dirAbs = resolvePublicDirectory(cwd, targetDir);
+  if (!dirAbs) return Response.json({ error: 'Invalid targetDir' }, { status: 400, headers: NO_STORE });
+
+  const saved: string[] = [];
+
+  if (authed.devBypass) {
+    await fs.mkdir(dirAbs, { recursive: true });
+    for (const file of files) {
+      const name = path.basename(file.name);
+      const abs = path.join(dirAbs, name);
+      const bytes = Buffer.from(await file.arrayBuffer());
+      await fs.writeFile(abs, bytes);
+      saved.push(path.relative(cwd, abs).replaceAll(path.sep, '/'));
+    }
+    return Response.json({ ok: true, mode: 'local-dev', saved }, { headers: NO_STORE });
+  }
+
+  const owner = repoOwner(); const repo = repoName(); const branch = repoBranch();
+  if (!owner || !repo || !authed.accessToken) return Response.json({ error: 'Repo/auth misconfiguration' }, { status: 500, headers: NO_STORE });
+  const headers = { Authorization: `Bearer ${authed.accessToken}`, Accept: 'application/vnd.github+json', 'User-Agent': 'portfolio-engine-admin-tools', 'Content-Type': 'application/json' };
+
+  for (const file of files) {
+    const name = path.basename(file.name);
+    const rel = path.relative(cwd, path.join(dirAbs, name)).replaceAll(path.sep, '/');
+    const base = `https://api.github.com/repos/${owner}/${repo}/contents/${encodeURIComponent(rel).replace(/%2F/g, '/')}`;
+    const currentRes = await fetch(`${base}?ref=${encodeURIComponent(branch)}`, { headers });
+    let sha: string | undefined;
+    if (currentRes.ok) {
+      const current = await currentRes.json() as { sha?: string };
+      sha = current.sha;
+    }
+    const content = Buffer.from(await file.arrayBuffer()).toString('base64');
+    const upRes = await fetch(base, { method: 'PUT', headers, body: JSON.stringify({ message: `admin-tools: upload ${rel}`, content, sha, branch }) });
+    if (!upRes.ok) {
+      return Response.json({ error: `Upload failed for ${rel}`, detail: await upRes.text() }, { status: 502, headers: NO_STORE });
+    }
+    saved.push(rel);
+  }
+
+  return Response.json({ ok: true, mode: 'github', saved }, { headers: NO_STORE });
 };


### PR DESCRIPTION
### Motivation

- Provide an in-dashboard way to inspect site layout and files and to enable a basic read/write editor for content/config/context/registry/public assets. 
- Support both local dev edits (`devBypass`) and authenticated GitHub Contents API writes for managed repositories. 
- Surface structural issues (missing paths / manifest) so the admin UI can guide follow-ups and extractions from `professional_site`.

### Description

- Add a new API route injection in `src/integration.ts` for `/api/content` via `route('/api/content', './routes/api/content.ts')`.
- Implement a new `routes/api/content.ts` endpoint that lists files per section, reads files (`GET?file=`), and writes files (`PUT`) with local-dev writes when `devBypass` is active and GitHub Contents API writes when authenticated; the endpoint enforces allowed roots and basic path sanitization with `resolveAllowed`.
- Extend the admin UI in `routes/admin.astro` to perform filesystem audits (`src/config`, `src/content`, `src/context`, `public`, `src/registry`) and read the `.portfolio-engine/manifest.json`, plus add an "Admin tools audit" panel and a basic in-browser content editor (load/save UI and client-side fetch handlers calling `/api/content`).
- Update docs (`docs/packages/admin-tools.md` and `packages/admin-tools/README.md`) to reflect shipped capabilities including the read-only dashboard enhancements, manifest/registry/audit coverage, the new read/write editor MVP, and `/api/content` inventory + file read/save behavior.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6df16726083208d5a30a11a567b6c)