### PR TITLE
feat(admin-tools): ship admin UI, content API, GitHub OAuth, registry-aware demo, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ src/
                                        Zod schemas
 ```
 
-The three **required** packages are published to npm — your repo installs them. `admin-tools` and `workflow-kit` are optional add-ons built on top.
+The three **required** packages are published to npm — your repo installs them. `@portfolio-engine/admin-tools` is an optional UI layer; `@portfolio-engine/workflow-kit` exists but is currently scaffold-stage (not a production MCP toolkit yet).
 
 ---
 
@@ -95,8 +95,8 @@ pnpm format   # Prettier check
 
 | Package                                                   | Description                                         |
 | --------------------------------------------------------- | --------------------------------------------------- |
-| [`@portfolio-engine/admin-tools`](packages/admin-tools/)  | Admin/reviewer UI for nontechnical site owners      |
-| [`portfolio-engine-workflow-kit`](packages/workflow-kit/) | Python/MCP tools for AI-assisted consumer workflows |
+| [`@portfolio-engine/admin-tools`](packages/admin-tools/)  | Admin/reviewer UI + `/api/content` + OAuth support (Node adapter required) |
+| [`@portfolio-engine/workflow-kit`](packages/workflow-kit/) | Reserved package for future workflow automation (currently scaffold) |
 
 ### CI
 

--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ pnpm format   # Prettier check
 
 **Optional** (post-MVP add-ons, not required to run a site):
 
-| Package                                                   | Description                                         |
-| --------------------------------------------------------- | --------------------------------------------------- |
-| [`@portfolio-engine/admin-tools`](packages/admin-tools/)  | Admin/reviewer UI + `/api/content` + OAuth support (Node adapter required) |
-| [`@portfolio-engine/workflow-kit`](packages/workflow-kit/) | Reserved package for future workflow automation (currently scaffold) |
+| Package                                                    | Description                                                                |
+| ---------------------------------------------------------- | -------------------------------------------------------------------------- |
+| [`@portfolio-engine/admin-tools`](packages/admin-tools/)   | Admin/reviewer UI + `/api/content` + OAuth support (Node adapter required) |
+| [`@portfolio-engine/workflow-kit`](packages/workflow-kit/) | Reserved package for future workflow automation (currently scaffold)       |
 
 ### CI
 

--- a/docs/downstream/setup-with-claude.md
+++ b/docs/downstream/setup-with-claude.md
@@ -1,6 +1,6 @@
 # Portfolio site setup — paste this into Claude Code
 
-Copy the entire contents of this file and paste it into Claude Code as your first message. Claude will guide you through everything from there — asking for your details, building the site, and telling you exactly when to go click something in Vercel.
+Copy the entire contents of this file and paste it into Claude Code as your first message. Claude should run this as a **phased operator runbook** for a modern portfolio-engine consumer (route registry, manifest, named overrides, and admin tools enabled by default).
 
 ---
 
@@ -16,18 +16,19 @@ and what — if anything — you need from me or need me to do manually.
 
 ## Phase 1 — Learn about me
 
-Before touching any files, ask me for everything you need. Collect it all at
-once rather than one question at a time:
+Before touching any files, ask me for everything you need in one grouped prompt:
 
 - **Name** — as it should appear on the site
-- **Role** — what I do (e.g. "product designer", "educator", "software engineer")
+- **Role** — what I do
 - **Tagline** — one short punchy line
 - **Description** — one sentence: my work and who I do it for
 - **Location** — city and country
-- **Tone** — how I write (e.g. "warm and direct", "precise and minimal")
-- **Audience** — who reads my site (e.g. "hiring managers at education nonprofits")
-- **Pages** — which of these I want: Work, Writing, About, Contact (default: all four)
-- **Repo name** — what to call my GitHub repository (e.g. "jordan-site")
+- **Tone** — how I write
+- **Audience** — who reads my site
+- **Pages** — which of these I want: Work, Writing, About, Contact (default: all)
+- **Booking URL** — optional scheduling link
+- **Social URLs** — GitHub, LinkedIn, X/Twitter (optional)
+- **Repo name** — what to call my GitHub repository
 
 If any answer is vague, ask one follow-up before moving on.
 
@@ -41,103 +42,106 @@ https://github.com/rainonej/portfolio-engine/blob/main/docs/downstream/new-site-
 Do all of the following:
 
 - Scaffold the Astro project and install `@portfolio-engine/editorial-theme`
+- Install `@portfolio-engine/admin-tools` and Node adapter support as part of the default setup
 - Create `src/config/site.json`, `navigation.json`, `theme.json`, `features.json`
-  with my real details
 - Create `src/content.config.ts` and placeholder content in `src/content/`
-  (I'll replace placeholders with real work later)
-- Fill in `src/context/site-owner.json` and `src/context/brand-voice.json`
-  from my Phase 1 answers; leave `agent-rules.md` as a template I can edit
+- Fill `src/context/site-owner.json` and `src/context/brand-voice.json`; keep `agent-rules.md` as an editable template
 - Create `src/overrides/README.md`
+- Wire at least one named override surface (Hero) so the overrides system is demonstrated
+- Run a local build and confirm `.portfolio-engine/manifest.json` is generated
 
-When done, tell me what was created and list any files I should come back and
-edit myself.
+When done, summarize what was created and list files I should customize first.
 
 ---
 
 ## Phase 3 — Push to GitHub
 
-1. Initialize a git repo here if one doesn't exist yet
-2. Create a new GitHub repo called the name I gave in Phase 1 — use
-   `gh repo create` if the GitHub CLI is available, otherwise walk me through
-   creating it at github.com
+1. Initialize a git repo if needed
+2. Create a new GitHub repo using my chosen repo name (`gh repo create` if available)
 3. Commit everything and push to `main`
 
-Tell me the GitHub URL when it's pushed.
+Tell me the GitHub URL after push.
 
 ---
 
-## Phase 4 — Vercel (you'll guide me through this manually)
+## Phase 4 — Vercel (manual, guided)
 
-You can't click buttons, so your job here is to give me exact instructions.
-Tell me:
+Give me exact click-by-click instructions.
 
-> Go to vercel.com and log in. Click **Add New → Project** and import your
-> **[repo name]** repository. Set:
+For a standard standalone consumer repo, tell me:
+
+> Go to vercel.com and log in. Click **Add New → Project** and import **[repo name]**.
+> Set:
 >
-> - Root Directory: `.` (leave it as-is)
+> - Root Directory: `.`
+> - Install Command: `pnpm install`
 > - Build Command: `pnpm build`
-> - Output Directory: leave as default
+> - Output Directory: default
 >
-> Click **Deploy** and wait for it to go green. Then go to
-> **Settings → General** and set Node.js to **22.x**. Come back here and
-> paste the URL it gave you (it looks like `your-repo.vercel.app`).
+> Click **Deploy**. After it succeeds, go to **Settings → General** and set Node.js to **22.x**.
+> Come back and paste the deployment URL.
 
-Wait for me to come back with the URL before doing anything else.
-
----
-
-## Phase 5 — Wire up the live URL
-
-Once I give you the Vercel URL:
-
-1. Update `src/config/site.json` `baseUrl` to that URL
-2. Commit and push the change
-3. Ask me: do I want to add my first real project now, or leave the placeholder?
-4. Ask me: do I want to add my first real writing piece now, or leave the placeholder?
-5. Walk me through filling in `src/context/brand-voice.json` properly — ask
-   me questions and write it from my answers rather than leaving it generic
+Wait for my URL before moving on.
 
 ---
 
-## Phase 6 — Production URL env var (you'll guide me)
+## Phase 5 — Wire up canonical URL + polish context
+
+Once I provide the Vercel URL:
+
+1. Update `src/config/site.json` `baseUrl`
+2. Commit and push
+3. Ask whether to replace placeholder project content now
+4. Ask whether to replace placeholder writing now
+5. Improve `src/context/brand-voice.json` by interviewing me briefly and writing concrete values
+
+---
+
+## Phase 6 — Production `SITE_URL` env var (manual, guided)
 
 Tell me:
 
-> Go to your Vercel project → **Settings → Environment Variables**. Add a
-> new variable:
+> In Vercel, open **Settings → Environment Variables**.
+> Add:
 >
 > - Name: `SITE_URL`
-> - Value: `[the URL from Phase 5]`
-> - Environment: **Production** only (uncheck Preview and Development)
+> - Value: `[production URL from Phase 5]`
+> - Environment: **Production only**
 >
-> Save it, then go to **Deployments**, open the latest deployment's menu
-> (three dots), and click **Redeploy**. Come back when it's done.
+> Save, then go to **Deployments**, open the latest deployment menu, and click **Redeploy**.
+> Come back when done.
 
 ---
 
-## Phase 7 — Custom domain (ask me first)
+## Phase 7 — Custom domain (ask first)
 
-Ask me: "Do you have a custom domain you want to use, like yourname.com?"
+Ask: “Do you have a custom domain you want to use, like yourname.com?”
 
-**If yes:** tell me to go to Vercel → **Settings → Domains** → add the
-domain, and walk me through the DNS records I need to set. Once I confirm the
-domain is live:
+- **If yes:** guide domain setup in Vercel, then:
+  1. update `site.json` `baseUrl`
+  2. commit + push
+  3. tell me to update Vercel `SITE_URL` and redeploy
+- **If no:** continue.
 
-1. Update `src/config/site.json` `baseUrl` to the new domain
-2. Commit and push
-3. Tell me to go back to Vercel and update the `SITE_URL` env var to the new
-   domain, then redeploy
+---
 
-**If no:** skip to the wrap-up.
+## Phase 8 — Registry / manifest / admin verification
+
+Run and report these checks:
+
+- Build passes
+- `.portfolio-engine/manifest.json` exists and lists route + override capabilities
+- `/admin` is present and `/api/content` contract is wired
+- Explain how route remaps/disables and named overrides are controlled in config/integration
 
 ---
 
 ## Wrap-up
 
-Give me a short summary:
+Give me a short summary with:
 
-- Where the site is live
-- The three folders that are mine to edit: `src/content/`, `src/config/`,
-  `src/context/`
-- One line on how to add new work later
-- One line on how to update the theme when a new version is out
+- Live URL
+- Repo URL
+- The three folders I own most: `src/content/`, `src/config/`, `src/context/`
+- Where to add overrides: `src/overrides/`
+- One line for theme updates (`pnpm update @portfolio-engine/editorial-theme && pnpm build`)

--- a/docs/packages/workflow-kit.md
+++ b/docs/packages/workflow-kit.md
@@ -2,7 +2,7 @@
 
 Reusable GitHub Actions workflow templates and AI change classifier for portfolio-engine downstream sites.
 
-## Planned capabilities
+## Planned capabilities (target)
 
 **Workflow classification contract** — classifies changes in a consumer site into one of:
 
@@ -21,7 +21,4 @@ Reusable GitHub Actions workflow templates and AI change classifier for portfoli
 
 ## Status
 
-Deferred — Epic 8. Requires:
-
-- Epic 3 (route registry — Task 3.6)
-- Epic 4 (override surfaces — Task 4.4)
+Scaffold-stage package is present in the workspace as `@portfolio-engine/workflow-kit`, but the workflow templates/classifier server described above are still planned work.

--- a/examples/demo-site/README.md
+++ b/examples/demo-site/README.md
@@ -1,6 +1,6 @@
 # demo-site
 
-Reference **Astro consumer** for [`@portfolio-engine/editorial-theme`](../../packages/editorial-theme/). It proves the integration end-to-end and mirrors how **agreni-site** / **jordan-site** should wire config, content, and `astro.config.mjs`.
+Reference **Astro consumer** for [`@portfolio-engine/editorial-theme`](../../packages/editorial-theme/). It proves integration end-to-end, including named overrides, explicit route/override registries, generated manifest output, and admin tooling.
 
 ## What you own vs the theme
 
@@ -30,6 +30,10 @@ pnpm --filter demo-site run build
 ```
 
 Build output: `examples/demo-site/dist/` (**SSR** via `@astrojs/node` so `/admin` and `/api/auth/*` work). Open `http://localhost:4321/admin` after `pnpm --filter demo-site dev` (dev bypass skips GitHub; see `.env.example` for OAuth).
