### PR TITLE
Add Claude-driven fast path and setup orchestrator scripts; update downstream docs and admin-tools integration

### DIFF
--- a/docs/downstream/new-site-setup.md
+++ b/docs/downstream/new-site-setup.md
@@ -12,7 +12,6 @@ Step-by-step guide for bootstrapping a new standalone portfolio site (like `jord
 
 ---
 
-
 ## 0 — Fast path (recommended for non-technical users)
 
 If you are using Claude Code, do this first:
@@ -29,6 +28,7 @@ The setup scripts are intentionally split into a **master orchestrator** + **sma
 ---
 
 Script controls:
+
 - Bash dry-run preview: `DRY_RUN=1 ./docs/downstream/setup.sh`
 - PowerShell dry-run preview: `./docs/downstream/setup.ps1 -DryRun`
 - Bash skip phase: `SKIP_INSTALL=1 ./docs/downstream/setup.sh`
@@ -268,7 +268,6 @@ Replace this with a real post.
 }
 ```
 
-
 ---
 
 ## 8 — Verify locally
@@ -299,8 +298,6 @@ Add this to `.gitignore`:
 7. **Production Branch:** `main`. Keep `dev` for staging previews.
 
 `SITE_URL` powers canonical URLs, Open Graph links, and sitemap URLs.
-
-
 
 ---
 

--- a/docs/downstream/new-site-setup.md
+++ b/docs/downstream/new-site-setup.md
@@ -17,9 +17,10 @@ Step-by-step guide for bootstrapping a new standalone portfolio site (like `jord
 
 If you are using Claude Code, do this first:
 
-1. Copy `docs/downstream/setup-with-claude.md` and paste it into Claude.
-2. If you already have source material, paste your resume and design brief in the same chat.
-3. Ask Claude to run `docs/downstream/setup.sh` (macOS/Linux) or `docs/downstream/setup.ps1` (Windows) first, then continue with manual file wiring.
+1. Scaffold the project first (`pnpm create astro@latest . --template minimal --install --typescript strict --git false`).
+2. In your new site repo, create `docs/downstream/` and copy `setup-with-claude.md`, `setup.sh`, `setup.ps1`, and `scripts/` from this repo.
+3. Paste `docs/downstream/setup-with-claude.md` into Claude and include your resume/design brief if available.
+4. Ask Claude to run `docs/downstream/setup.sh` (macOS/Linux) or `docs/downstream/setup.ps1` (Windows), then continue with manual file wiring.
 
 This reduces typing mistakes and keeps a machine-readable friction log in `src/docs/setup-feedback.md`.
 

--- a/docs/downstream/new-site-setup.md
+++ b/docs/downstream/new-site-setup.md
@@ -12,22 +12,44 @@ Step-by-step guide for bootstrapping a new standalone portfolio site (like `jord
 
 ---
 
+
+## 0 — Fast path (recommended for non-technical users)
+
+If you are using Claude Code, do this first:
+
+1. Copy `docs/downstream/setup-with-claude.md` and paste it into Claude.
+2. If you already have source material, paste your resume and design brief in the same chat.
+3. Ask Claude to run `docs/downstream/setup.sh` (macOS/Linux) or `docs/downstream/setup.ps1` (Windows) first, then continue with manual file wiring.
+
+This reduces typing mistakes and keeps a machine-readable friction log in `src/docs/setup-feedback.md`.
+
+The setup scripts are intentionally split into a **master orchestrator** + **small numbered phase scripts** in `docs/downstream/scripts/` so Claude can skip or edit phases safely.
+
+---
+
+Script controls:
+- Bash dry-run preview: `DRY_RUN=1 ./docs/downstream/setup.sh`
+- PowerShell dry-run preview: `./docs/downstream/setup.ps1 -DryRun`
+- Bash skip phase: `SKIP_INSTALL=1 ./docs/downstream/setup.sh`
+- PowerShell skip phase: `./docs/downstream/setup.ps1 -SkipInstall`
+
 ## 1 — Scaffold the Astro project
 
 Run this in the root of your empty repo:
 
 ```bash
 pnpm create astro@latest . --template minimal --install --typescript strict --git false
+rm -f src/pages/index.astro
 ```
 
-Accept all prompts. This drops in `astro.config.mjs`, `tsconfig.json`, `package.json`, and a minimal `src/` skeleton.
+The scaffold's default `src/pages/index.astro` conflicts with the theme's `/` route, so remove it immediately.
 
 ---
 
-## 2 — Install the theme
+## 2 — Install packages
 
 ```bash
-pnpm add @portfolio-engine/editorial-theme @astrojs/vercel
+pnpm add @portfolio-engine/editorial-theme @portfolio-engine/admin-tools @astrojs/vercel
 ```
 
 ---
@@ -39,6 +61,7 @@ pnpm add @portfolio-engine/editorial-theme @astrojs/vercel
 import { defineConfig } from 'astro/config';
 import vercel from '@astrojs/vercel';
 import { editorialTheme } from '@portfolio-engine/editorial-theme';
+import { adminTools } from '@portfolio-engine/admin-tools';
 
 // Production sets SITE_URL in Vercel env vars. Previews fall back to VERCEL_URL.
 const site =
@@ -57,16 +80,19 @@ export default defineConfig({
       themeConfigPath: './src/config/theme.json',
       featuresConfigPath: './src/config/features.json',
     }),
+    adminTools({ devBypass: true }),
   ],
 });
 ```
+
+Use `output: 'static'` for Astro 6 compatibility with both theme routes and admin API routes (`prerender = false` on admin endpoints handles SSR where needed).
 
 ---
 
 ## 4 — Create the `src/` directory layout
 
 ```bash
