### PR TITLE
Add downstream agent-tooling setup phase

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -17,3 +17,50 @@ This monorepo ships **`@portfolio-engine/*`** packages and a reference app under
 ## Docs
 
 Board and label conventions: **`docs/github-project-board.md`**, **`docs/project-management.md`**.
+
+## Downstream agent tooling
+
+When editing downstream setup docs, keep the setup model aligned with:
+
+- `docs/downstream/setup-with-claude.md`
+- `docs/downstream/new-site-setup.md`
+- `docs/downstream/setup.sh`
+- `docs/downstream/setup.ps1`
+- `docs/downstream/agent-tooling.md`
+
+Do not introduce a parallel setup flow. Prefer adding small numbered scripts under `docs/downstream/scripts/`.
+
+## Vercel MCP vs Vercel Plugin
+
+Use Vercel MCP for live Vercel state:
+
+- deployments
+- build logs
+- runtime logs
+- project settings
+- domains
+- environment variable names
+- protected preview URLs
+
+Use the Vercel Plugin for Vercel-aware implementation guidance:
+
+- Astro/Vercel adapter setup
+- build commands
+- env-var conventions
+- preview vs production behavior
+- deployment docs
+- Vercel best practices
+
+Prefer read-only MCP operations first.
+
+Do not mutate production Vercel settings without explicit human confirmation.
+
+## Context7
+
+Use Context7 for current package docs and API examples before implementing package-specific setup involving Astro, Vercel, Tailwind, Playwright, TypeScript, or OAuth libraries.
+
+## Visual QA
+
+For UI/design changes, add or update docs that require browser-based verification with Playwright MCP or Playwright CLI.
+
+Do not treat code inspection as visual verification.