+
+Each build also generates `.portfolio-engine/manifest.json` in the demo-site root, including resolved route registry entries and named override surfaces.
+
+The demo intentionally passes **custom registry metadata** (`agentGuidance`, `guidance`, `docsUrl`) through `editorialTheme({ registries })` in `astro.config.mjs` to exercise the registry + manifest contract directly.
 
 ## Checks
 

--- a/examples/demo-site/astro.config.mjs
+++ b/examples/demo-site/astro.config.mjs
@@ -2,7 +2,18 @@
 import node from '@astrojs/node';
 import { defineConfig } from 'astro/config';
 import { adminTools } from '@portfolio-engine/admin-tools';
-import { editorialTheme } from '@portfolio-engine/editorial-theme';
+import { DEFAULT_OVERRIDE_SURFACES, DEFAULT_ROUTE_REGISTRY, editorialTheme } from '@portfolio-engine/editorial-theme';
+
+const routeRegistry = DEFAULT_ROUTE_REGISTRY.map((route) => ({
+  ...route,
+  agentGuidance: `Prefer ${route.label} for ${route.visibility === 'public' ? 'public-facing' : 'internal'} navigation tasks.`,
+}));
+
+const overrideRegistry = DEFAULT_OVERRIDE_SURFACES.map((surface) => ({
+  ...surface,
+  docsUrl: '/admin',
+  guidance: `Use ${surface.name} for downstream customization before proposing upstream edits.`,
+}));
 
 export default defineConfig({
   output: 'server',
@@ -17,6 +28,10 @@ export default defineConfig({
         components: {
           Hero: './src/overrides/Hero.astro',
         },
+      },
+      registries: {
+        routes: routeRegistry,
+        overrideSurfaces: overrideRegistry,
       },
     }),
     adminTools({ devBypass: true }),

--- a/examples/demo-site/astro.config.mjs
+++ b/examples/demo-site/astro.config.mjs
@@ -2,7 +2,11 @@
 import node from '@astrojs/node';
 import { defineConfig } from 'astro/config';
 import { adminTools } from '@portfolio-engine/admin-tools';
-import { DEFAULT_OVERRIDE_SURFACES, DEFAULT_ROUTE_REGISTRY, editorialTheme } from '@portfolio-engine/editorial-theme';
+import {
+  DEFAULT_OVERRIDE_SURFACES,
+  DEFAULT_ROUTE_REGISTRY,
+  editorialTheme,
+} from '@portfolio-engine/editorial-theme';
 
 const routeRegistry = DEFAULT_ROUTE_REGISTRY.map((route) => ({
   ...route,

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -11,4 +11,4 @@ See [`docs/packages/schema.md`](../../docs/packages/schema.md) for architecture 
 
 ## Status
 
-Under development — Epic 3.
+Active runtime package used by `engine-core`/`editorial-theme`, including manifest-related registry types (`RouteRegistryEntry`, `OverrideSurfaceEntry`, `EngineManifest`).

--- a/packages/workflow-kit/README.md
+++ b/packages/workflow-kit/README.md
@@ -11,4 +11,4 @@ See [`docs/packages/workflow-kit.md`](../../docs/packages/workflow-kit.md) for a
 
 ## Status
 
-Deferred — Epic 8 (after Epics 3–6 complete).
+Scaffold package only. The npm workspace/package exists and typechecks, but runtime workflow templates and MCP tooling are not implemented yet.


### PR DESCRIPTION
## What this PR ships

This branch contains the full `@portfolio-engine/admin-tools` package and integrates it into the demo site, along with docs/runbook updates.

### admin-tools package (`packages/admin-tools/`)
- **`/admin` page** — SSR admin UI (Astro) with `SiteMapTree` component showing route registry, override surfaces, and site structure
- **GitHub OAuth flow** — `/api/auth/github` → `/api/auth/callback` with HMAC-SHA256 session tokens; access is gated to verified repo collaborators
- **`/api/content` endpoint** — reads and writes content files via GitHub API (production) or local fs (dev); supports GitHub/local write targets
- **`/api/auth/logout`** — session teardown
- **Server utilities** — `session.ts` (sign/verify), `paths.ts` (route helpers), `integration.ts` (Astro integration entry)
- **Node adapter required** — package sets `output: 'server'` and requires `@astrojs/node`

### Demo site (`examples/demo-site/`)
- Updated `astro.config.mjs` to import `DEFAULT_ROUTE_REGISTRY` and `DEFAULT_OVERRIDE_SURFACES`, build `routeRegistry` / `overrideRegistry` with guidance/docs metadata, pass `registries` into `editorialTheme`, and enable `adminTools({ devBypass: true })`
- Added `.env.example` documenting the five required OAuth env vars
- Updated `README.md` with manifest generation and registry usage docs

### Docs
- Expanded `docs/downstream/setup-with-claude.md` into a phased Claude Code runbook: collects user data up front, installs admin-tools by default, wires overrides, verifies manifest/registry/admin surfaces
- Updated `README.md` packages table to mark `admin-tools` as optional (Node adapter required) and `workflow-kit` as scaffold-stage
- Updated `packages/schema/README.md`, `packages/workflow-kit/README.md`, and `docs/packages/workflow-kit.md` with current status

## Environment variables required for admin
```
GITHUB_CLIENT_ID=
GITHUB_CLIENT_SECRET=
SESSION_SECRET=
ADMIN_TOOLS_GITHUB_REPO_OWNER=
ADMIN_TOOLS_GITHUB_REPO_NAME=
```

> **Preview 403**: Vercel preview deployments are protected by Vercel auth — clicking the preview URL while logged out returns 403. The deployment itself is `Ready`; the public site routes work. The `/admin` route redirects unauthenticated visitors to GitHub OAuth rather than erroring.

## Testing
- `pnpm --filter demo-site run check` — passes
- `pnpm --filter demo-site run build` — passes
- `pnpm check` (workspace typecheck) — passes
- Prettier (`pnpm format`) — passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)