-mkdir -p src/config src/content/projects src/content/writing src/content/profile src/content/testimonials src/context src/overrides
+mkdir -p src/config src/content/projects src/content/writing src/content/profile src/content/testimonials src/context src/overrides src/docs
 ```
 
 ---
@@ -177,11 +203,13 @@ const testimonials = defineCollection({
 
 const profile = defineCollection({
   loader: glob({ pattern: '**/*.json', base: './src/content/profile' }),
-  schema: z.object({
-    name: z.string().optional(),
-    bio: z.string().optional(),
-    email: z.string().optional(),
-  }),
+  schema: z
+    .object({
+      name: z.string().optional(),
+      bio: z.string().optional(),
+      email: z.string().optional(),
+    })
+    .passthrough(),
 });
 
 export const collections = { projects, writing, testimonials, profile };
@@ -192,6 +220,8 @@ export const collections = { projects, writing, testimonials, profile };
 ## 7 — Add placeholder content
 
 Drop at least one entry in each enabled collection so Astro doesn't error on empty globs.
+
+Also add required profile files used by `/about`.
 
 **`src/content/projects/hello-world.md`**
 
@@ -218,79 +248,46 @@ description: 'Writing placeholder.'
 Replace this with a real post.
 ```
 
----
-
-## 8 — Fill in `src/context/` (your identity layer)
-
-These files are **never read by the Astro build** — they exist for AI assistants (like Claude) working on your site. Take ten minutes to fill them in honestly; the more accurate they are, the better AI output you'll get.
-
-**`src/context/site-owner.json`** — who you are:
+**`src/content/profile/person.json`**
 
 ```json
 {
   "name": "Your Full Name",
-  "role": "Your title or discipline",
-  "location": "City, Country",
-  "website": "https://yoursite.com"
+  "bio": "One paragraph about you.",
+  "email": "you@example.com"
 }
 ```
 
-**`src/context/brand-voice.json`** — how you write:
+**`src/content/profile/cv.json`**
 
 ```json
 {
-  "tone": "describe your tone (e.g. warm and direct, precise and minimal)",
-  "audience": "who you're writing for (e.g. design-minded engineers, nonprofit hiring managers)",
-  "avoid": ["jargon words or phrases you dislike"],
-  "examples": ["a sentence that sounds like you"]
+  "awards": [{ "title": "...", "context": "...", "description": "..." }],
+  "education": [{ "degree": "...", "institution": "...", "location": "...", "year": "..." }]
 }
 ```
 
-**`src/context/agent-rules.md`** — standing instructions for AI:
-
-```md
-# Agent rules
-
-- Write in first person unless asked otherwise.
-- Keep descriptions under 100 words unless asked for long-form.
-- Do not invent credentials or project details — ask me if unsure.
-- Prefer concrete, specific language over abstract or corporate-speak.
-```
-
-**`src/context/README.md`**:
-
-```md
-# context/
-
-Site-owner identity and brand guidance for AI-assisted workflows.
-These files are read by agents, not by the Astro build.
-```
 
 ---
 
-## 9 — Add `src/overrides/README.md`
-
-```md
-# overrides/
-
-Drop component overrides here, then wire them in astro.config.mjs via
-editorialTheme({ overrides: { components: { Hero: './src/overrides/Hero.astro' } } }).
-Only named surfaces are stable. See docs/downstream/consumption.md.
-```
-
----
-
-## 10 — Verify locally
+## 8 — Verify locally
 
 ```bash
-pnpm dev        # Should open on http://localhost:4321
-pnpm check      # Astro type-check
-pnpm build      # Full build (catches SSR/adapter issues)
+pnpm dev
+pnpm check
+pnpm build
+```
+
+Add this to `.gitignore`:
+
+```gitignore
+.portfolio-engine/
+.vercel/
 ```
 
 ---
 
-## 11 — Deploy to Vercel
+## 9 — Deploy to Vercel
 
 1. Push to GitHub.
 2. In Vercel: **Add New → Project** → import your repo.
@@ -300,39 +297,16 @@ pnpm build      # Full build (catches SSR/adapter issues)
 6. **Environment variable:** `SITE_URL` = `https://your-custom-domain.com` (Production only; leave unset for Previews).
 7. **Production Branch:** `main`. Keep `dev` for staging previews.
 
-After the first deploy succeeds, update `src/config/site.json` `baseUrl` to the real production URL.
+`SITE_URL` powers canonical URLs, Open Graph links, and sitemap URLs.
+
+
 
 ---
 
-## Bootstrap with Claude
+## 10 — Troubleshooting quick hits
 