--- a/README.md
+++ b/README.md
@@ -55,12 +55,15 @@ Check the [releases](https://github.com/rainonej/portfolio-engine/releases) befo
 
 ## More docs
 
-| Topic                                                   | Link                                                                         |
-| ------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| Setup with Claude (paste whole file, Claude guides you) | [docs/downstream/setup-with-claude.md](docs/downstream/setup-with-claude.md) |
-| New site setup (full manual reference)                  | [docs/downstream/new-site-setup.md](docs/downstream/new-site-setup.md)       |
-| Semver vs. workspace-link, overrides, Vercel detail     | [docs/downstream/consumption.md](docs/downstream/consumption.md)             |
-| Lint, format, CI                                        | [docs/contributing/linting.md](docs/contributing/linting.md)                 |
+| Topic                                                   | Link                                                                                     |
+| ------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| Setup with Claude (paste whole file, Claude guides you) | [docs/downstream/setup-with-claude.md](docs/downstream/setup-with-claude.md)             |
+| New site setup (full manual reference)                  | [docs/downstream/new-site-setup.md](docs/downstream/new-site-setup.md)                   |
+| Semver vs. workspace-link, overrides, Vercel detail     | [docs/downstream/consumption.md](docs/downstream/consumption.md)                         |
+| Agent tooling for downstream vibe-coding                | [docs/downstream/agent-tooling.md](docs/downstream/agent-tooling.md)                     |
+| Visual QA prompt                                        | [docs/downstream/visual-qa-prompt.md](docs/downstream/visual-qa-prompt.md)               |
+| Design review checklist                                 | [docs/downstream/design-review-checklist.md](docs/downstream/design-review-checklist.md) |
+| Lint, format, CI                                        | [docs/contributing/linting.md](docs/contributing/linting.md)                             |
 
 ---
 

--- a/docs/downstream/agent-tooling.md
+++ b/docs/downstream/agent-tooling.md
@@ -1,0 +1,174 @@
+# Agent tooling for portfolio-engine consumer sites
+
+This repo is designed to work well with AI coding agents, but agents should use tools deliberately.
+
+Use the smallest tool that answers the question:
+
+| Tool                            | Use it for                                                                                                          | Do not use it for                                          |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| Vercel MCP                      | Inspecting real Vercel state: deployments, build logs, runtime logs, env var names, domains, protected preview URLs | Guessing how the code should be written                    |
+| Vercel Plugin                   | Vercel-aware implementation guidance, deployment best practices, env-var workflow, Vercel CLI guidance              | Reading private project state unless MCP/CLI is configured |
+| Context7                        | Current package docs and API examples for Astro, Vercel, Tailwind, Playwright, TypeScript, etc.                     | Project-specific state                                     |
+| Playwright MCP / Playwright CLI | Browser-based QA, navigation checks, console errors, layout review, accessibility-tree inspection                   | Static code review                                         |
+| Lighthouse CI                   | Optional performance, accessibility, SEO, and best-practice regression checks                                       | Replacing manual design review                             |
+| Vale                            | Optional prose and tone linting                                                                                     | Deciding factual content                                   |
+
+## Recommended install: Claude Code
+
+Run from the consumer-site repo root.
+
+```bash
+npm install -g @anthropic-ai/claude-code
+
+claude mcp add --transport http vercel https://mcp.vercel.com
+claude mcp add playwright npx @playwright/mcp@latest
+
+npx ctx7 setup
+npx plugins add vercel/vercel-plugin
+```
+
+Then start Claude Code and authenticate MCP servers when prompted:
+
+```bash
+claude
+/mcp
+```
+
+## Recommended install: Cursor
+
+Copy:
+
+```bash
+cp .cursor/mcp.example.json .cursor/mcp.json
+```
+
+Then restart Cursor and authenticate any MCP servers that ask for OAuth.
+
+Install Context7 and the Vercel Plugin:
+
+```bash
+npx ctx7 setup
+npx plugins add vercel/vercel-plugin
+```
+
+## Windows note
+
+If an `npx`-based MCP server fails in Cursor/VS Code on Windows, wrap it with `cmd /c`.
+
+Example:
+
+```json
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "cmd",
+      "args": ["/c", "npx", "@playwright/mcp@latest"]
+    }
+  }
+}
+```
+
+## Agent operating rules
+
+### Documentation and package APIs
+
+Use Context7 whenever implementing or changing package-specific code involving:
+
+- Astro
+- Vercel
+- Tailwind
+- Playwright
+- TypeScript
+- npm packages
+- OAuth/auth libraries
+- deployment adapters
+
+Do not guess package APIs from memory when a current-docs tool is available.
+
+### Deployment
+
+Use the Vercel Plugin for implementation guidance:
+
+- Astro/Vercel adapter setup
+- build command conventions
+- output directory conventions
+- preview vs production behavior
+- environment-variable workflow
+- Vercel CLI guidance
+- deployment documentation
+
+Use Vercel MCP for live account/project state:
+
+- deployment status
+- build logs
+- runtime logs
+- domains
+- project settings
+- environment variable names
+- protected preview URLs
+
+Prefer read-only MCP operations first.
+
+Do not change production Vercel settings, production branch, domains, or environment variables without explicit human confirmation.
+
+### Visual QA
+
+After meaningful UI changes, use Playwright MCP or Playwright CLI.
+
+At minimum check:
+
+- homepage desktop
+- homepage mobile
+- navigation links
+- `/work`
+- `/writing`
+- `/about`
+- `/contact`
+- `/admin` in local dev if admin tools are enabled
+- browser console errors
+- obvious overflow or clipping
+- obvious color-contrast problems
+
+Do not claim a visual bug is fixed unless the site was inspected in a browser, or explicitly say the review was code-only.
+
+### Content and tone
+
+Before writing copy, read:
+
+- `src/context/site-owner.json`
+- `src/context/brand-voice.json`
+- `src/context/agent-rules.md`
+- `src/docs/design-brief.md`, if present
+- `src/docs/resume.md`, if present
+
+Do not invent credentials, awards, jobs, publications, client names, degrees, or personal details.
+
+Prefer concrete language over generic marketing language.
+
+Avoid phrases like:
+
+- cutting-edge
+- world-class
+- innovative solutions
+- passionate about
+- unlock value
+- leverage synergies
+- results-driven
+- thought leader
+
+### Local validation
+
+Before considering work done:
+
+```bash
+pnpm check
+pnpm build
+```
+
+If linting is configured:
+
+```bash
+pnpm lint
+```
+
+For upstream `portfolio-engine` work, use the upstream quality bar in `.github/copilot-instructions.md`.

--- a/docs/downstream/agent-tooling.md
+++ b/docs/downstream/agent-tooling.md
@@ -115,7 +115,7 @@ Do not change production Vercel settings, production branch, domains, or environ
 
 After meaningful UI changes, use Playwright MCP or Playwright CLI.
 
-At minimum check:
+Check the routes that are active for this site (see `src/config/features.json` and `src/config/navigation.json`). Default routes are:
 
 - homepage desktop
 - homepage mobile
@@ -129,15 +129,17 @@ At minimum check:
 - obvious overflow or clipping
 - obvious color-contrast problems
 
+Routes may be disabled or renamed in your site's configuration; only check routes that are active.
+
 Do not claim a visual bug is fixed unless the site was inspected in a browser, or explicitly say the review was code-only.
 
 ### Content and tone
 
 Before writing copy, read:
 
-- `src/context/site-owner.json`
-- `src/context/brand-voice.json`
-- `src/context/agent-rules.md`
+- `src/context/site-owner.json`, if present
+- `src/context/brand-voice.json`, if present
+- `src/context/agent-rules.md`, if present
 - `src/docs/design-brief.md`, if present
 - `src/docs/resume.md`, if present
 

--- a/docs/downstream/design-review-checklist.md
+++ b/docs/downstream/design-review-checklist.md
@@ -1,0 +1,79 @@
+# Design review checklist
+
+Use this checklist before calling a portfolio site visually ready.
+
+## Brand fit
+
+- Does the page feel like the person described in `src/context/site-owner.json`?
+- Does the tone match `src/context/brand-voice.json`?
+- Does the design fit the audience?
+- Does the hero section immediately explain who this person is and why they matter?
+
+## Layout
+
+- Is there a clear visual hierarchy?
+- Is the hero section balanced?
+- Are sections visually distinct without feeling noisy?
+- Is there enough whitespace?
+- Are headings, body text, and metadata consistently sized?
+- Does the layout work on mobile without awkward stacking?
+
+## Typography
+
+- Are line lengths readable?
+- Are heading sizes intentional?
+- Is body copy comfortable to read?
+- Are links visually recognizable?
+- Are labels, dates, tags, and metadata visually subordinate?
+
+## Color
+
+- Are colors drawn from the site’s theme/config?
+- Is contrast sufficient?
+- Are accent colors used sparingly?
+- Do hover/focus states exist where needed?
+- Does the palette feel coherent across pages?
+
+## Content
+
+- Is the copy specific rather than generic?
+- Are claims supported by provided source material?
+- Are placeholders clearly marked or removed?
+- Are CTAs concrete and appropriate?
+- Is anything invented?
+
+## Navigation
+
+- Does the primary nav work?
+- Is the active/current page state clear?
+- Are links descriptive?
+- Do external links open appropriately?
+- Is the contact path obvious?
+
+## Accessibility
+
+- Is there one logical `h1` per page?
+- Are headings nested sensibly?
+- Are images given useful alt text?
+- Are interactive elements keyboard reachable?
+- Are focus states visible?
+- Are link labels meaningful outside visual context?
+- Does the page avoid click-only interactions?
+
+## Performance and build hygiene
+
+- Does `pnpm check` pass?
+- Does `pnpm build` pass?
+- Are images reasonably sized?
+- Are unused scripts avoided?
+- Are console errors resolved?
+
+## Final review statement
+
+Before marking complete, write:
+
+```md
+I checked [routes] at [viewports].
+Build status: [pass/fail].
+Known remaining issues: [...]
+```

--- a/docs/downstream/design-review-checklist.md
+++ b/docs/downstream/design-review-checklist.md
@@ -4,8 +4,8 @@ Use this checklist before calling a portfolio site visually ready.
 
 ## Brand fit
 
-- Does the page feel like the person described in `src/context/site-owner.json`?
-- Does the tone match `src/context/brand-voice.json`?
+- Does the page feel like the person described in `src/context/site-owner.json` (if present)?
+- Does the tone match `src/context/brand-voice.json` (if present)?
 - Does the design fit the audience?
 - Does the hero section immediately explain who this person is and why they matter?
 

--- a/docs/downstream/new-site-setup.md
+++ b/docs/downstream/new-site-setup.md
@@ -43,11 +43,8 @@ The setup scripts can seed optional agent-tooling files:
 - `CLAUDE.md`
 - `.github/copilot-instructions.md`
 - `.cursor/mcp.example.json`
-- `src/docs/agent-tooling.md`
-- `src/docs/visual-qa-prompt.md`
-- `src/docs/design-review-checklist.md`
 
-These files help Claude Code, Cursor, and Copilot use the right tools for the right job.
+These files help Claude Code, Cursor, and Copilot use the right tools for the right job. The full tooling guidance lives in `docs/downstream/agent-tooling.md` (already present if you copied the `docs/downstream/` directory in step 0).
 
 Recommended tools:
 

--- a/docs/downstream/new-site-setup.md
+++ b/docs/downstream/new-site-setup.md
@@ -17,7 +17,7 @@ Step-by-step guide for bootstrapping a new standalone portfolio site (like `jord
 If you are using Claude Code, do this first:
 
 1. Scaffold the project first (`pnpm create astro@latest . --template minimal --install --typescript strict --git false`).
-2. In your new site repo, create `docs/downstream/` and copy `setup-with-claude.md`, `setup.sh`, `setup.ps1`, and `scripts/` from this repo.
+2. In your new site repo, create `docs/downstream/` and copy the full `docs/downstream/` directory from this repo, including `setup-with-claude.md`, `setup.sh`, `setup.ps1`, `scripts/`, `templates/`, and the agent-tooling docs.
 3. Paste `docs/downstream/setup-with-claude.md` into Claude and include your resume/design brief if available.
 4. Ask Claude to run `docs/downstream/setup.sh` (macOS/Linux) or `docs/downstream/setup.ps1` (Windows), then continue with manual file wiring.
 
@@ -33,6 +33,46 @@ Script controls:
 - PowerShell dry-run preview: `./docs/downstream/setup.ps1 -DryRun`
 - Bash skip phase: `SKIP_INSTALL=1 ./docs/downstream/setup.sh`
 - PowerShell skip phase: `./docs/downstream/setup.ps1 -SkipInstall`
+- Bash skip agent tooling seed: `SKIP_AGENT_TOOLING=1 ./docs/downstream/setup.sh`
+- PowerShell skip agent tooling seed: `./docs/downstream/setup.ps1 -SkipAgentTooling`
+
+## 0.5 — Optional agent tooling
+
+The setup scripts can seed optional agent-tooling files:
+
+- `CLAUDE.md`
+- `.github/copilot-instructions.md`
+- `.cursor/mcp.example.json`
+- `src/docs/agent-tooling.md`
+- `src/docs/visual-qa-prompt.md`
+- `src/docs/design-review-checklist.md`
+
+These files help Claude Code, Cursor, and Copilot use the right tools for the right job.
+
+Recommended tools:
+
+| Tool                 | Purpose                                                                               |
+| -------------------- | ------------------------------------------------------------------------------------- |
+| Vercel MCP           | inspect live Vercel deployments, logs, domains, env var names, and protected previews |
+| Vercel Plugin        | Vercel-specific implementation guidance                                               |
+| Context7             | current package docs and API examples                                                 |
+| Playwright MCP / CLI | browser-based visual QA                                                               |
+| Lighthouse CI        | optional performance/accessibility/SEO regression checks                              |
+| Vale                 | optional prose and tone linting                                                       |
+
+See `docs/downstream/agent-tooling.md`.
+
+If you do not want these files, run:
+
+```bash
+SKIP_AGENT_TOOLING=1 ./docs/downstream/setup.sh
+```
+
+or on Windows:
+
+```powershell
+./docs/downstream/setup.ps1 -SkipAgentTooling
+```
 
 ## 1 — Scaffold the Astro project
 

--- a/docs/downstream/scripts/07-seed-agent-tooling.ps1
+++ b/docs/downstream/scripts/07-seed-agent-tooling.ps1
@@ -29,17 +29,13 @@ Install-IfMissing (Join-Path $TemplateDir 'mcp.example.json') '.cursor/mcp.examp
 Install-IfMissing (Join-Path $TemplateDir 'CLAUDE.md') 'CLAUDE.md'
 Install-IfMissing (Join-Path $TemplateDir 'copilot-instructions.md') '.github/copilot-instructions.md'
 
-Install-IfMissing (Join-Path $DownstreamDir 'agent-tooling.md') 'src/docs/agent-tooling.md'
-Install-IfMissing (Join-Path $DownstreamDir 'visual-qa-prompt.md') 'src/docs/visual-qa-prompt.md'
-Install-IfMissing (Join-Path $DownstreamDir 'design-review-checklist.md') 'src/docs/design-review-checklist.md'
-
 if (-not (Test-Path '.gitignore')) {
   New-Item -ItemType File -Path '.gitignore' | Out-Null
 }
 
 $content = Get-Content '.gitignore' -Raw
 if ($content -notmatch '(?m)^\.cursor/mcp\.json$') {
-  Add-Content '.gitignore' '.cursor/mcp.json'
+  Add-Content '.gitignore' "`n.cursor/mcp.json"
 }
 
 Write-Host 'Agent tooling seed complete.'

--- a/docs/downstream/scripts/07-seed-agent-tooling.ps1
+++ b/docs/downstream/scripts/07-seed-agent-tooling.ps1
@@ -1,0 +1,46 @@
+$ErrorActionPreference = 'Stop'
+
+Write-Host '[7/7] Seeding optional agent tooling files'
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$DownstreamDir = Split-Path -Parent $ScriptDir
+$TemplateDir = Join-Path $DownstreamDir 'templates/agent'
+
+function Install-IfMissing($src, $dest) {
+  $parent = Split-Path -Parent $dest
+  if ($parent -and -not (Test-Path $parent)) {
+    New-Item -ItemType Directory -Force -Path $parent | Out-Null
+  }
+
+  if (Test-Path $dest) {
+    Write-Host "Exists: $dest; leaving as-is"
+    return
+  }
+
+  Copy-Item $src $dest
+  Write-Host "Created: $dest"
+}
+
+if (-not (Test-Path $TemplateDir)) {
+  throw "Missing template directory: $TemplateDir. Copy the full docs/downstream directory before running setup."
+}
+
+Install-IfMissing (Join-Path $TemplateDir 'mcp.example.json') '.cursor/mcp.example.json'
+Install-IfMissing (Join-Path $TemplateDir 'CLAUDE.md') 'CLAUDE.md'
+Install-IfMissing (Join-Path $TemplateDir 'copilot-instructions.md') '.github/copilot-instructions.md'
+
+Install-IfMissing (Join-Path $DownstreamDir 'agent-tooling.md') 'src/docs/agent-tooling.md'
+Install-IfMissing (Join-Path $DownstreamDir 'visual-qa-prompt.md') 'src/docs/visual-qa-prompt.md'
+Install-IfMissing (Join-Path $DownstreamDir 'design-review-checklist.md') 'src/docs/design-review-checklist.md'
+
+if (-not (Test-Path '.gitignore')) {
+  New-Item -ItemType File -Path '.gitignore' | Out-Null
+}
+
+$content = Get-Content '.gitignore' -Raw
+if ($content -notmatch '(?m)^\.cursor/mcp\.json$') {
+  Add-Content '.gitignore' '.cursor/mcp.json'
+}
+
+Write-Host 'Agent tooling seed complete.'
+Write-Host 'Next: copy .cursor/mcp.example.json to .cursor/mcp.json if you want project-local Cursor MCP config.'

--- a/docs/downstream/scripts/07-seed-agent-tooling.sh
+++ b/docs/downstream/scripts/07-seed-agent-tooling.sh
@@ -32,12 +32,8 @@ install_if_missing "$TEMPLATE_DIR/mcp.example.json" ".cursor/mcp.example.json"
 install_if_missing "$TEMPLATE_DIR/CLAUDE.md" "CLAUDE.md"
 install_if_missing "$TEMPLATE_DIR/copilot-instructions.md" ".github/copilot-instructions.md"
 
-install_if_missing "$DOWNSTREAM_DIR/agent-tooling.md" "src/docs/agent-tooling.md"
-install_if_missing "$DOWNSTREAM_DIR/visual-qa-prompt.md" "src/docs/visual-qa-prompt.md"
-install_if_missing "$DOWNSTREAM_DIR/design-review-checklist.md" "src/docs/design-review-checklist.md"
-
 touch .gitignore
-grep -q '^\.cursor/mcp\.json$' .gitignore || echo '.cursor/mcp.json' >> .gitignore
+grep -q '^\.cursor/mcp\.json$' .gitignore || printf '\n.cursor/mcp.json\n' >> .gitignore
 
 echo "Agent tooling seed complete."
 echo "Next: copy .cursor/mcp.example.json to .cursor/mcp.json if you want project-local Cursor MCP config."

--- a/docs/downstream/scripts/07-seed-agent-tooling.sh
+++ b/docs/downstream/scripts/07-seed-agent-tooling.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[7/7] Seeding optional agent tooling files"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOWNSTREAM_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEMPLATE_DIR="$DOWNSTREAM_DIR/templates/agent"
+
+install_if_missing() {
+  local src="$1"
+  local dest="$2"
+
+  mkdir -p "$(dirname "$dest")"
+
+  if [[ -f "$dest" ]]; then
+    echo "Exists: $dest; leaving as-is"
+    return
+  fi
+
+  cp "$src" "$dest"
+  echo "Created: $dest"
+}
+
+[[ -d "$TEMPLATE_DIR" ]] || {
+  echo "ERROR: missing template directory: $TEMPLATE_DIR"
+  echo "Copy the full docs/downstream directory before running setup."
+  exit 1
+}
+
+install_if_missing "$TEMPLATE_DIR/mcp.example.json" ".cursor/mcp.example.json"
+install_if_missing "$TEMPLATE_DIR/CLAUDE.md" "CLAUDE.md"
+install_if_missing "$TEMPLATE_DIR/copilot-instructions.md" ".github/copilot-instructions.md"
+
+install_if_missing "$DOWNSTREAM_DIR/agent-tooling.md" "src/docs/agent-tooling.md"
+install_if_missing "$DOWNSTREAM_DIR/visual-qa-prompt.md" "src/docs/visual-qa-prompt.md"
+install_if_missing "$DOWNSTREAM_DIR/design-review-checklist.md" "src/docs/design-review-checklist.md"
+
+touch .gitignore
+grep -q '^\.cursor/mcp\.json$' .gitignore || echo '.cursor/mcp.json' >> .gitignore
+
+echo "Agent tooling seed complete."
+echo "Next: copy .cursor/mcp.example.json to .cursor/mcp.json if you want project-local Cursor MCP config."

--- a/docs/downstream/setup-with-claude.md
+++ b/docs/downstream/setup-with-claude.md
@@ -34,6 +34,14 @@ Also:
 - ensure Astro output is `static`
 - create placeholder `src/content/profile/person.json` and `src/content/profile/cv.json`
 - set `.gitignore` entries for `.portfolio-engine/` and `.vercel/`
+- seed agent tooling unless I explicitly opt out:
+  - `CLAUDE.md`
+  - `.github/copilot-instructions.md`
+  - `.cursor/mcp.example.json`
+  - `src/docs/agent-tooling.md`
+  - `src/docs/visual-qa-prompt.md`
+  - `src/docs/design-review-checklist.md`
+- read `src/docs/agent-tooling.md` before using MCP/plugin/browser tools
 
 Write each confusion/error/contradiction to `src/docs/setup-feedback.md` as you go.
 
@@ -55,7 +63,14 @@ Guide manual import and set:
 - Node 22
 - `SITE_URL` as production-only env var
 
-If available, offer Vercel MCP/plugin or Vercel CLI to reduce manual clicks; otherwise provide click-by-click fallback.
+If available, use the tool split documented in `src/docs/agent-tooling.md`:
+
+- Vercel Plugin for implementation guidance.
+- Vercel MCP for live Vercel state.
+- Context7 for current package docs.
+- Playwright for browser-based verification.
+
+If those tools are unavailable, provide click-by-click fallback instructions.
 
 ## Phase 5 — admin + branch behavior verification
 
@@ -64,6 +79,7 @@ Verify:
 - `/admin` works in local dev with `devBypass: true`
 - admin/auth routes are not main-branch-only and work on preview deployments too
 - OAuth env vars are documented (all required vars listed)
+- run the visual QA checklist in `src/docs/visual-qa-prompt.md` after deployment or meaningful UI changes
 
 ## Phase 6 — CI
 

--- a/docs/downstream/setup-with-claude.md
+++ b/docs/downstream/setup-with-claude.md
@@ -38,10 +38,7 @@ Also:
   - `CLAUDE.md`
   - `.github/copilot-instructions.md`
   - `.cursor/mcp.example.json`
-  - `src/docs/agent-tooling.md`
-  - `src/docs/visual-qa-prompt.md`
-  - `src/docs/design-review-checklist.md`
-- read `src/docs/agent-tooling.md` before using MCP/plugin/browser tools
+- read `docs/downstream/agent-tooling.md` before using MCP/plugin/browser tools (the file lives in the downstream docs directory copied in step 0)
 
 Write each confusion/error/contradiction to `src/docs/setup-feedback.md` as you go.
 
@@ -63,7 +60,7 @@ Guide manual import and set:
 - Node 22
 - `SITE_URL` as production-only env var
 
-If available, use the tool split documented in `src/docs/agent-tooling.md`:
+If available, use the tool split documented in `docs/downstream/agent-tooling.md`:
 
 - Vercel Plugin for implementation guidance.
 - Vercel MCP for live Vercel state.
@@ -79,7 +76,7 @@ Verify:
 - `/admin` works in local dev with `devBypass: true`
 - admin/auth routes are not main-branch-only and work on preview deployments too
 - OAuth env vars are documented (all required vars listed)
-- run the visual QA checklist in `src/docs/visual-qa-prompt.md` after deployment or meaningful UI changes
+- run the visual QA checklist in `docs/downstream/visual-qa-prompt.md` after deployment or meaningful UI changes
 
 ## Phase 6 — CI
 

--- a/docs/downstream/setup.ps1
+++ b/docs/downstream/setup.ps1
@@ -2,7 +2,7 @@
 Portfolio Engine downstream setup orchestrator (Windows)
 Safe to read before running.
 Use switches to skip phases, e.g.:
-  ./docs/downstream/setup.ps1 -DryRun -SkipInstall -SkipGitignore
+  ./docs/downstream/setup.ps1 -DryRun -SkipInstall -SkipAgentTooling
 #>
 
 param(
@@ -12,6 +12,7 @@ param(
   [switch]$SkipRouteFix,
   [switch]$SkipFeedback,
   [switch]$SkipGitignore,
+  [switch]$SkipAgentTooling,
   [switch]$DryRun
 )
 
@@ -38,5 +39,6 @@ Run-Step 'Create directories' (Join-Path $StepsDir '03-create-dirs.ps1') $SkipDi
 Run-Step 'Remove scaffold route collision' (Join-Path $StepsDir '04-remove-index-route.ps1') $SkipRouteFix
 Run-Step 'Seed setup feedback doc' (Join-Path $StepsDir '05-seed-feedback-log.ps1') $SkipFeedback
 Run-Step 'Patch .gitignore' (Join-Path $StepsDir '06-patch-gitignore.ps1') $SkipGitignore
+Run-Step 'Seed agent tooling' (Join-Path $StepsDir '07-seed-agent-tooling.ps1') $SkipAgentTooling
 
 Step 'DONE' 'Bootstrap complete. Continue with docs/downstream/new-site-setup.md'

--- a/docs/downstream/setup.sh
+++ b/docs/downstream/setup.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Portfolio Engine downstream setup orchestrator (macOS/Linux)
 # Safe to read before running. Set SKIP_* env vars to skip phases.
-# Example: DRY_RUN=1 SKIP_INSTALL=1 ./docs/downstream/setup.sh
+# Example: DRY_RUN=1 SKIP_INSTALL=1 SKIP_AGENT_TOOLING=1 ./docs/downstream/setup.sh
 
 ROOT_DIR="$(pwd -P)"
 SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/scripts"
@@ -38,5 +38,6 @@ run_step "Create directories" "$SCRIPTS_DIR/03-create-dirs.sh" "SKIP_DIRS"
 run_step "Remove scaffold route collision" "$SCRIPTS_DIR/04-remove-index-route.sh" "SKIP_ROUTE_FIX"
 run_step "Seed setup feedback doc" "$SCRIPTS_DIR/05-seed-feedback-log.sh" "SKIP_FEEDBACK"
 run_step "Patch .gitignore" "$SCRIPTS_DIR/06-patch-gitignore.sh" "SKIP_GITIGNORE"
+run_step "Seed agent tooling" "$SCRIPTS_DIR/07-seed-agent-tooling.sh" "SKIP_AGENT_TOOLING"
 
 step "DONE" "Bootstrap complete. Next: follow docs/downstream/new-site-setup.md for config/content wiring."

--- a/docs/downstream/templates/agent/CLAUDE.md
+++ b/docs/downstream/templates/agent/CLAUDE.md
@@ -1,0 +1,116 @@
+# Claude instructions for this portfolio site
+
+This is a consumer site built on `@portfolio-engine/editorial-theme` and optionally `@portfolio-engine/admin-tools`.
+
+The upstream engine lives at:
+
+```text
+https://github.com/rainonej/portfolio-engine
+```
+
+## Ownership model
+
+The site owner controls:
+
+- `src/content/` — projects, writing, profile, testimonials
+- `src/config/` — site, navigation, theme, features
+- `src/context/` — AI-readable identity, tone, brand, and agent rules
+- `src/overrides/` — local component overrides
+- `public/` — images and assets
+
+Do not modify upstream package code from this repo unless explicitly asked.
+
+Prefer consumer-site configuration, content, context, or override changes first.
+
+## Required reading before content/design work
+
+Before writing copy or changing design direction, read:
+
+- `src/context/site-owner.json`
+- `src/context/brand-voice.json`
+- `src/context/agent-rules.md`
+- `src/docs/design-brief.md`, if present
+- `src/docs/resume.md`, if present
+- `src/docs/agent-tooling.md`, if present
+- `src/docs/design-review-checklist.md`, if present
+
+Do not invent credentials, jobs, awards, publications, client names, degrees, or biographical details.
+
+If source material is missing, use placeholders and mark them clearly.
+
+## Tooling policy
+
+Use Context7 for current docs before implementing package-specific APIs or configuration.
+
+Use the Vercel Plugin for Vercel-aware implementation guidance.
+
+Use Vercel MCP for live Vercel state:
+
+- deployments
+- build logs
+- runtime logs
+- project settings
+- domains
+- env var names
+- protected preview URLs
+
+Use Playwright MCP or Playwright CLI after meaningful UI changes.
+
+Prefer read-only MCP actions first.
+
+Do not mutate production Vercel settings without explicit human confirmation.
+
+Do not commit secrets.
+
+## Local validation
+
+Before considering work done:
+
+```bash
+pnpm check
+pnpm build
+```
+
+If linting is configured:
+
+```bash
+pnpm lint
+```
+
+## Visual QA
+
+After layout/style changes, inspect the site in a browser.
+
+Check:
+
+- `/`
+- `/work`
+- `/writing`
+- `/about`
+- `/contact`
+- `/admin`, if enabled
+
+Check desktop and mobile.
+
+Report what was actually inspected.
+
+Do not claim a visual issue is fixed unless you inspected the page or clearly state it was code-only review.
+
+## Content style
+
+Prefer:
+
+- concrete claims
+- specific examples
+- short paragraphs
+- human voice
+- clear section hierarchy
+
+Avoid:
+
+- generic startup language
+- unexplained jargon
+- fake polish
+- invented detail
+- corporate filler
+- long walls of text

--- a/docs/downstream/templates/agent/CLAUDE.md
+++ b/docs/downstream/templates/agent/CLAUDE.md
@@ -26,13 +26,13 @@ Prefer consumer-site configuration, content, context, or override changes first.
 
 Before writing copy or changing design direction, read:
 
-- `src/context/site-owner.json`
-- `src/context/brand-voice.json`
-- `src/context/agent-rules.md`
+- `src/context/site-owner.json`, if present
+- `src/context/brand-voice.json`, if present
+- `src/context/agent-rules.md`, if present
 - `src/docs/design-brief.md`, if present
 - `src/docs/resume.md`, if present
-- `src/docs/agent-tooling.md`, if present
-- `src/docs/design-review-checklist.md`, if present
+- `docs/downstream/agent-tooling.md`, if present
+- `docs/downstream/design-review-checklist.md`, if present
 
 Do not invent credentials, jobs, awards, publications, client names, degrees, or biographical details.
 
@@ -81,7 +81,7 @@ pnpm lint
 
 After layout/style changes, inspect the site in a browser.
 
-Check:
+Check the routes that are active for this site (see `src/config/features.json` and `src/config/navigation.json`). Default routes are:
 
 - `/`
 - `/work`
@@ -89,6 +89,8 @@ Check:
 - `/about`
 - `/contact`
 - `/admin`, if enabled
+
+Routes may be disabled or renamed in your site's configuration; only check routes that are active.
 
 Check desktop and mobile.
 

--- a/docs/downstream/templates/agent/copilot-instructions.md
+++ b/docs/downstream/templates/agent/copilot-instructions.md
@@ -1,0 +1,80 @@
+# Copilot instructions for this portfolio site
+
+## Scope
+
+This is a consumer site built on `@portfolio-engine/editorial-theme`.
+
+The upstream engine lives in `rainonej/portfolio-engine`.
+
+Prefer changes in:
+
+- `src/content/`
+- `src/config/`
+- `src/context/`
+- `src/overrides/`
+- `public/`
+
+Do not patch upstream package behavior in this consumer repo unless explicitly asked.
+
+## Quality bar
+
+Before considering work complete, run:
+
+```bash
+pnpm check
+pnpm build
+```
+
+If linting is configured, also run:
+
+```bash
+pnpm lint
+```
+
+## Tooling rules
+
+Use Context7 for current package docs and API examples.
+
+Use the Vercel Plugin for Vercel-aware implementation guidance.
+
+Use Vercel MCP only for live Vercel state:
+
+- deployments
+- build logs
+- runtime logs
+- project settings
+- domains
+- env var names
+- protected preview URLs
+
+Use Playwright MCP or Playwright CLI after meaningful UI changes.
+
+Prefer read-only MCP operations first.
+
+Do not mutate production settings without explicit human confirmation.
+
+Do not commit secrets.
+
+## Content rules
+
+Read `src/context/` before writing copy.
+
+Do not invent credentials, awards, jobs, publications, client names, or biographical details.
+
+Prefer concrete, specific language over generic marketing language.
+
+## Design rules
+
+After UI changes, check desktop and mobile.
+
+Look for:
+
+- broken nav
+- overflow
+- clipping
+- weak contrast
+- bad spacing
+- console errors
+- generic or off-brand presentation
+
+Report what was actually checked.

--- a/docs/downstream/templates/agent/mcp.example.json
+++ b/docs/downstream/templates/agent/mcp.example.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "vercel": {
+      "url": "https://mcp.vercel.com"
+    },
+    "context7": {
+      "url": "https://mcp.context7.com/mcp"
+    },
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp@latest"]
+    }
+  }
+}

