### PR TITLE
Fix downstream setup flow for unpublished admin-tools package

### DIFF
--- a/docs/downstream/new-site-setup.md
+++ b/docs/downstream/new-site-setup.md
@@ -87,10 +87,14 @@ The scaffold's default `src/pages/index.astro` conflicts with the theme's `/` ro
 ## 2 — Install packages
 
 ```bash
-pnpm add @portfolio-engine/editorial-theme @portfolio-engine/admin-tools @astrojs/vercel
+pnpm add @portfolio-engine/editorial-theme @astrojs/vercel
 ```
 
 ---
+
+
+> **Note on admin tools:** `@portfolio-engine/admin-tools` is currently private/unpublished.
+> Do not include it in standalone consumer site installs until a public release is available.
 
 ## 3 — Replace `astro.config.mjs`
 
@@ -99,7 +103,6 @@ pnpm add @portfolio-engine/editorial-theme @portfolio-engine/admin-tools @astroj
 import { defineConfig } from 'astro/config';
 import vercel from '@astrojs/vercel';
 import { editorialTheme } from '@portfolio-engine/editorial-theme';
-import { adminTools } from '@portfolio-engine/admin-tools';
 
 // Production sets SITE_URL in Vercel env vars. Previews fall back to VERCEL_URL.
 const site =
@@ -118,7 +121,6 @@ export default defineConfig({
       themeConfigPath: './src/config/theme.json',
       featuresConfigPath: './src/config/features.json',
     }),
-    adminTools({ devBypass: true }),
   ],
 });
 ```

--- a/docs/downstream/scripts/02-install-packages.ps1
+++ b/docs/downstream/scripts/02-install-packages.ps1
@@ -1,4 +1,6 @@
 $ErrorActionPreference = 'Stop'
-Write-Host '[2/6] Installing required packages'
+Write-Host '[2/7] Installing required packages'
 if (-not (Test-Path 'package.json')) { throw 'package.json not found. Run from scaffolded repo root.' }
-pnpm add @portfolio-engine/editorial-theme @portfolio-engine/admin-tools @astrojs/vercel
+pnpm add @portfolio-engine/editorial-theme @astrojs/vercel
+Write-Host 'NOTE: @portfolio-engine/admin-tools is currently private/unpublished.'
+Write-Host 'Skip installing it in standalone consumer repos until it is published.'

--- a/docs/downstream/scripts/02-install-packages.sh
+++ b/docs/downstream/scripts/02-install-packages.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "[2/6] Installing required packages"
+echo "[2/7] Installing required packages"
 [[ -f package.json ]] || { echo "ERROR: package.json not found. Run from scaffolded repo root."; exit 1; }
-pnpm add @portfolio-engine/editorial-theme @portfolio-engine/admin-tools @astrojs/vercel
+pnpm add @portfolio-engine/editorial-theme @astrojs/vercel
+
+cat <<'NOTE'
+NOTE: @portfolio-engine/admin-tools is currently private/unpublished.
+Skip installing it in standalone consumer repos until it is published.
+NOTE

--- a/docs/downstream/setup-with-claude.md
+++ b/docs/downstream/setup-with-claude.md
@@ -8,6 +8,7 @@ You are helping me set up a new personal portfolio site from scratch using
 `@portfolio-engine/editorial-theme` + `@portfolio-engine/admin-tools`.
 
 Operate in phases. Keep a running friction log in `src/docs/setup-feedback.md` during setup.
+`@portfolio-engine/admin-tools` is currently private/unpublished for standalone consumer sites; do not attempt to install it unless a published release is available.
 If I provide a resume and/or design doc, save them to `src/docs/resume.md` and `src/docs/design-brief.md` first, then use them as source-of-truth.
 
 ## Phase 1 — intake
@@ -30,7 +31,6 @@ https://github.com/rainonej/portfolio-engine/blob/main/docs/downstream/new-site-
 Also:
 
 - run `docs/downstream/setup.sh` (macOS/Linux) or `docs/downstream/setup.ps1` (Windows) if present to automate standard setup
-- ensure `adminTools({ devBypass: true })` is configured after `editorialTheme(...)`
 - ensure Astro output is `static`
 - create placeholder `src/content/profile/person.json` and `src/content/profile/cv.json`
 - set `.gitignore` entries for `.portfolio-engine/` and `.vercel/`

--- a/docs/downstream/setup.ps1
+++ b/docs/downstream/setup.ps1
@@ -32,6 +32,7 @@ function Run-Step($name, $scriptPath, $skip) {
 }
 
 Step 'INFO' "Starting downstream bootstrap in $(Get-Location)"
+if (-not (Test-Path 'package.json')) { throw 'package.json not found. Run from scaffolded repo root.' }
 if ($DryRun) { Step 'INFO' 'DryRun enabled: no files will be modified' }
 Run-Step 'Preflight checks' (Join-Path $StepsDir '01-preflight.ps1') $SkipPreflight
 Run-Step 'Install packages' (Join-Path $StepsDir '02-install-packages.ps1') $SkipInstall


### PR DESCRIPTION
### Motivation
- Prevent downstream consumer setup from failing when attempting to install a private package (`@portfolio-engine/admin-tools`) by aligning docs and scripts with current package availability. 
- Remove misleading instructions that would configure an unavailable integration in the example `astro.config.mjs` used by standalone sites. 
- Improve robustness of the PowerShell orchestrator by failing fast when run from the wrong directory. 
- Keep orchestrator step labels consistent with the actual 7-phase flow to avoid confusion during automated runs. 

### Description
- Removed `@portfolio-engine/admin-tools` from the install commands in `docs/downstream/scripts/02-install-packages.sh` and `docs/downstream/scripts/02-install-packages.ps1` and added an explicit note that the package is private/unpublished. 
- Updated `docs/downstream/new-site-setup.md` and `docs/downstream/setup-with-claude.md` to remove the `adminTools(...)` import/integration from the example `astro.config.mjs` and to surface the admin-tools availability note. 
- Added a repo-root validation check to `docs/downstream/setup.ps1` so `-DryRun` (and normal runs) fail early if `package.json` is missing. 
- Corrected the install-phase step label in the bash/PowerShell install scripts from `[2/6]` to `[2/7]` to match the 7-step orchestrator and seeded an inline notice in the bash/PowerShell install steps. 

### Testing
- Inspected modified files with `sed`/`nl` to verify the install commands no longer reference `@portfolio-engine/admin-tools` and the Astro config example no longer includes `adminTools(...)`, with file contents reviewed successfully. 
- Searched updated docs and scripts with `rg` to confirm the admin-tools package warning is present and that stray `adminTools(` occurrences were removed, with results showing the expected changes. 
- Reviewed the `docs/downstream/setup.ps1` orchestrator to confirm the new `package.json` existence check is present and correctly positioned, and the check behaves as intended upon inspection. 
- Generated the PR payload via the local `make_pr` helper to validate the change summary and PR body; payload creation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8f28c79fc8320a52bc65c70999613)