-If you'd rather have an AI do the scaffolding, create a fresh repo, clone it, and paste this into a Claude Code session:
-
-```
-I'm setting up a new standalone portfolio site called [SITE_NAME] that consumes
-@portfolio-engine/editorial-theme from npm. The monorepo that publishes this package
-is at https://github.com/rainonej/portfolio-engine — read its README and
-docs/downstream/new-site-setup.md for the expected file layout and config shapes.
-
-Please scaffold everything: astro.config.mjs, src/config/*.json, src/content.config.ts,
-placeholder content, and src/context/ files using the details below.
-
-About me:
-- Name: [YOUR NAME]
-- Role/discipline: [WHAT YOU DO]
-- Location: [CITY, COUNTRY]
-- Tagline: [PUNCHY ONE-LINER]
-- Audience: [WHO YOU'RE WRITING FOR]
-- Tone: [HOW YOU WRITE]
-- Website I want to deploy to: [https://yoursite.com]
-
-Navigation I want: [list the pages — Work / Writing / About / Contact or your own]
-
-For content, create placeholder entries I can replace — do not invent real projects.
-For src/context/, fill in site-owner.json and brand-voice.json from the details above.
-Leave agent-rules.md as a template I can edit.
-
-After scaffolding, tell me exactly which files I still need to fill in myself.
-```
-
-Fill in the bracketed fields, paste, and Claude will set up the full structure. Then go back and fill in `src/content/` with your real work.
+- `/` route collision warning: delete `src/pages/index.astro`.
+- `/about` build error for missing profile entries: add `profile/person.json` and `profile/cv.json`.
+- `/admin` production 500 "server misconfiguration": verify all required OAuth env vars are present.
+- Canonical URL points to localhost: set `SITE_URL` in Vercel production env vars and redeploy.
+- Work detail pages 404: keep `output: 'static'` (do not switch to `server` for this setup).

--- a/docs/downstream/scripts/01-preflight.ps1
+++ b/docs/downstream/scripts/01-preflight.ps1
@@ -1,5 +1,6 @@
 $ErrorActionPreference = 'Stop'
-Write-Host '[1/6] Preflight: verifying tools'
+Write-Host '[1/6] Preflight: verifying tools + scaffold state'
+if (-not (Test-Path 'package.json')) { throw "package.json not found. Scaffold first with: pnpm create astro@latest . --template minimal --install --typescript strict --git false" }
 if (-not (Get-Command node -ErrorAction SilentlyContinue)) { throw 'node not found' }
 if (-not (Get-Command pnpm -ErrorAction SilentlyContinue)) { throw 'pnpm not found' }
 Write-Host "Node: $(node -v)"

--- a/docs/downstream/scripts/01-preflight.ps1
+++ b/docs/downstream/scripts/01-preflight.ps1
@@ -1,0 +1,6 @@
+$ErrorActionPreference = 'Stop'
+Write-Host '[1/6] Preflight: verifying tools'
+if (-not (Get-Command node -ErrorAction SilentlyContinue)) { throw 'node not found' }
+if (-not (Get-Command pnpm -ErrorAction SilentlyContinue)) { throw 'pnpm not found' }
+Write-Host "Node: $(node -v)"
+Write-Host "pnpm: $(pnpm -v)"

--- a/docs/downstream/scripts/01-preflight.sh
+++ b/docs/downstream/scripts/01-preflight.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[1/6] Preflight: verifying repo root + required tools"
+[[ -f package.json ]] || echo "WARN: package.json not found yet (ok before Astro scaffold)."
+command -v node >/dev/null || { echo "ERROR: node not found"; exit 1; }
+command -v pnpm >/dev/null || { echo "ERROR: pnpm not found"; exit 1; }
+echo "Node: $(node -v)"
+echo "pnpm: $(pnpm -v)"

--- a/docs/downstream/scripts/01-preflight.sh
+++ b/docs/downstream/scripts/01-preflight.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 echo "[1/6] Preflight: verifying repo root + required tools"
-[[ -f package.json ]] || echo "WARN: package.json not found yet (ok before Astro scaffold)."
+[[ -f package.json ]] || { echo "ERROR: package.json not found. Scaffold first with: pnpm create astro@latest . --template minimal --install --typescript strict --git false"; exit 1; }
 command -v node >/dev/null || { echo "ERROR: node not found"; exit 1; }
 command -v pnpm >/dev/null || { echo "ERROR: pnpm not found"; exit 1; }
 echo "Node: $(node -v)"

--- a/docs/downstream/scripts/02-install-packages.ps1
+++ b/docs/downstream/scripts/02-install-packages.ps1
@@ -1,0 +1,3 @@
+$ErrorActionPreference = 'Stop'
+Write-Host '[2/6] Installing required packages'
+pnpm add @portfolio-engine/editorial-theme @portfolio-engine/admin-tools @astrojs/vercel

--- a/docs/downstream/scripts/02-install-packages.ps1
+++ b/docs/downstream/scripts/02-install-packages.ps1
@@ -1,3 +1,4 @@
 $ErrorActionPreference = 'Stop'
 Write-Host '[2/6] Installing required packages'
+if (-not (Test-Path 'package.json')) { throw 'package.json not found. Run from scaffolded repo root.' }
 pnpm add @portfolio-engine/editorial-theme @portfolio-engine/admin-tools @astrojs/vercel