--- a/docs/downstream/visual-qa-prompt.md
+++ b/docs/downstream/visual-qa-prompt.md
@@ -14,7 +14,7 @@ pnpm dev
 
 Open the local URL in Playwright.
 
-Review these routes:
+Review the routes that are active for this site. Check `src/config/features.json` and `src/config/navigation.json` to determine which routes are enabled. Default routes are:
 
 - `/`
 - `/work`
@@ -22,6 +22,8 @@ Review these routes:
 - `/about`
 - `/contact`
 - `/admin` if admin tools are enabled
+
+Routes may be disabled or renamed in your site's configuration; only review routes that are active.
 
 Review these viewport sizes:
 

--- a/docs/downstream/visual-qa-prompt.md
+++ b/docs/downstream/visual-qa-prompt.md
@@ -1,0 +1,72 @@
+# Visual QA prompt
+
+Use this prompt after meaningful layout, style, routing, content, or override changes.
+
+---
+
+You are reviewing a `portfolio-engine` consumer site.
+
+Run the local site:
+
+```bash
+pnpm dev
+```
+
+Open the local URL in Playwright.
+
+Review these routes:
+
+- `/`
+- `/work`
+- `/writing`
+- `/about`
+- `/contact`
+- `/admin` if admin tools are enabled
+
+Review these viewport sizes:
+
+- desktop: `1440x1000`
+- laptop: `1280x800`
+- tablet: `768x1024`
+- mobile: `390x844`
+
+For each important page, report:
+
+1. visual hierarchy issues
+2. spacing or rhythm problems
+3. overflow, clipping, or horizontal scroll
+4. unreadable text or contrast concerns
+5. broken images
+6. broken links
+7. console errors
+8. navigation problems
+9. mobile-specific problems
+10. places where the design feels generic, unpolished, or off-brand
+
+Do not make changes immediately.
+
+First produce:
+
+```md
+## Visual QA findings
+
+### Critical
+
+- ...
+
+### Should fix
+
+- ...
+
+### Nice to improve
+
+- ...
+
+### No issue found
+
+- ...
+```
+
+Then propose a small patch plan.
+
+Only after that, edit files.