--- a/docs/downstream/scripts/02-install-packages.sh
+++ b/docs/downstream/scripts/02-install-packages.sh
@@ -2,4 +2,5 @@
 set -euo pipefail
 
 echo "[2/6] Installing required packages"
+[[ -f package.json ]] || { echo "ERROR: package.json not found. Run from scaffolded repo root."; exit 1; }
 pnpm add @portfolio-engine/editorial-theme @portfolio-engine/admin-tools @astrojs/vercel

--- a/docs/downstream/scripts/02-install-packages.sh
+++ b/docs/downstream/scripts/02-install-packages.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[2/6] Installing required packages"
+pnpm add @portfolio-engine/editorial-theme @portfolio-engine/admin-tools @astrojs/vercel

--- a/docs/downstream/scripts/03-create-dirs.ps1
+++ b/docs/downstream/scripts/03-create-dirs.ps1
@@ -1,0 +1,4 @@
+$ErrorActionPreference = 'Stop'
+Write-Host '[3/6] Creating required source directories'
+$dirs = @('src/config','src/content/projects','src/content/writing','src/content/profile','src/content/testimonials','src/context','src/overrides','src/docs')
+foreach ($d in $dirs) { New-Item -ItemType Directory -Force -Path $d | Out-Null }

--- a/docs/downstream/scripts/03-create-dirs.sh
+++ b/docs/downstream/scripts/03-create-dirs.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[3/6] Creating required source directories"
+mkdir -p src/config src/content/projects src/content/writing src/content/profile src/content/testimonials src/context src/overrides src/docs

--- a/docs/downstream/scripts/04-remove-index-route.ps1
+++ b/docs/downstream/scripts/04-remove-index-route.ps1
@@ -1,0 +1,3 @@
+$ErrorActionPreference = 'Stop'
+Write-Host '[4/6] Removing scaffold src/pages/index.astro if present'
+if (Test-Path 'src/pages/index.astro') { Remove-Item 'src/pages/index.astro' -Force; Write-Host 'Removed src/pages/index.astro' } else { Write-Host 'No scaffold index route found' }

--- a/docs/downstream/scripts/04-remove-index-route.sh
+++ b/docs/downstream/scripts/04-remove-index-route.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[4/6] Removing scaffold src/pages/index.astro if present"
+if [[ -f src/pages/index.astro ]]; then
+  rm -f src/pages/index.astro
+  echo "Removed src/pages/index.astro"
+else
+  echo "No scaffold index route found"
+fi

--- a/docs/downstream/scripts/05-seed-feedback-log.ps1
+++ b/docs/downstream/scripts/05-seed-feedback-log.ps1
@@ -1,0 +1,13 @@
+$ErrorActionPreference = 'Stop'
+Write-Host '[5/6] Seeding setup feedback log'
+New-Item -ItemType Directory -Force -Path 'src/docs' | Out-Null
+if (-not (Test-Path 'src/docs/setup-feedback.md')) {
+@'
+# Setup Feedback Log
+
+Capture friction, missing steps, and confusion encountered during setup.
+Please remove personal information and secrets before sharing publicly.
+'@ | Set-Content 'src/docs/setup-feedback.md'
+} else {
+  Write-Host 'setup-feedback.md already exists; leaving as-is'
+}

--- a/docs/downstream/scripts/05-seed-feedback-log.sh
+++ b/docs/downstream/scripts/05-seed-feedback-log.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[5/6] Seeding setup feedback log"
+mkdir -p src/docs
+if [[ ! -f src/docs/setup-feedback.md ]]; then
+  cat > src/docs/setup-feedback.md <<'MD'
+# Setup Feedback Log
+
+Capture friction, missing steps, and confusion encountered during setup.
+Please remove personal information and secrets before sharing publicly.
+MD
+else
+  echo "setup-feedback.md already exists; leaving as-is"
+fi

--- a/docs/downstream/scripts/06-patch-gitignore.ps1
+++ b/docs/downstream/scripts/06-patch-gitignore.ps1
@@ -1,0 +1,6 @@
+$ErrorActionPreference = 'Stop'
+Write-Host '[6/6] Ensuring .gitignore contains local/build artifacts'
+if (-not (Test-Path '.gitignore')) { New-Item -ItemType File -Path '.gitignore' | Out-Null }
+$content = Get-Content '.gitignore' -Raw
+if ($content -notmatch '(?m)^\.portfolio-engine/$') { Add-Content '.gitignore' '.portfolio-engine/' }
+if ($content -notmatch '(?m)^\.vercel/$') { Add-Content '.gitignore' '.vercel/' }

--- a/docs/downstream/scripts/06-patch-gitignore.sh
+++ b/docs/downstream/scripts/06-patch-gitignore.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[6/6] Ensuring .gitignore contains local/build artifacts"
+touch .gitignore
+grep -q '^\.portfolio-engine/$' .gitignore || echo '.portfolio-engine/' >> .gitignore
+grep -q '^\.vercel/$' .gitignore || echo '.vercel/' >> .gitignore

--- a/docs/downstream/setup-with-claude.md
+++ b/docs/downstream/setup-with-claude.md
@@ -13,6 +13,7 @@ If I provide a resume and/or design doc, save them to `src/docs/resume.md` and `
 ## Phase 1 — intake
 
 Ask once for missing items only:
+
 - name, role, tagline, one-line description, location
 - tone, audience
 - pages (Work/Writing/About/Contact)
@@ -27,6 +28,7 @@ Follow:
 https://github.com/rainonej/portfolio-engine/blob/main/docs/downstream/new-site-setup.md
 
 Also:
+
 - run `docs/downstream/setup.sh` (macOS/Linux) or `docs/downstream/setup.ps1` (Windows) if present to automate standard setup
 - ensure `adminTools({ devBypass: true })` is configured after `editorialTheme(...)`
 - ensure Astro output is `static`
@@ -47,6 +49,7 @@ Before running setup scripts, read them first and execute a dry-run preview (`DR
 ## Phase 4 — Vercel setup (guided)
 
 Guide manual import and set:
+
 - Production branch: `main`
 - Preview branches: `dev` + PRs
 - Node 22
@@ -57,6 +60,7 @@ If available, offer Vercel MCP/plugin or Vercel CLI to reduce manual clicks; oth
 ## Phase 5 — admin + branch behavior verification
 
 Verify:
+
 - `/admin` works in local dev with `devBypass: true`
 - admin/auth routes are not main-branch-only and work on preview deployments too
 - OAuth env vars are documented (all required vars listed)
@@ -68,9 +72,9 @@ Ensure CI runs on pushes/PRs for both `main` and `dev`.
 ## Phase 7 — wrap-up + feedback ticket
 
 At end:
+
 1. summarize live URL, repo URL, branch strategy, and where to edit content
 2. sanitize `src/docs/setup-feedback.md` (no personal data, no secrets)
 3. open a GitHub issue in `portfolio-engine` titled
    `Setup friction report from [repo-name]` and paste sanitized feedback
 4. include issue URL in final summary
-

--- a/docs/downstream/setup-with-claude.md
+++ b/docs/downstream/setup-with-claude.md
@@ -1,147 +1,76 @@
 # Portfolio site setup — paste this into Claude Code
 
-Copy the entire contents of this file and paste it into Claude Code as your first message. Claude should run this as a **phased operator runbook** for a modern portfolio-engine consumer (route registry, manifest, named overrides, and admin tools enabled by default).
+Copy this whole file into Claude Code as your first message.
 
 ---
 
 You are helping me set up a new personal portfolio site from scratch using