### PR DESCRIPTION
### Motivation

- Provide a recommended, safe agent-tooling profile for downstream consumer sites so AI coding agents (Claude/Cursor/Copilot) have clear operating rules and examples. 
- Seed non-sensitive example MCP config and agent instruction templates while avoiding committing local auth or overwriting consumer customizations. 
- Integrate agent-tooling into the existing phased, dry-runnable setup model so non-technical users and agents can opt in or skip the step. 

### Description

- Add new docs and templates under `docs/downstream/` and `docs/downstream/templates/agent/`, including `agent-tooling.md`, `visual-qa-prompt.md`, `design-review-checklist.md`, `CLAUDE.md`, `copilot-instructions.md`, and `mcp.example.json`. 
- Add seed scripts `docs/downstream/scripts/07-seed-agent-tooling.sh` and `07-seed-agent-tooling.ps1` that copy templates only when target files are missing and append `.cursor/mcp.json` to `.gitignore`. 
- Update orchestrators to run the new phase with skip controls by adding `run_step "Seed agent tooling" ... "SKIP_AGENT_TOOLING"` to `docs/downstream/setup.sh` and a `[switch]$SkipAgentTooling` + `Run-Step 'Seed agent tooling' ...` to `docs/downstream/setup.ps1`. 
- Update downstream docs (`new-site-setup.md`, `setup-with-claude.md`, `README.md`, and `.github/copilot-instructions.md`) to document the optional agent-tooling phase, tool split (Vercel MCP vs Plugin, Context7, Playwright), and visual QA guardrails. 

### Testing

- Ran `pnpm format` and code style checks which passed after formatting fixes. 
- Ran `pnpm lint` and `pnpm check` which completed without errors. 
- Built the demo site with `pnpm --filter demo-site run build` and ran the workspace `pnpm build`, both of which succeeded. 
- Exercised the setup dry-run flows `DRY_RUN=1 ./docs/downstream/setup.sh` and `DRY_RUN=1 SKIP_AGENT_TOOLING=1 ./docs/downstream/setup.sh` which reported the expected DRY and SKIP behavior; PowerShell dry-run commands were not executed in this environment because `pwsh` is unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8c80076188320ae95d4b05e3f8223)