-`@portfolio-engine/editorial-theme` (published on npm, source at
-https://github.com/rainonej/portfolio-engine).
+`@portfolio-engine/editorial-theme` + `@portfolio-engine/admin-tools`.
 
-Work through the phases below in order. Do not move to the next phase until
-the current one is finished. At each phase, tell me clearly what you're doing
-and what — if anything — you need from me or need me to do manually.
+Operate in phases. Keep a running friction log in `src/docs/setup-feedback.md` during setup.
+If I provide a resume and/or design doc, save them to `src/docs/resume.md` and `src/docs/design-brief.md` first, then use them as source-of-truth.
 
----
+## Phase 1 — intake
 
-## Phase 1 — Learn about me
+Ask once for missing items only:
+- name, role, tagline, one-line description, location
+- tone, audience
+- pages (Work/Writing/About/Contact)
+- social links + booking URL (optional)
+- repo name
 
-Before touching any files, ask me for everything you need in one grouped prompt:
+If resume/design docs were provided, do **not** re-ask obvious info; infer carefully and only confirm ambiguities.
 
-- **Name** — as it should appear on the site
-- **Role** — what I do
-- **Tagline** — one short punchy line
-- **Description** — one sentence: my work and who I do it for
-- **Location** — city and country
-- **Tone** — how I write
-- **Audience** — who reads my site
-- **Pages** — which of these I want: Work, Writing, About, Contact (default: all)
-- **Booking URL** — optional scheduling link
-- **Social URLs** — GitHub, LinkedIn, X/Twitter (optional)
-- **Repo name** — what to call my GitHub repository
+## Phase 2 — scaffold + configure
 
-If any answer is vague, ask one follow-up before moving on.
-
----
-
-## Phase 2 — Build the project
-
-Using my answers, follow the technical setup guide at:
+Follow:
 https://github.com/rainonej/portfolio-engine/blob/main/docs/downstream/new-site-setup.md
 
-Do all of the following:
+Also:
+- run `docs/downstream/setup.sh` (macOS/Linux) or `docs/downstream/setup.ps1` (Windows) if present to automate standard setup
+- ensure `adminTools({ devBypass: true })` is configured after `editorialTheme(...)`
+- ensure Astro output is `static`
+- create placeholder `src/content/profile/person.json` and `src/content/profile/cv.json`
+- set `.gitignore` entries for `.portfolio-engine/` and `.vercel/`
 
-- Scaffold the Astro project and install `@portfolio-engine/editorial-theme`
-- Install `@portfolio-engine/admin-tools` and Node adapter support as part of the default setup
-- Create `src/config/site.json`, `navigation.json`, `theme.json`, `features.json`
-- Create `src/content.config.ts` and placeholder content in `src/content/`
-- Fill `src/context/site-owner.json` and `src/context/brand-voice.json`; keep `agent-rules.md` as an editable template
-- Create `src/overrides/README.md`
-- Wire at least one named override surface (Hero) so the overrides system is demonstrated
-- Run a local build and confirm `.portfolio-engine/manifest.json` is generated
+Write each confusion/error/contradiction to `src/docs/setup-feedback.md` as you go.
 
-When done, summarize what was created and list files I should customize first.
+Before running setup scripts, read them first and execute a dry-run preview (`DRY_RUN=1` or `-DryRun`). If a phase is unnecessary, skip it using script flags/environment variables rather than hand-editing unrelated files.
 
----
+## Phase 3 — git + GitHub
 
-## Phase 3 — Push to GitHub
+- create `main` (production) and `dev` (preview/staging) branches
+- set default branch to `main`
+- push both branches
+- use branch protections if available
 
-1. Initialize a git repo if needed
-2. Create a new GitHub repo using my chosen repo name (`gh repo create` if available)
-3. Commit everything and push to `main`
+## Phase 4 — Vercel setup (guided)
 
-Tell me the GitHub URL after push.
+Guide manual import and set:
+- Production branch: `main`
+- Preview branches: `dev` + PRs
+- Node 22
+- `SITE_URL` as production-only env var
 
----
+If available, offer Vercel MCP/plugin or Vercel CLI to reduce manual clicks; otherwise provide click-by-click fallback.
 
-## Phase 4 — Vercel (manual, guided)
+## Phase 5 — admin + branch behavior verification
 
-Give me exact click-by-click instructions.
+Verify:
+- `/admin` works in local dev with `devBypass: true`
+- admin/auth routes are not main-branch-only and work on preview deployments too
+- OAuth env vars are documented (all required vars listed)
 
-For a standard standalone consumer repo, tell me:
+## Phase 6 — CI
 
-> Go to vercel.com and log in. Click **Add New → Project** and import **[repo name]**.
-> Set:
->
-> - Root Directory: `.`
-> - Install Command: `pnpm install`
-> - Build Command: `pnpm build`
-> - Output Directory: default
->
-> Click **Deploy**. After it succeeds, go to **Settings → General** and set Node.js to **22.x**.
-> Come back and paste the deployment URL.
+Ensure CI runs on pushes/PRs for both `main` and `dev`.
 
-Wait for my URL before moving on.
+## Phase 7 — wrap-up + feedback ticket
 
----
+At end:
+1. summarize live URL, repo URL, branch strategy, and where to edit content
+2. sanitize `src/docs/setup-feedback.md` (no personal data, no secrets)
+3. open a GitHub issue in `portfolio-engine` titled
+   `Setup friction report from [repo-name]` and paste sanitized feedback
+4. include issue URL in final summary
 
-## Phase 5 — Wire up canonical URL + polish context
-
-Once I provide the Vercel URL:
-
-1. Update `src/config/site.json` `baseUrl`
-2. Commit and push
-3. Ask whether to replace placeholder project content now
-4. Ask whether to replace placeholder writing now
-5. Improve `src/context/brand-voice.json` by interviewing me briefly and writing concrete values
-
----
-
-## Phase 6 — Production `SITE_URL` env var (manual, guided)
-
-Tell me:
-
-> In Vercel, open **Settings → Environment Variables**.
-> Add:
->
-> - Name: `SITE_URL`
-> - Value: `[production URL from Phase 5]`
-> - Environment: **Production only**
->
-> Save, then go to **Deployments**, open the latest deployment menu, and click **Redeploy**.
-> Come back when done.
-
----
-
-## Phase 7 — Custom domain (ask first)
-
-Ask: “Do you have a custom domain you want to use, like yourname.com?”
-
-- **If yes:** guide domain setup in Vercel, then:
-  1. update `site.json` `baseUrl`
-  2. commit + push
-  3. tell me to update Vercel `SITE_URL` and redeploy
-- **If no:** continue.
-
----
-
-## Phase 8 — Registry / manifest / admin verification
-
-Run and report these checks:
-
-- Build passes
-- `.portfolio-engine/manifest.json` exists and lists route + override capabilities
-- `/admin` is present and `/api/content` contract is wired
-- Explain how route remaps/disables and named overrides are controlled in config/integration
-
----
-
-## Wrap-up
-
-Give me a short summary with:
-
-- Live URL
-- Repo URL
-- The three folders I own most: `src/content/`, `src/config/`, `src/context/`
-- Where to add overrides: `src/overrides/`
-- One line for theme updates (`pnpm update @portfolio-engine/editorial-theme && pnpm build`)

--- a/docs/downstream/setup.ps1
+++ b/docs/downstream/setup.ps1
@@ -1,0 +1,41 @@
+$ErrorActionPreference = 'Stop'
+
+<#
+Portfolio Engine downstream setup orchestrator (Windows)
+Safe to read before running.
+Use switches to skip phases, e.g.:
+  ./docs/downstream/setup.ps1 -DryRun -SkipInstall -SkipGitignore
+#>
+
+param(
+  [switch]$SkipPreflight,
+  [switch]$SkipInstall,
+  [switch]$SkipDirs,
+  [switch]$SkipRouteFix,
+  [switch]$SkipFeedback,
+  [switch]$SkipGitignore,
+  [switch]$DryRun
+)
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$StepsDir = Join-Path $ScriptDir 'scripts'
+
+function Step($kind, $msg) { Write-Host "`n[$kind] $msg" }
+function Run-Step($name, $scriptPath, $skip) {
+  if ($skip) { Step 'SKIP' $name; return }
+  if ($DryRun) { Step 'DRY' "$name -> $scriptPath"; return }
+  Step 'RUN' $name
+  & $scriptPath
+  Step 'OK' $name
+}
+
+Step 'INFO' "Starting downstream bootstrap in $(Get-Location)"
+if ($DryRun) { Step 'INFO' 'DryRun enabled: no files will be modified' }
+Run-Step 'Preflight checks' (Join-Path $StepsDir '01-preflight.ps1') $SkipPreflight
+Run-Step 'Install packages' (Join-Path $StepsDir '02-install-packages.ps1') $SkipInstall
+Run-Step 'Create directories' (Join-Path $StepsDir '03-create-dirs.ps1') $SkipDirs
+Run-Step 'Remove scaffold route collision' (Join-Path $StepsDir '04-remove-index-route.ps1') $SkipRouteFix
+Run-Step 'Seed setup feedback doc' (Join-Path $StepsDir '05-seed-feedback-log.ps1') $SkipFeedback
+Run-Step 'Patch .gitignore' (Join-Path $StepsDir '06-patch-gitignore.ps1') $SkipGitignore
+
+Step 'DONE' 'Bootstrap complete. Continue with docs/downstream/new-site-setup.md'

--- a/docs/downstream/setup.ps1
+++ b/docs/downstream/setup.ps1
@@ -1,5 +1,3 @@
-$ErrorActionPreference = 'Stop'
-
 <#
 Portfolio Engine downstream setup orchestrator (Windows)
 Safe to read before running.
@@ -17,8 +15,11 @@ param(
   [switch]$DryRun
 )
 
+$ErrorActionPreference = 'Stop'
+
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $StepsDir = Join-Path $ScriptDir 'scripts'
+if (-not (Test-Path $StepsDir)) { throw "Missing scripts directory: $StepsDir" }
 
 function Step($kind, $msg) { Write-Host "`n[$kind] $msg" }
 function Run-Step($name, $scriptPath, $skip) {

--- a/docs/downstream/setup.sh
+++ b/docs/downstream/setup.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Safe to read before running. Set SKIP_* env vars to skip phases.
 # Example: DRY_RUN=1 SKIP_INSTALL=1 ./docs/downstream/setup.sh
 
-ROOT_DIR="$(pwd)"
+ROOT_DIR="$(pwd -P)"
 SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/scripts"
 
 step() { printf "\n[%s] %s\n" "$1" "$2"; }
@@ -26,6 +26,8 @@ run_step() {
 
 step "INFO" "Starting downstream bootstrap in $ROOT_DIR"
 step "INFO" "Scripts directory: $SCRIPTS_DIR"
+[[ -d "$SCRIPTS_DIR" ]] || { step "ERROR" "Missing scripts directory: $SCRIPTS_DIR"; exit 1; }
+[[ -f "$ROOT_DIR/package.json" ]] || { step "ERROR" "Run from your scaffolded site repo root (missing package.json in $ROOT_DIR)"; exit 1; }
 if [[ "${DRY_RUN:-0}" == "1" ]]; then
   step "INFO" "DRY_RUN=1: no files will be modified"
 fi

--- a/docs/downstream/setup.sh
+++ b/docs/downstream/setup.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Portfolio Engine downstream setup orchestrator (macOS/Linux)
+# Safe to read before running. Set SKIP_* env vars to skip phases.
+# Example: DRY_RUN=1 SKIP_INSTALL=1 ./docs/downstream/setup.sh
+
+ROOT_DIR="$(pwd)"
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/scripts"
+
+step() { printf "\n[%s] %s\n" "$1" "$2"; }
+run_step() {
+  local name="$1" script="$2" skip_var="$3"
+  if [[ "${!skip_var:-0}" == "1" ]]; then
+    step "SKIP" "$name (set $skip_var=1)"
+    return
+  fi
+  if [[ "${DRY_RUN:-0}" == "1" ]]; then
+    step "DRY" "$name -> bash $script"
+    return
+  fi
+  step "RUN" "$name"
+  bash "$script"
+  step "OK" "$name"
+}
+
+step "INFO" "Starting downstream bootstrap in $ROOT_DIR"
+step "INFO" "Scripts directory: $SCRIPTS_DIR"
+if [[ "${DRY_RUN:-0}" == "1" ]]; then
+  step "INFO" "DRY_RUN=1: no files will be modified"
+fi
+
+run_step "Preflight checks" "$SCRIPTS_DIR/01-preflight.sh" "SKIP_PREFLIGHT"
+run_step "Install packages" "$SCRIPTS_DIR/02-install-packages.sh" "SKIP_INSTALL"
+run_step "Create directories" "$SCRIPTS_DIR/03-create-dirs.sh" "SKIP_DIRS"
+run_step "Remove scaffold route collision" "$SCRIPTS_DIR/04-remove-index-route.sh" "SKIP_ROUTE_FIX"
+run_step "Seed setup feedback doc" "$SCRIPTS_DIR/05-seed-feedback-log.sh" "SKIP_FEEDBACK"
+run_step "Patch .gitignore" "$SCRIPTS_DIR/06-patch-gitignore.sh" "SKIP_GITIGNORE"
+
+step "DONE" "Bootstrap complete. Next: follow docs/downstream/new-site-setup.md for config/content wiring."

--- a/packages/admin-tools/README.md
+++ b/packages/admin-tools/README.md
@@ -59,5 +59,4 @@ The default dashboard expects collections named **`writing`**, **`projects`**, *
 
 MVP overview, auth plumbing, and a basic in-browser file editor are shipped. `/api/content` now supports inventory + file reads and saves (local writes in `devBypass`, GitHub Contents API writes in OAuth mode) across content/config/context/registry/public paths. Includes drag-and-drop/browse upload for `public/` assets (with optional subfolder target) so non-technical users can add images/files and reference them in pages. Rich schema-aware drawers and polished editing UX remain a follow-up extraction step from `professional_site`.
 
-
 > `devBypass` only applies in local dev and is safe to leave configured; production behavior still requires OAuth env vars.

--- a/packages/admin-tools/README.md
+++ b/packages/admin-tools/README.md
@@ -6,20 +6,20 @@ Optional Astro integration that injects a **private `/admin` dashboard** and **G
 
 - Use together with `@portfolio-engine/editorial-theme` (or any setup that registers `@portfolio-engine/engine-core` virtual modules: `config`, `routes`, …).
 - **`adminTools()` must appear after `editorialTheme([...])`** in `astro.config` so injected routes resolve engine virtual modules and your content collections.
-- **SSR**: set `output: 'server'` (or hybrid) and add a Node (or other) adapter. Admin API routes do not run in static export.
+- Use `output: 'static'` for Astro 6 consumer sites with the editorial theme; admin API routes opt into SSR individually via `prerender = false`.
 
 ## Quick start (local)
 
 ```js
 // astro.config.mjs
 import { defineConfig } from 'astro/config';
-import node from '@astrojs/node';
+import vercel from '@astrojs/vercel';
 import { editorialTheme } from '@portfolio-engine/editorial-theme';
 import { adminTools } from '@portfolio-engine/admin-tools';
 
 export default defineConfig({
-  output: 'server',
-  adapter: node({ mode: 'standalone' }),
+  output: 'static',
+  adapter: vercel(),
   integrations: [
     editorialTheme({
       /* engine paths */
@@ -58,3 +58,6 @@ The default dashboard expects collections named **`writing`**, **`projects`**, *
 ## Status
 
 MVP overview, auth plumbing, and a basic in-browser file editor are shipped. `/api/content` now supports inventory + file reads and saves (local writes in `devBypass`, GitHub Contents API writes in OAuth mode) across content/config/context/registry/public paths. Includes drag-and-drop/browse upload for `public/` assets (with optional subfolder target) so non-technical users can add images/files and reference them in pages. Rich schema-aware drawers and polished editing UX remain a follow-up extraction step from `professional_site`.
+
+
+> `devBypass` only applies in local dev and is safe to leave configured; production behavior still requires OAuth env vars.


### PR DESCRIPTION
### Motivation

- Provide a low-friction, phased onboarding flow for downstream consumers (including non-technical users and Claude Code) to scaffold a new standalone portfolio site.
- Automate common bootstrap steps (tool checks, package install, directory creation, route removal, feedback seeding, and .gitignore patching) to reduce manual errors.
- Ensure the editorial theme and admin dashboard work together with Astro 6 static output and Vercel adapter while enabling a safe local dev bypass for admin UX.

### Description

- Add a recommended fast path to `docs/downstream/new-site-setup.md` and introduce guidance for running `docs/downstream/setup.sh` or `docs/downstream/setup.ps1` with dry-run and skip flags.  
- Add a suite of phased setup scripts in `docs/downstream/scripts/` (`01-*-06-*` in both Bash and PowerShell) plus orchestrators `docs/downstream/setup.sh` and `docs/downstream/setup.ps1` that perform preflight checks, install packages, create directories, remove scaffold index route, seed `src/docs/setup-feedback.md`, and patch `.gitignore`.  
- Update the scaffold instructions to install `@portfolio-engine/admin-tools`, remove the default `src/pages/index.astro`, create `src/docs`, and add `src/content/profile/person.json` and `src/content/profile/cv.json` placeholders while changing the `profile` collection schema to use `z.object(...).passthrough()` to tolerate extra fields.  
- Update `packages/admin-tools/README.md` to recommend `output: 'static'` with the Vercel adapter for Astro 6 consumer sites, document `devBypass: true` for local dev, and clarify OAuth/session env var requirements.  
- Revise `docs/downstream/setup-with-claude.md` to a phased intake + orchestration guide that instructs Claude to keep a running friction log in `src/docs/setup-feedback.md` and to prefer script dry-runs and skip flags instead of ad-hoc edits.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8b56358988320bea61b244a4ac7d3)