### PR TITLE
Admin dashboard + shared editorial design tokens

### DIFF
--- a/packages/admin-tools/package.json
+++ b/packages/admin-tools/package.json
@@ -26,6 +26,7 @@
     "astro": "^6.0.0"
   },
   "dependencies": {
+    "@portfolio-engine/editorial-theme": "workspace:*",
     "@portfolio-engine/engine-core": "workspace:*"
   },
   "devDependencies": {

--- a/packages/admin-tools/src/client/admin-app.ts
+++ b/packages/admin-tools/src/client/admin-app.ts
@@ -1,0 +1,762 @@
+import { createContentApi } from './content-api.js';
+import { yamlFrontmatter } from './yaml-frontmatter.js';
+import type { DesignTokenGroup } from '../lib/design-token-groups.js';
+
+const PERSON_PATH = 'src/content/profile/person.json';
+const SITE_PATH = 'src/config/site.json';
+
+const PERSON_FIELDS = ['name', 'email', 'linkedin', 'instagram', 'photo', 'bio'] as const;
+
+type FieldDef = {
+  name: string;
+  label: string;
+  type?: string;
+  rows?: number;
+  value?: unknown;
+  uploadCollection?: string;
+};
+
+type FieldGroup = { label: string; fields: FieldDef[] };
+
+function slugify(str: string): string {
+  return str
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/[\s_]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function parseTokenGroups(): DesignTokenGroup[] {
+  const el = document.getElementById('admin-token-json');
+  if (!el?.textContent) return [];
+  try {
+    return JSON.parse(el.textContent) as DesignTokenGroup[];
+  } catch {
+    return [];
+  }
+}
+
+function parseThemeConfigColors(): Record<string, string> {
+  const raw = document.getElementById('admin-root')?.dataset.themeColors;
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw) as Record<string, string>;
+  } catch {
+    return {};
+  }
+}
+
+function initTokenSwatches(): void {
+  const root = document.getElementById('admin-design-swatches');
+  if (!root) return;
+  const style = getComputedStyle(document.documentElement);
+  const groups = parseTokenGroups();
+
+  for (const group of groups) {
+    const wrap = document.createElement('div');
+    wrap.className = 'adm-token-group';
+    const h3 = document.createElement('h3');
+    h3.className = 'adm-token-group-title';
+    h3.textContent = group.title;
+    wrap.appendChild(h3);
+    const grid = document.createElement('div');
+    grid.className = 'adm-token-grid';
+    for (const t of group.tokens) {
+      const value = style.getPropertyValue(t.cssVar).trim() || '(not set)';
+      const card = document.createElement('div');
+      card.className = 'adm-token-card';
+      card.innerHTML = `
+        <div class="adm-token-swatch" style="background:${value.startsWith('(') ? 'transparent' : value}"></div>
+        <div class="adm-token-meta">
+          <p class="adm-token-label">${escapeHtml(t.label)}</p>
+          <p class="adm-token-value">${escapeHtml(value)}</p>
+          <p class="adm-token-var">${escapeHtml(t.cssVar)}</p>
+          <p class="adm-token-usage">${escapeHtml(t.usage)}</p>
+        </div>`;
+      grid.appendChild(card);
+    }
+    wrap.appendChild(grid);
+    root.appendChild(wrap);
+  }
+
+  const cfg = parseThemeConfigColors();
+  const entries = Object.entries(cfg).filter(([, v]) => typeof v === 'string' && v.trim());
+  if (entries.length === 0) return;
+  const wrap = document.createElement('div');
+  wrap.className = 'adm-token-group';
+  const h3 = document.createElement('h3');
+  h3.className = 'adm-token-group-title';
+  h3.textContent = 'Theme file (src/config/theme.json)';
+  wrap.appendChild(h3);
+  const p = document.createElement('p');
+  p.className = 'adm-token-file-hint';
+  p.textContent =
+    'These entries come from your theme config. They are optional; the editorial theme primarily uses the CSS variables above.';
+  wrap.appendChild(p);
+  const grid = document.createElement('div');
+  grid.className = 'adm-token-grid';
+  const labels: Record<string, string> = {
+    primary: 'Primary',
+    secondary: 'Secondary',
+    background: 'Background',
+    text: 'Text',
+  };
+  const usage: Record<string, string> = {
+    primary: 'Brand primary actions and highlights when wired to components',
+    secondary: 'Secondary brand tone when wired to components',
+    background: 'Page or section background when wired to components',
+    text: 'Default text color when wired to components',
+  };
+  for (const [key, val] of entries) {
+    const card = document.createElement('div');
+    card.className = 'adm-token-card';
+    card.innerHTML = `
+      <div class="adm-token-swatch" style="background:${escapeHtml(val)}"></div>
+      <div class="adm-token-meta">
+        <p class="adm-token-label">${escapeHtml(labels[key] ?? key)}</p>
+        <p class="adm-token-value">${escapeHtml(val)}</p>
+        <p class="adm-token-var">theme.colors.${escapeHtml(key)}</p>
+        <p class="adm-token-usage">${escapeHtml(usage[key] ?? 'From theme config')}</p>
+      </div>`;
+    grid.appendChild(card);
+  }
+  wrap.appendChild(grid);
+  root.appendChild(wrap);
+}
+
+function initLogout(logoutBtn: HTMLButtonElement): void {
+  logoutBtn.addEventListener('click', async () => {
+    const url = logoutBtn.dataset.logoutUrl;
+    const home = logoutBtn.dataset.homeUrl;
+    if (!url || !home) return;
+    await fetch(url, { method: 'POST', credentials: 'include' });
+    window.location.href = home;
+  });
+}
+
+function showToast(el: HTMLElement, msg: string, isError = false): void {
+  el.textContent = msg;
+  el.className = `adm-toast adm-toast--show ${isError ? 'adm-toast--err' : 'adm-toast--ok'}`;
+  window.setTimeout(() => {
+    el.className = `adm-toast ${isError ? 'adm-toast--err' : 'adm-toast--ok'}`;
+  }, 4000);
+}
+
+function collectionMdPath(type: 'project' | 'writing', slug: string): string {
+  const dir = type === 'project' ? 'projects' : 'writing';
+  return `src/content/${dir}/${slug}.md`;
+}
+
+function testimonialPath(slug: string): string {
+  return `src/content/testimonials/${slug}.json`;
+}
+
+function renderFields(fields: FieldDef[]): string {
+  return fields
+    .map((f) => {
+      const id = `df-${f.name}`;
+      const safeVal = escapeHtml(String(f.value ?? ''));
+      if (f.type === 'checkbox') {
+        return `<div class="adm-drawer-field">
+          <label class="adm-drawer-check">
+            <input type="checkbox" id="${id}" name="${f.name}" ${f.value ? 'checked' : ''}>
+            ${escapeHtml(f.label)}
+          </label>
+        </div>`;
+      }
+      if (f.type === 'textarea') {
+        const isBody = f.name === 'body';
+        const extra = isBody ? ' adm-drawer-textarea--body' : '';
+        return `<div class="adm-drawer-field">
+          <label class="adm-drawer-label" for="${id}">${escapeHtml(f.label)}</label>
+          <textarea id="${id}" name="${f.name}" class="adm-drawer-input adm-drawer-textarea${extra}">${safeVal}</textarea>
+        </div>`;
+      }
+      if (f.uploadCollection) {
+        return `<div class="adm-drawer-field">
+          <label class="adm-drawer-label" for="${id}">${escapeHtml(f.label)}</label>
+          <input type="text" id="${id}" name="${f.name}" class="adm-drawer-input" value="${safeVal}" placeholder="/media/${f.uploadCollection}/photo.jpg">
+          <div class="adm-img-drop" data-collection="${f.uploadCollection}" data-field="${id}">
+            <span class="adm-img-drop-hint">Drop an image or click to browse</span>
+            <input type="file" class="adm-img-drop-input" accept=".jpg,.jpeg,.png,.webp,.gif" aria-label="Upload image">
+          </div>
+          <div class="adm-img-preview" hidden>
+            <img class="adm-img-preview-img" src="" alt="Preview">
+          </div>
+        </div>`;
+      }
+      return `<div class="adm-drawer-field">
+        <label class="adm-drawer-label" for="${id}">${escapeHtml(f.label)}</label>
+        <input type="${f.type ?? 'text'}" id="${id}" name="${f.name}" class="adm-drawer-input" value="${safeVal}">
+      </div>`;
+    })
+    .join('');
+}
+
+function renderGroupedFields(groups: FieldGroup[]): string {
+  return groups
+    .map(
+      (g) =>
+        `<div class="adm-drawer-section"><h3 class="adm-drawer-section-label">${escapeHtml(g.label)}</h3>${renderFields(g.fields)}</div>`,
+    )
+    .join('');
+}
+
+function readDrawerForm(fieldsEl: HTMLElement): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const el of Array.from(fieldsEl.querySelectorAll('input, textarea, select'))) {
+    const inp = el as HTMLInputElement | HTMLTextAreaElement;
+    if (!inp.name) continue;
+    result[inp.name] = inp.type === 'checkbox' ? (inp as HTMLInputElement).checked : inp.value;
+  }
+  return result;
+}
+
+function initImageUploadFields(fieldsEl: HTMLElement, api: ReturnType<typeof createContentApi>, toastEl: HTMLElement): void {
+  const ALLOWED = ['jpg', 'jpeg', 'png', 'webp', 'gif'];
+
+  fieldsEl.querySelectorAll<HTMLElement>('.adm-img-drop').forEach((zone) => {
+    const collection = zone.dataset.collection!;
+    const fieldId = zone.dataset.field!;
+    const pathInput = fieldsEl.querySelector<HTMLInputElement>(`#${fieldId}`);
+    const previewWrap = zone.nextElementSibling as HTMLElement | null;
+    const previewImg = previewWrap?.querySelector<HTMLImageElement>('.adm-img-preview-img');
+    const fileInput = zone.querySelector<HTMLInputElement>('.adm-img-drop-input');
+    if (!pathInput || !previewWrap || !previewImg || !fileInput) return;
+
+    const pathIn = pathInput;
+    const prevWrap = previewWrap;
+    const prevImg = previewImg;
+    const fileIn = fileInput;
+
+    if (pathIn.value.trim()) {
+      prevImg.src = pathIn.value.trim();
+      prevWrap.hidden = false;
+    }
+
+    async function handleFile(file: File) {
+      const ext = file.name.split('.').pop()?.toLowerCase() ?? '';
+      if (!ALLOWED.includes(ext)) {
+        showToast(toastEl, 'Only jpg, png, webp, or gif images are allowed.', true);
+        return;
+      }
+      zone.classList.add('adm-img-drop--busy');
+      try {
+        const buf = await file.arrayBuffer();
+        const bytes = new Uint8Array(buf);
+        let binary = '';
+        for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]!);
+        const b64 = btoa(binary);
+        const rel = `public/media/${collection}/${file.name}`;
+        const pub = `/media/${collection}/${file.name}`;
+        await api.putBase64(rel, b64, `admin-tools: upload ${file.name}`);
+        pathIn.value = pub;
+        prevImg.src = URL.createObjectURL(file);
+        prevWrap.hidden = false;
+        showToast(toastEl, 'Image uploaded');
+      } catch (e: unknown) {
+        showToast(toastEl, (e as Error).message, true);
+      } finally {
+        zone.classList.remove('adm-img-drop--busy');
+      }
+    }
+
+    let dragDepth = 0;
+    zone.addEventListener('dragenter', (e) => {
+      e.preventDefault();
+      dragDepth++;
+      zone.classList.add('adm-img-drop--over');
+    });
+    zone.addEventListener('dragleave', () => {
+      dragDepth--;
+      if (dragDepth <= 0) {
+        dragDepth = 0;
+        zone.classList.remove('adm-img-drop--over');
+      }
+    });
+    zone.addEventListener('dragover', (e) => e.preventDefault());
+    zone.addEventListener('drop', (e) => {
+      e.preventDefault();
+      dragDepth = 0;
+      zone.classList.remove('adm-img-drop--over');
+      const file = e.dataTransfer?.files[0];
+      if (file) void handleFile(file);
+    });
+    zone.addEventListener('click', (e) => {
+      if ((e.target as HTMLElement).closest('.adm-img-drop-input')) return;
+      fileIn.click();
+    });
+    fileIn.addEventListener('change', () => {
+      const file = fileIn.files?.[0];
+      if (file) void handleFile(file);
+      fileIn.value = '';
+    });
+  });
+}
+
+function markdownGroups(type: string, d: Record<string, unknown> = {}): FieldGroup[] {
+  const meta: FieldDef[] = [
+    { name: 'title', label: 'Title', value: d.title },
+    { name: 'date', label: 'Date (YYYY-MM-DD)', value: d.date },
+    {
+      name: 'tags',
+      label: 'Tags (comma-separated)',
+      value: Array.isArray(d.tags) ? (d.tags as string[]).join(', ') : d.tags ?? '',
+    },
+    {
+      name: 'description',
+      label: 'Description',
+      type: 'textarea',
+      rows: 3,
+      value: d.description,
+    },
+  ];
+  if (type === 'project') {
+    meta.push({ name: 'link', label: 'External link (URL)', value: d.link });
+  }
+  meta.push({ name: 'featured', label: 'Featured', type: 'checkbox', value: d.featured });
+  if (type === 'writing') {
+    meta.push({ name: 'draft', label: 'Draft (hidden on site)', type: 'checkbox', value: d.draft });
+  }
+  const contentFields: FieldDef[] = [
+    { name: 'body', label: 'Body (Markdown)', type: 'textarea', rows: 14, value: d._body },
+  ];
+  const mediaFields: FieldDef[] = [
+    {
+      name: 'image',
+      label: 'Image path',
+      value: d.image,
+      uploadCollection: type === 'project' ? 'projects' : 'writing',
+    },
+  ];
+  return [
+    { label: 'Metadata', fields: meta },
+    { label: 'Content', fields: contentFields },
+    { label: 'Media', fields: mediaFields },
+  ];
+}
+
+function initDrawer(
+  api: ReturnType<typeof createContentApi>,
+  toastEl: HTMLElement,
+  onSaved: () => void,
+): void {
+  const drawer = document.getElementById('adm-drawer')!;
+  const backdrop = document.getElementById('adm-drawer-backdrop')!;
+  const fieldsEl = document.getElementById('adm-drawer-fields')!;
+  const titleEl = document.getElementById('adm-drawer-title')!;
+  const subtitleEl = document.getElementById('adm-drawer-subtitle')!;
+  const saveBtn = document.getElementById('adm-drawer-save') as HTMLButtonElement;
+  const cancelBtn = document.getElementById('adm-drawer-cancel')!;
+  const closeBtn = document.getElementById('adm-drawer-close')!;
+  const delBtn = document.getElementById('adm-drawer-delete') as HTMLButtonElement;
+
+  let onSave: ((vals: Record<string, unknown>) => Promise<void>) | null = null;
+  let onDelete: (() => Promise<void>) | null = null;
+  let triggerEl: HTMLElement | null = null;
+
+  function close(): void {
+    drawer.classList.remove('adm-drawer--open');
+    backdrop.classList.remove('adm-drawer-backdrop--open');
+    document.body.style.overflow = '';
+    drawer.setAttribute('inert', '');
+    triggerEl?.focus();
+    triggerEl = null;
+    onSave = null;
+    onDelete = null;
+  }
+
+  function open(): void {
+    triggerEl = document.activeElement as HTMLElement | null;
+    drawer.removeAttribute('inert');
+    drawer.classList.add('adm-drawer--open');
+    backdrop.classList.add('adm-drawer-backdrop--open');
+    document.body.style.overflow = 'hidden';
+    const first = drawer.querySelector<HTMLElement>('button, [href], input, textarea, select');
+    (first ?? closeBtn).focus();
+  }
+
+  saveBtn.addEventListener('click', async () => {
+    if (!onSave) return;
+    saveBtn.disabled = true;
+    saveBtn.textContent = 'Saving…';
+    try {
+      await onSave(readDrawerForm(fieldsEl));
+      showToast(toastEl, 'Saved');
+      close();
+      onSaved();
+    } catch (e: unknown) {
+      showToast(toastEl, (e as Error).message, true);
+    } finally {
+      saveBtn.disabled = false;
+      saveBtn.textContent = 'Save';
+    }
+  });
+
+  delBtn.addEventListener('click', async () => {
+    if (!onDelete) return;
+    if (!confirm('Delete this entry? This cannot be undone.')) return;
+    delBtn.disabled = true;
+    try {
+      await onDelete();
+      showToast(toastEl, 'Deleted');
+      close();
+      onSaved();
+    } catch (e: unknown) {
+      showToast(toastEl, (e as Error).message, true);
+    } finally {
+      delBtn.disabled = false;
+    }
+  });
+
+  for (const el of [cancelBtn, closeBtn, backdrop]) el.addEventListener('click', close);
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && drawer.classList.contains('adm-drawer--open')) close();
+  });
+
+  function openModal(opts: {
+    title: string;
+    subtitle?: string;
+    fields?: FieldDef[];
+    groups?: FieldGroup[];
+    onSave: (vals: Record<string, unknown>) => Promise<void>;
+    onDelete?: () => Promise<void>;
+  }): void {
+    titleEl.textContent = opts.title;
+    subtitleEl.textContent = opts.subtitle ?? '';
+    subtitleEl.style.display = opts.subtitle ? '' : 'none';
+    fieldsEl.innerHTML = opts.groups ? renderGroupedFields(opts.groups) : renderFields(opts.fields ?? []);
+    saveBtn.disabled = false;
+    saveBtn.textContent = 'Save';
+    delBtn.hidden = !opts.onDelete;
+    delBtn.disabled = false;
+    onSave = opts.onSave;
+    onDelete = opts.onDelete ?? null;
+    initImageUploadFields(fieldsEl, api, toastEl);
+    fieldsEl.scrollTop = 0;
+    open();
+  }
+
+  async function openMarkdownEditor(slug: string | null, type: 'project' | 'writing'): Promise<void> {
+    let existing: Record<string, unknown> = {};
+    let pathForDelete: string | null = null;
+    if (slug) {
+      pathForDelete = collectionMdPath(type, slug);
+      try {
+        const { content } = await api.getText(pathForDelete);
+        const { data, body } = yamlFrontmatter.parse(content);
+        existing = { ...data, _body: body };
+      } catch (e: unknown) {
+        showToast(toastEl, (e as Error).message, true);
+        return;
+      }
+    }
+    const typeLabel = type === 'project' ? 'Project' : 'Essay';
+    const dir = type === 'project' ? 'projects' : 'writing';
+    openModal({
+      title: slug ? `Edit ${typeLabel}` : `New ${typeLabel}`,
+      subtitle: slug ? `content/${dir}/${slug}.md` : `content/${dir}/…`,
+      groups: markdownGroups(type, existing),
+      onSave: async (vals) => {
+        const title = (vals.title as string).trim();
+        if (!title) throw new Error('Title is required');
+        const tags = (vals.tags as string)
+          .split(',')
+          .map((t) => t.trim())
+          .filter(Boolean);
+        const fmData: Record<string, unknown> = {
+          title,
+          description: vals.description || undefined,
+          date: vals.date || new Date().toISOString().slice(0, 10),
+          tags,
+          image: vals.image || undefined,
+          featured: !!vals.featured,
+        };
+        if (type === 'project' && vals.link) fmData.link = vals.link;
+        if (type === 'writing') fmData.draft = !!vals.draft;
+        const fileContent = yamlFrontmatter.stringify(fmData, (vals.body as string) || '');
+        const targetSlug = slug ?? slugify(title);
+        const verb = slug ? 'update' : 'add';
+        const label = type === 'project' ? 'project' : 'essay';
+        await api.putText(
+          collectionMdPath(type, targetSlug),
+          fileContent,
+          `admin-tools: ${verb} ${label} "${title}"`,
+        );
+      },
+      onDelete:
+        slug && pathForDelete
+          ? async () => {
+              await api.remove(pathForDelete!, `admin-tools: delete ${type} "${slug}"`);
+            }
+          : undefined,
+    });
+  }
+
+  async function openTestimonialEditor(slug: string | null): Promise<void> {
+    let data: Record<string, unknown> = {};
+    let path: string | null = null;
+    if (slug) {
+      path = testimonialPath(slug);
+      try {
+        const { content } = await api.getText(path);
+        data = JSON.parse(content) as Record<string, unknown>;
+      } catch (e: unknown) {
+        showToast(toastEl, (e as Error).message, true);
+        return;
+      }
+    }
+    openModal({
+      title: slug ? 'Edit testimonial' : 'New testimonial',
+      subtitle: slug ? `content/testimonials/${slug}.json` : 'content/testimonials/…',
+      fields: [
+        { name: 'author', label: 'Author', value: data.author },
+        { name: 'role', label: 'Role / title', value: data.role },
+        { name: 'quote', label: 'Quote', type: 'textarea', rows: 5, value: data.quote },
+        { name: 'featured', label: 'Featured', type: 'checkbox', value: data.featured },
+      ],
+      onSave: async (vals) => {
+        const author = (vals.author as string).trim();
+        if (!author) throw new Error('Author is required');
+        const payload = {
+          author,
+          role: (vals.role as string)?.trim() || '',
+          quote: (vals.quote as string).trim(),
+          featured: !!vals.featured,
+        };
+        const targetSlug = slug ?? slugify(author);
+        const verb = slug ? 'update' : 'add';
+        await api.putText(
+          testimonialPath(targetSlug),
+          `${JSON.stringify(payload, null, 2)}\n`,
+          `admin-tools: ${verb} testimonial from "${author}"`,
+        );
+      },
+      onDelete:
+        slug && path
+          ? async () => {
+              await api.remove(path!, `admin-tools: delete testimonial "${slug}"`);
+            }
+          : undefined,
+    });
+  }
+
+  document.querySelectorAll<HTMLElement>('[data-admin-edit]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const kind = btn.dataset.adminEdit;
+      const slug = btn.dataset.slug ?? '';
+      if (kind === 'project') void openMarkdownEditor(slug || null, 'project');
+      else if (kind === 'writing') void openMarkdownEditor(slug || null, 'writing');
+      else if (kind === 'testimonial') void openTestimonialEditor(slug || null);
+    });
+  });
+
+  document.querySelectorAll<HTMLElement>('[data-admin-new]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const kind = btn.dataset.adminNew;
+      if (kind === 'project') void openMarkdownEditor(null, 'project');
+      else if (kind === 'writing') void openMarkdownEditor(null, 'writing');
+      else if (kind === 'testimonial') void openTestimonialEditor(null);
+    });
+  });
+}
+
+function initSettingsEditor(
+  api: ReturnType<typeof createContentApi>,
+  toastEl: HTMLElement,
+  onSaved: () => void,
+): void {
+  const section = document.getElementById('settings');
+  if (!section || section.dataset.settingsAvailable !== 'true') return;
+
+  const displayEl = document.getElementById('adm-settings-display')!;
+  const formEl = document.getElementById('adm-settings-form') as HTMLFormElement;
+  const editBtn = document.getElementById('adm-settings-edit')!;
+  const cancelBtn = document.getElementById('adm-settings-cancel')!;
+
+  editBtn.addEventListener('click', async () => {
+    displayEl.hidden = true;
+    formEl.hidden = false;
+    try {
+      const [personRaw, siteRaw] = await Promise.all([api.getText(PERSON_PATH), api.getText(SITE_PATH)]);
+      const person = JSON.parse(personRaw.content) as Record<string, string>;
+      const site = JSON.parse(siteRaw.content) as Record<string, unknown>;
+      formEl.dataset.personJson = JSON.stringify(person);
+      formEl.dataset.siteJson = JSON.stringify(site);
+      const contact =
+        site.contact && typeof site.contact === 'object'
+          ? (site.contact as Record<string, string>)
+          : { heading: '', body: '' };
+      const flat: Record<string, string> = {
+        ...person,
+        title: String(site.title ?? ''),
+        tagline: String(site.tagline ?? ''),
+        description: String(site.description ?? ''),
+        bookingUrl: String(site.bookingUrl ?? ''),
+        contactHeading: String(contact.heading ?? ''),
+        contactBody: String(contact.body ?? ''),
+      };
+      for (const [k, v] of Object.entries(flat)) {
+        const el = formEl.querySelector<HTMLInputElement | HTMLTextAreaElement>(`[name="${k}"]`);
+        if (el) el.value = v ?? '';
+      }
+    } catch (e: unknown) {
+      showToast(toastEl, (e as Error).message, true);
+      displayEl.hidden = false;
+      formEl.hidden = true;
+    }
+  });
+
+  cancelBtn.addEventListener('click', () => {
+    displayEl.hidden = false;
+    formEl.hidden = true;
+  });
+
+  formEl.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const personData = JSON.parse(formEl.dataset.personJson ?? '{}') as Record<string, string>;
+    const siteData = JSON.parse(formEl.dataset.siteJson ?? '{}') as Record<string, unknown>;
+    const fd = new FormData(formEl);
+    for (const k of PERSON_FIELDS) personData[k] = String(fd.get(k) ?? '');
+    siteData.title = String(fd.get('title') ?? '');
+    siteData.tagline = String(fd.get('tagline') ?? '');
+    siteData.description = String(fd.get('description') ?? '');
+    const booking = String(fd.get('bookingUrl') ?? '').trim();
+    if (booking) siteData.bookingUrl = booking;
+    else delete siteData.bookingUrl;
+    const contact =
+      siteData.contact && typeof siteData.contact === 'object'
+        ? { ...(siteData.contact as Record<string, string>) }
+        : {};
+    contact.heading = String(fd.get('contactHeading') ?? '');
+    contact.body = String(fd.get('contactBody') ?? '');
+    siteData.contact = contact;
+
+    const submitBtn = formEl.querySelector<HTMLButtonElement>('[type="submit"]')!;
+    submitBtn.disabled = true;
+    submitBtn.textContent = 'Saving…';
+    try {
+      await api.putText(PERSON_PATH, `${JSON.stringify(personData, null, 2)}\n`, 'admin-tools: update profile');
+      await api.putText(SITE_PATH, `${JSON.stringify(siteData, null, 2)}\n`, 'admin-tools: update site config');
+      showToast(toastEl, 'Settings saved');
+      onSaved();
+    } catch (err: unknown) {
+      showToast(toastEl, (err as Error).message, true);
+    } finally {
+      submitBtn.disabled = false;
+      submitBtn.textContent = 'Save settings';
+    }
+  });
+}
+
+function initLegacyFileTools(contentApiUrl: string): void {
+  const api = createContentApi(contentApiUrl);
+  const fileInput = document.getElementById('adm-file') as HTMLInputElement | null;
+  const contentArea = document.getElementById('adm-content') as HTMLTextAreaElement | null;
+  const status = document.getElementById('adm-status');
+
+  document.getElementById('adm-load')?.addEventListener('click', async () => {
+    const file = fileInput?.value?.trim();
+    if (!file || !status) return;
+    status.textContent = 'Loading…';
+    try {
+      const { content } = await api.getText(file);
+      if (contentArea) contentArea.value = content;
+      status.textContent = `Loaded ${file}`;
+    } catch (e: unknown) {
+      status.textContent = `Load failed: ${(e as Error).message}`;
+    }
+  });
+
+  document.getElementById('adm-save')?.addEventListener('click', async () => {
+    const file = fileInput?.value?.trim();
+    if (!file || !status) return;
+    status.textContent = 'Saving…';
+    try {
+      await api.putText(file, contentArea?.value ?? '', `admin-tools: update ${file}`);
+      status.textContent = `Saved ${file}`;
+    } catch (e: unknown) {
+      status.textContent = `Save failed: ${(e as Error).message}`;
+    }
+  });
+
+  const dropzone = document.getElementById('adm-dropzone');
+  const uploadInput = document.getElementById('adm-upload-input') as HTMLInputElement | null;
+  const uploadList = document.getElementById('adm-upload-list');
+  const uploadStatus = document.getElementById('adm-upload-status');
+  const targetDirInput = document.getElementById('adm-target-dir') as HTMLInputElement | null;
+
+  const renderFiles = (files: FileList) => {
+    if (!uploadList) return;
+    uploadList.innerHTML = '';
+    [...files].forEach((f) => {
+      const li = document.createElement('li');
+      li.textContent = `${f.name} (${f.type || 'binary'}, ${f.size} bytes)`;
+      uploadList.appendChild(li);
+    });
+  };
+
+  const doUpload = async (fileList: FileList | null) => {
+    if (!fileList || fileList.length === 0) return;
+    renderFiles(fileList);
+    if (uploadStatus) uploadStatus.textContent = 'Uploading…';
+    const fd = new FormData();
+    const dir = targetDirInput?.value?.trim() || '';
+    fd.append('targetDir', dir);
+    [...fileList].forEach((f) => fd.append('files', f));
+    const res = await fetch(contentApiUrl, { method: 'POST', credentials: 'include', body: fd });
+    const data = (await res.json().catch(() => ({}))) as { saved?: string[]; error?: string };
+    if (uploadStatus)
+      uploadStatus.textContent = res.ok
+        ? `Uploaded: ${(data.saved || []).join(', ')}`
+        : `Upload failed: ${data.error || res.status}`;
+  };
+
+  dropzone?.addEventListener('click', () => uploadInput?.click());
+  uploadInput?.addEventListener('change', () => doUpload(uploadInput.files ?? null));
+  ['dragenter', 'dragover'].forEach((evt) =>
+    dropzone?.addEventListener(evt, (e) => {
+      e.preventDefault();
+      dropzone.classList.add('is-over');
+    }),
+  );
+  ['dragleave', 'drop'].forEach((evt) =>
+    dropzone?.addEventListener(evt, (e) => {
+      e.preventDefault();
+      dropzone.classList.remove('is-over');
+    }),
+  );
+  dropzone?.addEventListener('drop', (e) => {
+    const dt = e.dataTransfer;
+    if (!dt?.files) return;
+    void doUpload(dt.files);
+  });
+}
+
+export function initAdminApp(contentApiUrl: string): void {
+  const root = document.getElementById('admin-root');
+  if (!root) return;
+
+  const api = createContentApi(contentApiUrl);
+  const toastEl = document.getElementById('adm-toast')!;
+  const logoutBtn = document.getElementById('logout-btn') as HTMLButtonElement | null;
+
+  if (logoutBtn) initLogout(logoutBtn);
+  initTokenSwatches();
+
+  const reload = () => {
+    window.location.reload();
+  };
+
+  initDrawer(api, toastEl, reload);
+  initSettingsEditor(api, toastEl, reload);
+  initLegacyFileTools(contentApiUrl);
+}

--- a/packages/admin-tools/src/client/content-api.ts
+++ b/packages/admin-tools/src/client/content-api.ts
@@ -1,0 +1,44 @@
+export function createContentApi(baseUrl: string) {
+  async function getText(file: string): Promise<{ content: string }> {
+    const res = await fetch(`${baseUrl}?file=${encodeURIComponent(file)}`, { credentials: 'include' });
+    const data = (await res.json().catch(() => ({}))) as { content?: string; error?: string };
+    if (!res.ok) throw new Error(data.error ?? `Load failed (${res.status})`);
+    if (typeof data.content !== 'string') throw new Error('Unexpected response');
+    return { content: data.content };
+  }
+
+  async function putText(file: string, content: string, message: string): Promise<void> {
+    const res = await fetch(baseUrl, {
+      method: 'PUT',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ file, content, message }),
+    });
+    const data = (await res.json().catch(() => ({}))) as { error?: string };
+    if (!res.ok) throw new Error(data.error ?? `Save failed (${res.status})`);
+  }
+
+  async function putBase64(file: string, base64: string, message: string): Promise<void> {
+    const res = await fetch(baseUrl, {
+      method: 'PUT',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ file, content: base64, message, base64: true }),
+    });
+    const data = (await res.json().catch(() => ({}))) as { error?: string };
+    if (!res.ok) throw new Error(data.error ?? `Upload failed (${res.status})`);
+  }
+
+  async function remove(file: string, message: string): Promise<void> {
+    const res = await fetch(baseUrl, {
+      method: 'DELETE',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ file, message }),
+    });
+    const data = (await res.json().catch(() => ({}))) as { error?: string };
+    if (!res.ok) throw new Error(data.error ?? `Delete failed (${res.status})`);
+  }
+
+  return { getText, putText, putBase64, remove };
+}

--- a/packages/admin-tools/src/client/yaml-frontmatter.ts
+++ b/packages/admin-tools/src/client/yaml-frontmatter.ts
@@ -1,0 +1,92 @@
+/** YAML frontmatter subset used by portfolio content collections. */
+
+function unquoteYaml(s: string): string {
+  if (s.startsWith('"')) {
+    try {
+      return JSON.parse(s) as string;
+    } catch {
+      return s.slice(1, -1);
+    }
+  }
+  if (s.startsWith("'")) {
+    return s.slice(1, -1).replace(/''/g, "'");
+  }
+  return s;
+}
+
+export const yamlFrontmatter = {
+  parse(raw: string): { data: Record<string, unknown>; body: string } {
+    const m = raw.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)([\s\S]*)/);
+    if (!m) return { data: {}, body: raw };
+    const data: Record<string, unknown> = {};
+    const lines = m[1].split('\n');
+    let i = 0;
+    while (i < lines.length) {
+      const line = lines[i];
+      if (!line.trim()) {
+        i++;
+        continue;
+      }
+
+      const bsKey = line.match(/^(\w[\w-]*):\s*[>|]/)?.[1];
+      if (bsKey) {
+        const parts: string[] = [];
+        i++;
+        while (i < lines.length && /^\s/.test(lines[i])) {
+          parts.push(lines[i].trim());
+          i++;
+        }
+        data[bsKey] = parts.join(' ');
+        continue;
+      }
+
+      const colonIdx = line.indexOf(':');
+      if (colonIdx === -1) {
+        i++;
+        continue;
+      }
+      const key = line.slice(0, colonIdx).trim();
+      const rest = line.slice(colonIdx + 1).trim();
+
+      if (rest === '' || rest === '[]') {
+        const items: string[] = [];
+        i++;
+        while (i < lines.length && /^\s*-/.test(lines[i])) {
+          const rawItem = lines[i].replace(/^\s*-\s*/, '').trim();
+          items.push(unquoteYaml(rawItem));
+          i++;
+        }
+        data[key] = items;
+        continue;
+      }
+
+      if (rest === 'true') data[key] = true;
+      else if (rest === 'false') data[key] = false;
+      else data[key] = unquoteYaml(rest);
+      i++;
+    }
+    return { data, body: (m[2] ?? '').trimStart() };
+  },
+
+  stringify(data: Record<string, unknown>, body: string): string {
+    let yaml = '---\n';
+    for (const [key, val] of Object.entries(data)) {
+      if (val === undefined || val === null || val === '') continue;
+      if (Array.isArray(val)) {
+        if ((val as unknown[]).length === 0) {
+          yaml += `${key}: []\n`;
+          continue;
+        }
+        yaml += `${key}:\n`;
+        for (const item of val as string[]) yaml += `  - ${JSON.stringify(String(item))}\n`;
+      } else if (typeof val === 'boolean') {
+        yaml += `${key}: ${val}\n`;
+      } else {
+        yaml += `${key}: ${JSON.stringify(String(val))}\n`;
+      }
+    }
+    yaml += '---\n';
+    if (body.trim()) yaml += `\n${body.trimEnd()}\n`;
+    return yaml;
+  },
+};

--- a/packages/admin-tools/src/lib/design-token-groups.ts
+++ b/packages/admin-tools/src/lib/design-token-groups.ts
@@ -1,0 +1,75 @@
+/**
+ * Grouped CSS custom properties for the editorial palette (labels + usage copy for the admin UI).
+ * Variable names match `design-tokens.css` in `@portfolio-engine/editorial-theme` — keep names in sync.
+ */
+export type DesignToken = { cssVar: string; label: string; usage: string };
+
+export type DesignTokenGroup = { id: string; title: string; tokens: DesignToken[] };
+
+export const EDITORIAL_THEME_TOKEN_GROUPS: DesignTokenGroup[] = [
+  {
+    id: 'primary',
+    title: 'Primary colors',
+    tokens: [
+      {
+        cssVar: '--ink',
+        label: 'Ink',
+        usage: 'Headings, primary text, primary buttons, key UI emphasis',
+      },
+      {
+        cssVar: '--copper',
+        label: 'Accent',
+        usage: 'Links, eyebrow labels, featured badges, primary interactive highlights',
+      },
+    ],
+  },
+  {
+    id: 'secondary',
+    title: 'Secondary text & warmth',
+    tokens: [
+      {
+        cssVar: '--stone-soft',
+        label: 'Muted text',
+        usage: 'Supporting copy, captions, dates, metadata, navigation hints',
+      },
+      {
+        cssVar: '--clay',
+        label: 'Clay',
+        usage: 'Warmer hover states and secondary accent next to copper',
+      },
+      {
+        cssVar: '--olive',
+        label: 'Olive',
+        usage: 'Tags, subtle decorative accents, secondary labels',
+      },
+    ],
+  },
+  {
+    id: 'surfaces',
+    title: 'Surfaces & backgrounds',
+    tokens: [
+      { cssVar: '--paper', label: 'Paper', usage: 'Default page background' },
+      {
+        cssVar: '--paper-light',
+        label: 'Paper light',
+        usage: 'Cards, inset panels, elevated sections',
+      },
+      {
+        cssVar: '--pale-sand',
+        label: 'Pale sand',
+        usage: 'Soft section fills (e.g. testimonials, callouts)',
+      },
+    ],
+  },
+  {
+    id: 'structure',
+    title: 'Borders & dividers',
+    tokens: [
+      {
+        cssVar: '--warm-line',
+        label: 'Warm line',
+        usage: 'Borders, dividers, table rules, card outlines',
+      },
+    ],
+  },
+];

--- a/packages/admin-tools/src/routes/admin.astro
+++ b/packages/admin-tools/src/routes/admin.astro
@@ -1,17 +1,24 @@
 ---
 export const prerender = false;
 
+import '@portfolio-engine/editorial-theme/styles/global.css';
+import ThemeTypographyOverrides from '@portfolio-engine/editorial-theme/components/ThemeTypographyOverrides.astro';
+import { EDITORIAL_GOOGLE_FONTS_STYLESHEET_HREF } from '@portfolio-engine/editorial-theme';
 import { getCollection } from 'astro:content';
 import { config } from '@portfolio-engine:config';
 import { routes } from '@portfolio-engine:routes';
 import SiteMapTree from '../components/SiteMapTree.astro';
 import { parseCookies, verifySession } from '../server/session.js';
 import { siteHomeUrl, sitePathUrl } from '../server/paths.js';
+import { EDITORIAL_THEME_TOKEN_GROUPS } from '../lib/design-token-groups.js';
 
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
-interface DirAudit { exists: boolean; files: string[]; }
+interface DirAudit {
+  exists: boolean;
+  files: string[];
+}
 async function listFilesSafe(relativeDir: string): Promise<DirAudit> {
   const root = process.cwd();
   const start = path.join(root, relativeDir);
@@ -88,9 +95,21 @@ const projectsSorted = [...projects].sort(
   (a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime(),
 );
 
+function formatShort(d: Date): string {
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
 const logoutUrl = sitePathUrl(Astro.request, 'api/auth/logout');
 const homeUrl = siteHomeUrl(Astro.request);
 const contentApiUrl = sitePathUrl(Astro.request, 'api/content');
+
+const personOnDisk = await readJsonSafe('src/content/profile/person.json');
+const siteOnDisk = await readJsonSafe('src/config/site.json');
+const settingsAvailable =
+  personOnDisk !== null &&
+  siteOnDisk !== null &&
+  typeof personOnDisk['name'] === 'string' &&
+  typeof siteOnDisk['title'] === 'string';
 
 const configAudit = await listFilesSafe('src/config');
 const contentAudit = await listFilesSafe('src/content');
@@ -107,6 +126,8 @@ const missingAreas = [
   !registryAudit.exists && 'src/registry',
   !hasManifest && '.portfolio-engine/manifest.json',
 ].filter(Boolean);
+
+const themeColorsJson = JSON.stringify(config.theme?.colors ?? {});
 ---
 
 <!doctype html>
@@ -116,222 +137,489 @@ const missingAreas = [
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="robots" content="noindex,nofollow" />
     <title>Admin — Site overview</title>
-    <style is:global>
-      :root {
-        --adm-ink: #0f172a;
-        --adm-muted: #64748b;
-        --adm-border: #e2e8f0;
-        --adm-paper: #ffffff;
-        --adm-paper-2: #f8fafc;
-        --adm-accent: #b45309;
-      }
-      body {
-        margin: 0;
-        font-family:
-          ui-sans-serif,
-          system-ui,
-          sans-serif;
-        background: var(--adm-paper-2);
-        color: var(--adm-ink);
-        line-height: 1.5;
-      }
-    </style>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href={EDITORIAL_GOOGLE_FONTS_STYLESHEET_HREF} rel="stylesheet" />
   </head>
-  <body>
-    <div class="adm-wrap">
-      <header class="adm-header">
-        <p class="adm-kicker">Private</p>
-        <h1 class="adm-h1">Site overview</h1>
-        <p class="adm-lead">
-          {config.site.title} — design, routes, and content at a glance (read-only for now).
-        </p>
-        <button
-          type="button"
-          id="logout-btn"
-          class="adm-logout"
-          data-logout-url={logoutUrl}
-          data-home-url={homeUrl}>Log out</button>
-      </header>
+  <body class="admin-shell">
+    <ThemeTypographyOverrides />
+    <script type="application/json" id="admin-token-json" set:html={JSON.stringify(EDITORIAL_THEME_TOKEN_GROUPS)} />
 
-      {
-        devBypass && (
-          <p class="adm-banner">
-            Dev bypass mode: local file writes enabled. Configure GitHub OAuth and <code>SESSION_SECRET</code> for full
-            sign-in. In production, set <code>ADMIN_TOOLS_GITHUB_REPO_OWNER</code> and{' '}
-            <code>ADMIN_TOOLS_GITHUB_REPO_NAME</code> for collaborator checks.
+    <div id="admin-root" data-content-api={contentApiUrl} data-theme-colors={themeColorsJson}>
+      <div class="adm-wrap">
+        <header class="adm-header">
+          <p class="adm-kicker">Private</p>
+          <h1 class="adm-h1">Site overview</h1>
+          <p class="adm-lead">
+            {config.site.title} — design tokens, content, and structure in one place.
           </p>
-        )
-      }
+          <button
+            type="button"
+            id="logout-btn"
+            class="adm-logout"
+            data-logout-url={logoutUrl}
+            data-home-url={homeUrl}>Log out</button>
 
-      {
-        writing.length === 0 &&
-          projects.length === 0 &&
-          testimonials.length === 0 &&
-          profile.length === 0 && (
-            <p class="adm-banner adm-banner--info">
-              No content collections matched the default admin set (<code>writing</code>, <code>projects</code>,{' '}
-              <code>testimonials</code>, <code>profile</code>). Add them or customize this page for your site.
+          <nav class="adm-jump" aria-label="Page sections">
+            <a class="adm-jump-link" href="#design">Design</a>
+            <a class="adm-jump-link" href="#settings">Settings</a>
+            <a class="adm-jump-link" href="#content">Content</a>
+            <a class="adm-jump-link" href="#structure">Structure</a>
+            <a class="adm-jump-link" href="#audit">Audit</a>
+            <a class="adm-jump-link" href="#advanced">Advanced</a>
+          </nav>
+        </header>
+
+        {
+          devBypass && (
+            <p class="adm-banner">
+              Dev bypass mode: local file writes enabled. Configure GitHub OAuth and <code>SESSION_SECRET</code> for full
+              sign-in. In production, set <code>ADMIN_TOOLS_GITHUB_REPO_OWNER</code> and{' '}
+              <code>ADMIN_TOOLS_GITHUB_REPO_NAME</code> for collaborator checks.
             </p>
           )
-      }
+        }
 
-      <section class="adm-section">
-        <h2 class="adm-h2">Site</h2>
-        <div class="adm-card">
-          <dl class="adm-dl">
-            <div>
-              <dt class="adm-dt">Title</dt>
-              <dd class="adm-dd">{config.site.title}</dd>
+        {
+          writing.length === 0 &&
+            projects.length === 0 &&
+            testimonials.length === 0 &&
+            profile.length === 0 && (
+              <p class="adm-banner adm-banner--info">
+                No content collections matched the default admin set (<code>writing</code>, <code>projects</code>,{' '}
+                <code>testimonials</code>, <code>profile</code>). Add them or extend this page for your site.
+              </p>
+            )
+        }
+
+        <section class="adm-section" id="design">
+          <h2 class="adm-h2">Design</h2>
+          <p class="adm-section-lead">
+            Colors, fonts, and type scale come from the same <code>design-tokens.css</code> and <code>global.css</code> as
+            the public site (<code>@portfolio-engine/editorial-theme</code>). Swatches read live CSS variables; optional
+            <code>theme.json</code> colors and typography overrides apply here too.
+          </p>
+          <div id="admin-design-swatches"></div>
+
+          <div class="adm-subsection">
+            <h3 class="adm-h3">Typography</h3>
+            <p class="adm-muted">
+              Samples use the shared theme utility classes (serif/sans stacks, weights, and sizes) so this preview tracks
+              the live site. Heading font and root size can be tuned via <code>src/config/theme.json</code>.
+            </p>
+            <div class="admin-preview-typography-stack">
+              <div class="admin-preview-panel">
+                <p class="admin-preview-meta-spaced">font-serif — Cormorant Garamond</p>
+                <p class="admin-preview-serif-aa">Aa</p>
+                <p class="admin-preview-serif-title">Page heading — bold serif</p>
+                <p class="admin-preview-serif-italic">Page heading — italic serif</p>
+                <p class="admin-preview-serif-section">Section heading — regular serif</p>
+              </div>
+              <div class="admin-preview-panel">
+                <p class="admin-preview-meta-spaced">font-sans — Inter</p>
+                <p class="admin-preview-sans-aa">Aa</p>
+                <p class="admin-preview-sans-strong">Body text — semibold</p>
+                <p class="admin-preview-body">
+                  Body text — regular. This sample paragraph shows how reading text looks on the site using the sans stack
+                  at base size with relaxed line-height.
+                </p>
+                <p class="admin-preview-meta">Small text — labels, captions, metadata</p>
+                <p class="admin-preview-eyebrow">Eyebrow label — uppercase tracked</p>
+              </div>
+              <div class="admin-preview-panel">
+                <p class="admin-preview-interactive-label">Interactive samples</p>
+                <div class="admin-preview-actions">
+                  <span class="admin-preview-btn-primary">Primary button</span>
+                  <span class="admin-preview-btn-secondary">Secondary button</span>
+                  <span class="admin-preview-link">Text link →</span>
+                </div>
+              </div>
             </div>
-            <div>
-              <dt class="adm-dt">Description</dt>
-              <dd class="adm-dd">{config.site.description ?? '—'}</dd>
+          </div>
+        </section>
+
+        <section class="adm-section" id="settings" data-settings-available={settingsAvailable ? 'true' : 'false'}>
+          <h2 class="adm-h2">Settings</h2>
+          {
+            settingsAvailable ? (
+              <>
+                <p class="adm-section-lead">
+                  Profile fields live in <code>src/content/profile/person.json</code>. Site fields live in{' '}
+                  <code>src/config/site.json</code>.
+                </p>
+                <div class="adm-card adm-card--wide" id="adm-settings">
+                  <div id="adm-settings-display">
+                    <div class="adm-settings-head">
+                      <p class="adm-settings-kicker">Preview</p>
+                      <button type="button" class="adm-btn adm-btn--ghost" id="adm-settings-edit">
+                        Edit settings
+                      </button>
+                    </div>
+                    <div class="adm-settings-body">
+                      {
+                        typeof personOnDisk?.['photo'] === 'string' && personOnDisk['photo'] ? (
+                          <img
+                            src={String(personOnDisk['photo'])}
+                            alt=""
+                            class="adm-settings-photo"
+                            width="64"
+                            height="64"
+                          />
+                        ) : (
+                          <div class="adm-settings-photo-placeholder" aria-hidden="true" />
+                        )
+                      }
+                      <div class="adm-settings-copy">
+                        <p class="adm-settings-name">{String(personOnDisk?.['name'] ?? '')}</p>
+                        <p class="adm-settings-tagline">{config.site.tagline}</p>
+                        <p class="adm-settings-bio">{shortBio || String(personOnDisk?.['bio'] ?? '')}</p>
+                      </div>
+                    </div>
+                  </div>
+
+                  <form id="adm-settings-form" class="adm-settings-form" hidden>
+                    <div class="adm-settings-head">
+                      <p class="adm-settings-kicker">Editing</p>
+                      <div class="adm-settings-actions">
+                        <button type="button" class="adm-btn adm-btn--ghost" id="adm-settings-cancel">
+                          Cancel
+                        </button>
+                        <button type="submit" class="adm-btn adm-btn--primary">
+                          Save settings
+                        </button>
+                      </div>
+                    </div>
+                    <p class="adm-form-group-label">Profile</p>
+                    <div class="adm-form-grid">
+                      <label class="adm-label"
+                        >Name<input class="adm-input" name="name" type="text" /></label
+                      >
+                      <label class="adm-label"
+                        >Email<input class="adm-input" name="email" type="email" /></label
+                      >
+                      <label class="adm-label"
+                        >LinkedIn<input class="adm-input" name="linkedin" type="url" /></label
+                      >
+                      <label class="adm-label"
+                        >Instagram<input class="adm-input" name="instagram" type="url" /></label
+                      >
+                      <label class="adm-label adm-label--full"
+                        >Photo path<input class="adm-input" name="photo" type="text" placeholder="/media/portrait.jpg" /></label
+                      >
+                      <label class="adm-label adm-label--full"
+                        >Bio<textarea class="adm-input adm-textarea" name="bio" rows="4"></textarea></label
+                      >
+                    </div>
+                    <p class="adm-form-group-label">Site</p>
+                    <div class="adm-form-grid">
+                      <label class="adm-label adm-label--full"
+                        >Title<input class="adm-input" name="title" type="text" /></label
+                      >
+                      <label class="adm-label adm-label--full"
+                        >Tagline<input class="adm-input" name="tagline" type="text" /></label
+                      >
+                      <label class="adm-label adm-label--full"
+                        >Description<textarea class="adm-input adm-textarea" name="description" rows="3"></textarea></label
+                      >
+                      <label class="adm-label adm-label--full"
+                        >Booking URL<input class="adm-input" name="bookingUrl" type="url" placeholder="https://…" /></label
+                      >
+                      <label class="adm-label adm-label--full"
+                        >Contact heading<input class="adm-input" name="contactHeading" type="text" /></label
+                      >
+                      <label class="adm-label adm-label--full"
+                        >Contact body<textarea class="adm-input adm-textarea" name="contactBody" rows="3"></textarea></label
+                      >
+                    </div>
+                  </form>
+                </div>
+              </>
+            ) : (
+              <p class="adm-banner adm-banner--info">
+                Settings editor needs both <code>src/content/profile/person.json</code> and <code>src/config/site.json</code>.
+              </p>
+            )
+          }
+        </section>
+
+        <section class="adm-section" id="content">
+          <h2 class="adm-h2">Content</h2>
+          <p class="adm-section-lead">Edit entries in place. New items are saved to your content folders.</p>
+
+          <div class="adm-stat-row">
+            <div class="adm-stat">
+              <span class="adm-stat-num">{projects.length}</span>
+              <span class="adm-stat-label">Projects</span>
             </div>
-          </dl>
-        </div>
-      </section>
-
-      {
-        personEntry && 'name' in personEntry.data && (
-          <section class="adm-section">
-            <h2 class="adm-h2">Profile</h2>
-            <div class="adm-card">
-              <p class="adm-profile-name">{personEntry.data.name}</p>
-              <p class="adm-profile-bio">{shortBio}</p>
+            <div class="adm-stat">
+              <span class="adm-stat-num">{writing.length}</span>
+              <span class="adm-stat-label">Writing</span>
             </div>
-          </section>
-        )
-      }
-
-      <section class="adm-section">
-        <h2 class="adm-h2">Routes</h2>
-        <div class="adm-card adm-card--wide">
-          <SiteMapTree routes={routes} />
-        </div>
-      </section>
-
-
-      <section class="adm-section">
-        <h2 class="adm-h2">Admin tools audit</h2>
-        <div class="adm-card adm-card--wide">
-          <p class="adm-lead">Coverage of planned admin areas: config, content, context, assets, registry, and manifest.</p>
-          <ul class="adm-list">
-            <li>Config files: {configAudit.files.length}</li>
-            <li>Content files: {contentAudit.files.length}</li>
-            <li>Context files: {contextAudit.files.length}</li>
-            <li>Public assets: {publicAudit.files.length}</li>
-            <li>Registry files: {registryAudit.files.length}</li>
-            <li>Manifest detected: {hasManifest ? 'yes' : 'no'}</li>
-          </ul>
-          {missingAreas.length > 0 ? <p class="adm-banner adm-banner--info">Missing expected paths: {missingAreas.join(', ')}</p> : <p class="adm-profile-bio">No structural blockers detected.</p>}
-        </div>
-      </section>
-
-
-      <section class="adm-section" id="adm-editor-section" data-content-api-url={contentApiUrl}>
-        <h2 class="adm-h2">Content editor (MVP)</h2>
-        <div class="adm-card adm-card--wide">
-          <p class="adm-profile-bio">Read/write editor for files in src/content, src/config, src/context, src/registry, and public.</p>
-          <div class="adm-editor-row">
-            <input id="adm-file" class="adm-input" placeholder="src/content/writing/post.md" />
-            <button id="adm-load" class="adm-btn">Load</button>
-            <button id="adm-save" class="adm-btn adm-btn--primary">Save</button>
+            <div class="adm-stat">
+              <span class="adm-stat-num">{testimonials.length}</span>
+              <span class="adm-stat-label">Testimonials</span>
+            </div>
           </div>
-          <textarea id="adm-content" class="adm-textarea" spellcheck="false"></textarea>
-          <p id="adm-status" class="adm-profile-bio"></p>
-        </div>
-      </section>
 
-
-      <section class="adm-section">
-        <h2 class="adm-h2">Public assets uploader</h2>
-        <div class="adm-card adm-card--wide">
-          <p class="adm-profile-bio">Drag & drop files to upload into <code>public/</code>. Use a subfolder path if desired (example: <code>media/projects</code>).</p>
-          <div class="adm-editor-row">
-            <input id="adm-target-dir" class="adm-input" placeholder="media/uploads" />
+          <div class="adm-list-section">
+            <div class="adm-list-head">
+              <div>
+                <p class="adm-list-kicker">Projects</p>
+                <p class="adm-list-path">src/content/projects/</p>
+              </div>
+              <button type="button" class="adm-btn adm-btn--ghost" data-admin-new="project">
+                + New project
+              </button>
+            </div>
+            <div class="adm-card-list">
+              {
+                projectsSorted.map((p, i) => (
+                  <div class:list={['adm-card-row', i > 0 && 'adm-card-row--border']}>
+                    <div class="adm-card-main">
+                      <p class="adm-card-title">{p.data.title}</p>
+                      <div class="adm-card-meta">
+                        <span>{formatShort(p.data.date)}</span>
+                        {p.data.featured && <span class="adm-pill adm-pill--accent">Featured</span>}
+                        {p.data.tags?.map((tag) => <span class="adm-pill">{tag}</span>)}
+                      </div>
+                    </div>
+                    <button type="button" class="adm-btn adm-btn--ghost" data-admin-edit="project" data-slug={p.id}>
+                      Edit
+                    </button>
+                  </div>
+                ))
+              }
+            </div>
           </div>
-          <div id="adm-dropzone" class="adm-dropzone">Drop files here or click to choose files.</div>
-          <input id="adm-upload-input" type="file" multiple class="adm-hidden-input" />
-          <ul id="adm-upload-list" class="adm-list"></ul>
-          <p id="adm-upload-status" class="adm-profile-bio"></p>
-        </div>
-      </section>
 
-      <section class="adm-section">
-        <h2 class="adm-h2">Content</h2>
-        <div class="adm-grid">
-          <div class="adm-card">
-            <h3 class="adm-h3">Writing</h3>
-            <p class="adm-count">{writing.length}</p>
-            <ul class="adm-list">
-              {writingSorted.slice(0, 8).map((w) => <li>{w.data.title}</li>)}
-              {writing.length > 8 && <li>…</li>}
+          <div class="adm-list-section">
+            <div class="adm-list-head">
+              <div>
+                <p class="adm-list-kicker">Writing</p>
+                <p class="adm-list-path">src/content/writing/</p>
+              </div>
+              <button type="button" class="adm-btn adm-btn--ghost" data-admin-new="writing">
+                + New essay
+              </button>
+            </div>
+            <div class="adm-card-list">
+              {
+                writingSorted.map((w, i) => (
+                  <div
+                    class:list={['adm-card-row', i > 0 && 'adm-card-row--border', w.data.draft && 'adm-card-row--draft']}
+                  >
+                    <div class="adm-card-main">
+                      <p class="adm-card-title">{w.data.title}</p>
+                      <div class="adm-card-meta">
+                        <span>{formatShort(w.data.date)}</span>
+                        {w.data.draft && <span class="adm-pill adm-pill--warn">Draft</span>}
+                        {w.data.tags?.map((tag) => <span class="adm-pill">{tag}</span>)}
+                      </div>
+                    </div>
+                    <button type="button" class="adm-btn adm-btn--ghost" data-admin-edit="writing" data-slug={w.id}>
+                      Edit
+                    </button>
+                  </div>
+                ))
+              }
+            </div>
+          </div>
+
+          <div class="adm-list-section">
+            <div class="adm-list-head">
+              <div>
+                <p class="adm-list-kicker">Testimonials</p>
+                <p class="adm-list-path">src/content/testimonials/</p>
+              </div>
+              <button type="button" class="adm-btn adm-btn--ghost" data-admin-new="testimonial">
+                + New testimonial
+              </button>
+            </div>
+            <div class="adm-card-list">
+              {
+                testimonials.map((t, i) => (
+                  <div class:list={['adm-card-row', i > 0 && 'adm-card-row--border']}>
+                    <div class="adm-card-main">
+                      <p class="adm-card-title">{t.data.author}</p>
+                      <p class="adm-card-quote">
+                        “{t.data.quote.length > 140 ? t.data.quote.slice(0, 140).trimEnd() + '…' : t.data.quote}”
+                      </p>
+                      <div class="adm-card-meta">
+                        <span>{t.data.role}</span>
+                        {t.data.featured && <span class="adm-pill adm-pill--accent">Featured</span>}
+                      </div>
+                    </div>
+                    <button type="button" class="adm-btn adm-btn--ghost" data-admin-edit="testimonial" data-slug={t.id}>
+                      Edit
+                    </button>
+                  </div>
+                ))
+              }
+            </div>
+          </div>
+        </section>
+
+        <section class="adm-section" id="structure">
+          <h2 class="adm-h2">Structure</h2>
+          <p class="adm-section-lead">Theme routes and how they connect.</p>
+          <div class="adm-card adm-card--wide adm-card--scroll">
+            <SiteMapTree routes={routes} />
+          </div>
+        </section>
+
+        <section class="adm-section" id="audit">
+          <h2 class="adm-h2">Admin tools audit</h2>
+          <div class="adm-card adm-card--wide">
+            <p class="adm-section-lead">Coverage of planned admin areas: config, content, context, assets, registry, and manifest.</p>
+            <ul class="adm-inline-list">
+              <li>Config files: {configAudit.files.length}</li>
+              <li>Content files: {contentAudit.files.length}</li>
+              <li>Context files: {contextAudit.files.length}</li>
+              <li>Public assets: {publicAudit.files.length}</li>
+              <li>Registry files: {registryAudit.files.length}</li>
+              <li>Manifest detected: {hasManifest ? 'yes' : 'no'}</li>
             </ul>
+            {
+              missingAreas.length > 0 ? (
+                <p class="adm-banner adm-banner--info">Missing expected paths: {missingAreas.join(', ')}</p>
+              ) : (
+                <p class="adm-muted">No structural blockers detected.</p>
+              )
+            }
           </div>
-          <div class="adm-card">
-            <h3 class="adm-h3">Projects</h3>
-            <p class="adm-count">{projects.length}</p>
-            <ul class="adm-list">
-              {projectsSorted.slice(0, 8).map((p) => <li>{p.data.title}</li>)}
-              {projects.length > 8 && <li>…</li>}
-            </ul>
+        </section>
+
+        <section class="adm-section" id="advanced">
+          <h2 class="adm-h2">Advanced</h2>
+          <p class="adm-section-lead">Raw path editor and asset uploads for power users.</p>
+          <div class="adm-card adm-card--wide">
+            <h3 class="adm-h3">File editor</h3>
+            <p class="adm-muted">Edit any allowed path under content, config, context, registry, or public metadata.</p>
+            <div class="adm-editor-row">
+              <input id="adm-file" class="adm-input" placeholder="src/content/writing/post.md" />
+              <button type="button" id="adm-load" class="adm-btn adm-btn--ghost">
+                Load
+              </button>
+              <button type="button" id="adm-save" class="adm-btn adm-btn--primary">
+                Save
+              </button>
+            </div>
+            <textarea id="adm-content" class="adm-textarea" spellcheck="false"></textarea>
+            <p id="adm-status" class="adm-muted"></p>
           </div>
-          <div class="adm-card">
-            <h3 class="adm-h3">Testimonials</h3>
-            <p class="adm-count">{testimonials.length}</p>
-            <ul class="adm-list">
-              {testimonials.slice(0, 8).map((t) => <li>{t.data.author}</li>)}
-              {testimonials.length > 8 && <li>…</li>}
-            </ul>
+          <div class="adm-card adm-card--wide">
+            <h3 class="adm-h3">Public uploads</h3>
+            <p class="adm-muted">
+              Upload into <code>public/</code>. Optional subfolder (example: <code>media/projects</code>).
+            </p>
+            <div class="adm-editor-row">
+              <input id="adm-target-dir" class="adm-input" placeholder="media/uploads" />
+            </div>
+            <div id="adm-dropzone" class="adm-dropzone">Drop files here or click to choose files.</div>
+            <input id="adm-upload-input" type="file" multiple class="adm-hidden-input" />
+            <ul id="adm-upload-list" class="adm-upload-list"></ul>
+            <p id="adm-upload-status" class="adm-muted"></p>
           </div>
-        </div>
-      </section>
+        </section>
+      </div>
     </div>
+
+    <div id="adm-drawer-backdrop" class="adm-drawer-backdrop" aria-hidden="true"></div>
+    <div id="adm-drawer" class="adm-drawer" role="dialog" aria-modal="true" aria-labelledby="adm-drawer-title" inert>
+      <div class="adm-drawer-inner">
+        <header class="adm-drawer-head">
+          <div>
+            <h2 id="adm-drawer-title" class="adm-drawer-title"></h2>
+            <p id="adm-drawer-subtitle" class="adm-drawer-subtitle"></p>
+          </div>
+          <button type="button" id="adm-drawer-close" class="adm-icon-btn" aria-label="Close">
+            ×
+          </button>
+        </header>
+        <div id="adm-drawer-fields" class="adm-drawer-fields"></div>
+        <footer class="adm-drawer-foot">
+          <button type="button" id="adm-drawer-delete" class="adm-btn adm-btn--danger" hidden>
+            Delete
+          </button>
+          <div class="adm-drawer-foot-actions">
+            <button type="button" id="adm-drawer-cancel" class="adm-btn adm-btn--ghost">
+              Cancel
+            </button>
+            <button type="button" id="adm-drawer-save" class="adm-btn adm-btn--primary">
+              Save
+            </button>
+          </div>
+        </footer>
+      </div>
+    </div>
+
+    <div id="adm-toast" class="adm-toast" role="status" aria-live="polite"></div>
 
     <style>
       .adm-wrap {
-        max-width: 64rem;
+        max-width: 52rem;
         margin: 0 auto;
-        padding: 3rem 1.5rem 6rem;
+        padding: 2.5rem 1.25rem 5rem;
       }
       .adm-header {
-        margin-bottom: 3rem;
-        padding-bottom: 2rem;
-        border-bottom: 1px solid var(--adm-border);
+        margin-bottom: 2rem;
+        padding-bottom: 1.5rem;
+        border-bottom: 1px solid var(--warm-line);
       }
       .adm-kicker {
-        margin: 0 0 0.5rem;
+        margin: 0 0 0.35rem;
         font-size: 0.6875rem;
         font-weight: 600;
         letter-spacing: 0.2em;
         text-transform: uppercase;
-        color: var(--adm-accent);
+        color: var(--copper);
       }
       .adm-h1 {
         margin: 0;
-        font-size: 2.25rem;
+        font-size: 2rem;
         font-weight: 700;
         letter-spacing: -0.02em;
       }
       .adm-lead {
         margin: 0.5rem 0 0;
-        color: var(--adm-muted);
+        color: var(--stone-soft);
+        max-width: 40rem;
       }
       .adm-logout {
-        margin-top: 1rem;
+        margin-top: 0.75rem;
         padding: 0;
         border: none;
         background: none;
         font-size: 0.75rem;
-        color: var(--adm-muted);
+        color: var(--stone-soft);
         text-decoration: underline;
         cursor: pointer;
       }
       .adm-logout:hover {
-        color: var(--adm-ink);
+        color: var(--ink);
+      }
+      .adm-jump {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        margin-top: 1.25rem;
+      }
+      .adm-jump-link {
+        display: inline-block;
+        padding: 0.35rem 0.85rem;
+        border-radius: 999px;
+        border: 1px solid var(--warm-line);
+        background: var(--paper-light);
+        font-size: 0.75rem;
+        font-weight: 500;
+        color: var(--copper);
+        text-decoration: none;
+      }
+      .adm-jump-link:hover {
+        border-color: var(--copper);
       }
       .adm-banner {
-        margin-bottom: 2rem;
+        margin-bottom: 1.5rem;
         padding: 0.75rem 1rem;
         border: 1px solid #fde68a;
         border-radius: 0.5rem;
@@ -344,176 +632,581 @@ const missingAreas = [
         background: #f0f9ff;
         color: #0c4a6e;
       }
-      .adm-banner code {
-        padding: 0.1em 0.35em;
-        border-radius: 0.25rem;
-        background: #fef3c7;
-        font-size: 0.85em;
-      }
-      .adm-banner--info code {
-        background: #e0f2fe;
-      }
       .adm-section {
-        margin-bottom: 3.5rem;
+        margin-bottom: 3rem;
       }
       .adm-h2 {
-        margin: 0 0 1rem;
+        margin: 0 0 0.35rem;
         font-size: 0.6875rem;
         font-weight: 600;
         letter-spacing: 0.15em;
         text-transform: uppercase;
-        color: var(--adm-muted);
+        color: var(--stone-soft);
+      }
+      .adm-section-lead {
+        margin: 0 0 1rem;
+        font-size: 0.875rem;
+        color: var(--stone-soft);
+        max-width: 44rem;
       }
       .adm-h3 {
-        margin: 0;
-        font-size: 0.875rem;
+        margin: 0 0 0.5rem;
+        font-size: 0.9375rem;
         font-weight: 600;
       }
-      .adm-card {
-        border: 1px solid var(--adm-border);
+      .adm-muted {
+        margin: 0;
+        font-size: 0.8125rem;
+        color: var(--stone-soft);
+      }
+      .adm-subsection {
+        margin-top: 2rem;
+        padding: 1.25rem;
+        border: 1px solid var(--warm-line);
         border-radius: 0.75rem;
-        background: var(--adm-paper);
-        padding: 1.5rem;
-        box-shadow: 0 1px 2px rgb(15 23 42 / 0.04);
+        background: var(--paper-light);
       }
-      .adm-card--wide {
-        overflow-x: auto;
-        padding: 2rem;
+      .adm-token-group {
+        margin-bottom: 1.75rem;
       }
-      .adm-dl {
+      .adm-token-group-title {
+        margin: 0 0 0.75rem;
+        font-size: 1.05rem;
+        font-weight: 600;
+      }
+      .adm-token-file-hint {
+        margin: 0 0 0.75rem;
+        font-size: 0.8125rem;
+        color: var(--stone-soft);
+      }
+      .adm-token-grid {
         display: grid;
         gap: 0.75rem;
+        grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+      }
+      .adm-token-card {
+        border: 1px solid var(--warm-line);
+        border-radius: 0.65rem;
+        overflow: hidden;
+        background: var(--paper-light);
+      }
+      .adm-token-swatch {
+        height: 4.5rem;
+      }
+      .adm-token-meta {
+        padding: 0.65rem 0.75rem;
+      }
+      .adm-token-label {
         margin: 0;
-        font-size: 0.875rem;
-      }
-      @media (min-width: 640px) {
-        .adm-dl {
-          grid-template-columns: 1fr 1fr;
-        }
-      }
-      .adm-dt {
-        margin: 0;
-        color: var(--adm-muted);
-        font-size: 0.875rem;
-      }
-      .adm-dd {
-        margin: 0.25rem 0 0;
-        font-weight: 500;
-      }
-      .adm-profile-name {
-        margin: 0;
-        font-size: 1.125rem;
+        font-size: 0.8125rem;
         font-weight: 600;
       }
-      .adm-profile-bio {
+      .adm-token-value,
+      .adm-token-var {
+        margin: 0.2rem 0 0;
+        font-size: 0.7rem;
+        font-family: ui-monospace, monospace;
+        color: var(--stone-soft);
+      }
+      .adm-token-usage {
+        margin: 0.45rem 0 0;
+        font-size: 0.72rem;
+        color: var(--stone-soft);
+        line-height: 1.35;
+      }
+      .adm-card {
+        border: 1px solid var(--warm-line);
+        border-radius: 0.75rem;
+        background: var(--paper-light);
+        padding: 1.25rem;
+        box-shadow: 0 1px 2px rgb(30 26 23 / 0.04);
+      }
+      .adm-card--wide {
+        padding: 1.5rem;
+      }
+      .adm-card--scroll {
+        overflow-x: auto;
+      }
+      .adm-settings-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+        margin-bottom: 1rem;
+      }
+      .adm-settings-kicker {
+        margin: 0;
+        font-size: 0.65rem;
+        font-weight: 600;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--stone-soft);
+      }
+      .adm-settings-body {
+        display: flex;
+        gap: 1rem;
+        align-items: flex-start;
+      }
+      .adm-settings-photo {
+        width: 4rem;
+        height: 4rem;
+        border-radius: 999px;
+        object-fit: cover;
+        border: 1px solid var(--warm-line);
+      }
+      .adm-settings-photo-placeholder {
+        width: 4rem;
+        height: 4rem;
+        border-radius: 999px;
+        background: var(--pale-sand);
+        border: 1px dashed var(--warm-line);
+        flex-shrink: 0;
+      }
+      .adm-settings-name {
+        margin: 0;
+        font-size: 1.15rem;
+        font-weight: 600;
+      }
+      .adm-settings-tagline {
+        margin: 0.15rem 0 0;
+        font-size: 0.875rem;
+        color: var(--stone-soft);
+      }
+      .adm-settings-bio {
         margin: 0.5rem 0 0;
         font-size: 0.875rem;
-        color: var(--adm-muted);
+        color: var(--stone-soft);
+        line-height: 1.45;
       }
-      .adm-grid {
+      .adm-settings-form {
+        margin-top: 0.5rem;
+      }
+      .adm-form-group-label {
+        margin: 1.25rem 0 0.5rem;
+        font-size: 0.65rem;
+        font-weight: 600;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--stone-soft);
+      }
+      .adm-form-grid {
         display: grid;
-        gap: 1.5rem;
+        gap: 0.65rem;
+        grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
       }
-      @media (min-width: 768px) {
-        .adm-grid {
-          grid-template-columns: repeat(3, 1fr);
-        }
+      .adm-label {
+        display: flex;
+        flex-direction: column;
+        font-size: 0.78rem;
+        font-weight: 500;
+        gap: 0.25rem;
       }
-      .adm-count {
-        margin: 0.25rem 0 0;
+      .adm-label--full {
+        grid-column: 1 / -1;
+      }
+      .adm-settings-actions {
+        display: flex;
+        gap: 0.5rem;
+      }
+      .adm-stat-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.65rem;
+        margin-bottom: 1.5rem;
+      }
+      .adm-stat {
+        display: flex;
+        align-items: baseline;
+        gap: 0.5rem;
+        padding: 0.5rem 1rem;
+        border-radius: 999px;
+        border: 1px solid var(--warm-line);
+        background: var(--paper-light);
+      }
+      .adm-stat-num {
+        font-family: ui-serif, Georgia, serif;
         font-size: 1.5rem;
         font-weight: 700;
       }
-      .adm-editor-row { display:flex; gap:.5rem; margin:.75rem 0; flex-wrap:wrap; }
-      .adm-input { flex:1; min-width:20rem; border:1px solid var(--adm-border); border-radius:.5rem; padding:.5rem .65rem; }
-      .adm-btn { border:1px solid var(--adm-border); border-radius:.5rem; background:#fff; padding:.45rem .75rem; cursor:pointer; }
-      .adm-btn--primary { background:#0f172a; color:#fff; border-color:#0f172a; }
-      .adm-textarea { width:100%; min-height:18rem; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size:.8rem; border:1px solid var(--adm-border); border-radius:.5rem; padding:.75rem; }
-      .adm-dropzone { border:2px dashed var(--adm-border); border-radius:.75rem; padding:1.25rem; text-align:center; color:var(--adm-muted); cursor:pointer; margin:.5rem 0; }
-      .adm-dropzone.is-over { border-color:#0f172a; color:#0f172a; background:#f8fafc; }
-      .adm-hidden-input { display:none; }
-      .adm-list {
-        margin: 0.75rem 0 0;
-        padding-left: 1.1rem;
-        max-height: 10rem;
-        overflow-y: auto;
+      .adm-stat-label {
+        font-size: 0.8125rem;
+        color: var(--stone-soft);
+      }
+      .adm-list-section {
+        margin-bottom: 2rem;
+      }
+      .adm-list-head {
+        display: flex;
+        align-items: flex-end;
+        justify-content: space-between;
+        gap: 0.75rem;
+        margin-bottom: 0.65rem;
+      }
+      .adm-list-kicker {
+        margin: 0;
+        font-size: 0.65rem;
+        font-weight: 600;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--stone-soft);
+      }
+      .adm-list-path {
+        margin: 0.15rem 0 0;
         font-size: 0.75rem;
-        color: var(--adm-muted);
+        font-family: ui-monospace, monospace;
+        color: var(--stone-soft);
+      }
+      .adm-card-list {
+        border: 1px solid var(--warm-line);
+        border-radius: 0.75rem;
+        overflow: hidden;
+        background: var(--paper-light);
+      }
+      .adm-card-row {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        padding: 0.9rem 1rem;
+      }
+      .adm-card-row--border {
+        border-top: 1px solid var(--warm-line);
+      }
+      .adm-card-row--draft {
+        background: rgb(255 251 235 / 0.5);
+      }
+      .adm-card-main {
+        flex: 1;
+        min-width: 0;
+      }
+      .adm-card-title {
+        margin: 0;
+        font-weight: 600;
+        font-size: 0.9375rem;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .adm-card-quote {
+        margin: 0.35rem 0 0;
+        font-size: 0.8125rem;
+        color: var(--stone-soft);
+        line-height: 1.4;
+      }
+      .adm-card-meta {
+        margin-top: 0.35rem;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.35rem;
+        align-items: center;
+        font-size: 0.72rem;
+        color: var(--stone-soft);
+      }
+      .adm-pill {
+        display: inline-block;
+        padding: 0.12rem 0.45rem;
+        border-radius: 999px;
+        border: 1px solid var(--warm-line);
+        background: var(--paper);
+        font-size: 0.68rem;
+      }
+      .adm-pill--accent {
+        background: var(--copper);
+        color: #fff;
+        border-color: var(--copper);
+      }
+      .adm-pill--warn {
+        border-color: #fbbf24;
+        background: #fffbeb;
+        color: #92400e;
+      }
+      .adm-btn {
+        border-radius: 0.5rem;
+        border: 1px solid var(--warm-line);
+        background: var(--paper-light);
+        padding: 0.4rem 0.85rem;
+        font-size: 0.8125rem;
+        font-weight: 500;
+        cursor: pointer;
+        color: var(--ink);
+      }
+      .adm-btn--primary {
+        background: var(--ink);
+        color: #fff;
+        border-color: var(--ink);
+      }
+      .adm-btn--ghost {
+        background: transparent;
+        color: var(--copper);
+        border-color: var(--warm-line);
+      }
+      .adm-btn--danger {
+        border-color: #fecaca;
+        color: #b91c1c;
+        background: #fff;
+      }
+      .adm-btn--danger:hover {
+        background: #fef2f2;
+      }
+      .adm-inline-list {
+        margin: 0.5rem 0 0;
+        padding-left: 1.1rem;
+        font-size: 0.875rem;
+        color: var(--stone-soft);
+      }
+      .adm-editor-row {
+        display: flex;
+        gap: 0.5rem;
+        margin: 0.65rem 0;
+        flex-wrap: wrap;
+      }
+      .adm-input {
+        flex: 1;
+        min-width: 12rem;
+        border: 1px solid var(--warm-line);
+        border-radius: 0.5rem;
+        padding: 0.45rem 0.6rem;
+        font: inherit;
+      }
+      .adm-textarea {
+        width: 100%;
+        min-height: 14rem;
+        font-family: ui-monospace, monospace;
+        font-size: 0.8rem;
+        border: 1px solid var(--warm-line);
+        border-radius: 0.5rem;
+        padding: 0.65rem;
+      }
+      .adm-dropzone {
+        border: 2px dashed var(--warm-line);
+        border-radius: 0.75rem;
+        padding: 1.1rem;
+        text-align: center;
+        color: var(--stone-soft);
+        cursor: pointer;
+      }
+      .adm-dropzone.is-over {
+        border-color: var(--copper);
+        color: var(--copper);
+        background: var(--paper);
+      }
+      .adm-hidden-input {
+        display: none;
+      }
+      .adm-upload-list {
+        margin: 0.5rem 0 0;
+        padding-left: 1.1rem;
+        font-size: 0.75rem;
+        color: var(--stone-soft);
+      }
+
+      .adm-drawer-backdrop {
+        position: fixed;
+        inset: 0;
+        background: rgb(0 0 0 / 0.35);
+        z-index: 40;
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.2s ease;
+      }
+      .adm-drawer-backdrop--open {
+        opacity: 1;
+        pointer-events: auto;
+      }
+      .adm-drawer {
+        position: fixed;
+        top: 0;
+        right: 0;
+        height: 100vh;
+        width: min(36rem, 100vw);
+        z-index: 50;
+        background: var(--paper-light);
+        box-shadow: -4px 0 24px rgb(0 0 0 / 0.08);
+        transform: translateX(100%);
+        transition: transform 0.25s ease;
+        display: flex;
+        flex-direction: column;
+      }
+      .adm-drawer--open {
+        transform: translateX(0);
+      }
+      .adm-drawer-inner {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        min-height: 0;
+      }
+      .adm-drawer-head {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 0.75rem;
+        padding: 1rem 1.1rem;
+        border-bottom: 1px solid var(--warm-line);
+        background: var(--pale-sand);
+      }
+      .adm-drawer-title {
+        margin: 0;
+        font-size: 1.05rem;
+        font-weight: 700;
+      }
+      .adm-drawer-subtitle {
+        margin: 0.2rem 0 0;
+        font-size: 0.72rem;
+        font-family: ui-monospace, monospace;
+        color: var(--stone-soft);
+        word-break: break-all;
+      }
+      .adm-icon-btn {
+        border: 1px solid var(--warm-line);
+        background: var(--paper-light);
+        border-radius: 999px;
+        width: 2rem;
+        height: 2rem;
+        cursor: pointer;
+        font-size: 1.25rem;
+        line-height: 1;
+        color: var(--stone-soft);
+      }
+      .adm-drawer-fields {
+        flex: 1;
+        overflow-y: auto;
+        padding: 1rem 1.1rem 1.5rem;
+      }
+      .adm-drawer-section {
+        margin-bottom: 1.25rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--warm-line);
+      }
+      .adm-drawer-section:last-child {
+        border-bottom: none;
+      }
+      .adm-drawer-section-label {
+        margin: 0 0 0.65rem;
+        font-size: 0.65rem;
+        font-weight: 600;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        color: var(--stone-soft);
+      }
+      .adm-drawer-field {
+        margin-bottom: 0.85rem;
+      }
+      .adm-drawer-label {
+        display: block;
+        font-size: 0.78rem;
+        font-weight: 600;
+        margin-bottom: 0.25rem;
+      }
+      .adm-drawer-check {
+        display: flex;
+        align-items: center;
+        gap: 0.45rem;
+        font-size: 0.875rem;
+        cursor: pointer;
+      }
+      .adm-drawer-input {
+        width: 100%;
+        border: 1px solid var(--warm-line);
+        border-radius: 0.5rem;
+        padding: 0.45rem 0.55rem;
+        font: inherit;
+        box-sizing: border-box;
+      }
+      .adm-drawer-input:focus {
+        outline: 2px solid rgb(154 90 46 / 0.25);
+        border-color: var(--copper);
+      }
+      .adm-drawer-textarea {
+        min-height: 6rem;
+        resize: vertical;
+      }
+      .adm-drawer-textarea--body {
+        min-height: 16rem;
+        font-family: ui-monospace, monospace;
+        font-size: 0.8rem;
+      }
+      .adm-img-drop {
+        margin-top: 0.35rem;
+        padding: 0.65rem;
+        border: 1px dashed var(--warm-line);
+        border-radius: 0.5rem;
+        text-align: center;
+        cursor: pointer;
+        position: relative;
+        background: var(--paper);
+      }
+      .adm-img-drop--over {
+        border-color: var(--copper);
+        background: var(--pale-sand);
+      }
+      .adm-img-drop--busy {
+        opacity: 0.6;
+        pointer-events: none;
+      }
+      .adm-img-drop-hint {
+        font-size: 0.78rem;
+        color: var(--stone-soft);
+      }
+      .adm-img-drop-input {
+        position: absolute;
+        inset: 0;
+        opacity: 0;
+        cursor: pointer;
+      }
+      .adm-img-preview {
+        margin-top: 0.35rem;
+      }
+      .adm-img-preview-img {
+        max-height: 7rem;
+        border-radius: 0.35rem;
+        border: 1px solid var(--warm-line);
+      }
+      .adm-drawer-foot {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.85rem 1rem;
+        border-top: 1px solid var(--warm-line);
+        background: var(--pale-sand);
+      }
+      .adm-drawer-foot-actions {
+        margin-left: auto;
+        display: flex;
+        gap: 0.5rem;
+      }
+      .adm-toast {
+        position: fixed;
+        bottom: 1.25rem;
+        left: 50%;
+        transform: translateX(-50%) translateY(120%);
+        padding: 0.55rem 1.1rem;
+        border-radius: 999px;
+        font-size: 0.8125rem;
+        font-weight: 500;
+        z-index: 60;
+        opacity: 0;
+        transition:
+          transform 0.2s ease,
+          opacity 0.2s ease;
+        pointer-events: none;
+      }
+      .adm-toast--show {
+        transform: translateX(-50%) translateY(0);
+        opacity: 1;
+      }
+      .adm-toast--ok {
+        background: var(--ink);
+        color: #fff;
+      }
+      .adm-toast--err {
+        background: #b91c1c;
+        color: #fff;
       }
     </style>
 
-    <script>
-      const logoutBtn = document.getElementById('logout-btn')!;
-      logoutBtn.addEventListener('click', async () => {
-        const url = logoutBtn.getAttribute('data-logout-url');
-        const home = logoutBtn.getAttribute('data-home-url');
-        if (!url || !home) return;
-        await fetch(url, { method: 'POST', credentials: 'include' });
-        window.location.href = home;
-      });
-
-      const contentApiUrl = (document.getElementById('adm-editor-section') as HTMLElement)?.dataset.contentApiUrl ?? '/api/content';
-      const fileInput = document.getElementById('adm-file') as HTMLInputElement | null;
-      const contentArea = document.getElementById('adm-content') as HTMLTextAreaElement | null;
-      const status = document.getElementById('adm-status');
-      document.getElementById('adm-load')?.addEventListener('click', async () => {
-        const file = fileInput?.value?.trim();
-        if (!file || !status) return;
-        status.textContent = 'Loading…';
-        const res = await fetch(`${contentApiUrl}?file=${encodeURIComponent(file)}`, { credentials: 'include' });
-        const data = await res.json();
-        if (!res.ok) { status.textContent = `Load failed: ${data.error ?? res.status}`; return; }
-        if (contentArea) contentArea.value = data.content ?? '';
-        status.textContent = `Loaded ${file}`;
-      });
-      document.getElementById('adm-save')?.addEventListener('click', async () => {
-        const file = fileInput?.value?.trim();
-        if (!file || !status) return;
-        status.textContent = 'Saving…';
-        const res = await fetch(contentApiUrl, { method: 'PUT', credentials: 'include', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ file, content: contentArea?.value ?? '' }) });
-        const data = await res.json();
-        status.textContent = res.ok ? `Saved ${file} (${data.mode})` : `Save failed: ${data.error ?? res.status}`;
-      });
-
-      const dropzone = document.getElementById('adm-dropzone');
-      const uploadInput = document.getElementById('adm-upload-input') as HTMLInputElement | null;
-      const uploadList = document.getElementById('adm-upload-list');
-      const uploadStatus = document.getElementById('adm-upload-status');
-      const targetDirInput = document.getElementById('adm-target-dir') as HTMLInputElement | null;
-
-      const renderFiles = (files: FileList) => {
-        if (!uploadList) return;
-        uploadList.innerHTML = '';
-        [...files].forEach((f) => {
-          const li = document.createElement('li');
-          li.textContent = `${f.name} (${f.type || 'binary'}, ${f.size} bytes)`;
-          uploadList.appendChild(li);
-        });
-      };
-
-      const doUpload = async (fileList: FileList | null) => {
-        if (!fileList || fileList.length === 0) return;
-        renderFiles(fileList);
-        if (uploadStatus) uploadStatus.textContent = 'Uploading…';
-        const fd = new FormData();
-        const dir = targetDirInput?.value?.trim() || '';
-        fd.append('targetDir', dir);
-        [...fileList].forEach((f) => fd.append('files', f));
-        const res = await fetch(contentApiUrl, { method: 'POST', credentials: 'include', body: fd });
-        const data = await res.json();
-        if (uploadStatus) uploadStatus.textContent = res.ok ? `Uploaded: ${(data.saved || []).join(', ')}` : `Upload failed: ${data.error || res.status}`;
-      };
-
-      dropzone?.addEventListener('click', () => uploadInput?.click());
-      uploadInput?.addEventListener('change', () => doUpload(uploadInput?.files ?? null));
-      ['dragenter', 'dragover'].forEach((evt) => dropzone?.addEventListener(evt, (e) => { e.preventDefault(); dropzone.classList.add('is-over'); }));
-      ['dragleave', 'drop'].forEach((evt) => dropzone?.addEventListener(evt, (e) => { e.preventDefault(); dropzone.classList.remove('is-over'); }));
-      dropzone?.addEventListener('drop', (e) => {
-        const dt = e.dataTransfer;
-        if (!dt?.files) return;
-        doUpload(dt.files);
-      });
-
+    <script define:vars={{ contentApiUrl }}>
+      import { initAdminApp } from '../client/admin-app.ts';
+      initAdminApp(contentApiUrl);
     </script>
   </body>
 </html>

--- a/packages/admin-tools/src/routes/api/content.ts
+++ b/packages/admin-tools/src/routes/api/content.ts
@@ -100,17 +100,28 @@ export const GET: APIRoute = async ({ request, url }) => {
 
 export const PUT: APIRoute = async ({ request }) => {
   const authed = await auth(request); if (authed.error) return authed.error;
-  const body = await request.json().catch(() => null) as { file?: string; content?: string; message?: string } | null;
+  const body = await request.json().catch(() => null) as {
+    file?: string;
+    content?: string;
+    message?: string;
+    base64?: boolean;
+  } | null;
   if (!body?.file || typeof body.content !== 'string') return Response.json({ error: 'Missing file or content' }, { status: 400, headers: NO_STORE });
   const cwd = process.cwd();
   const abs = resolveAllowed(cwd, body.file);
   if (!abs) return Response.json({ error: 'Invalid file path' }, { status: 400, headers: NO_STORE });
 
+  const useB64 = body.base64 === true;
+  const ghPayloadContent = useB64
+    ? body.content.replace(/\n/g, '')
+    : Buffer.from(body.content, 'utf8').toString('base64');
+
   if (authed.devBypass) {
     await fs.mkdir(path.dirname(abs), { recursive: true });
     const lstat = await fs.lstat(abs).catch(() => null);
     if (lstat?.isSymbolicLink()) return Response.json({ error: 'Invalid file path' }, { status: 400, headers: NO_STORE });
-    await fs.writeFile(abs, body.content, 'utf8');
+    const payload = useB64 ? Buffer.from(body.content.replace(/\n/g, ''), 'base64') : Buffer.from(body.content, 'utf8');
+    await fs.writeFile(abs, payload);
     return Response.json({ ok: true, mode: 'local-dev' }, { headers: NO_STORE });
   }
 
@@ -130,11 +141,57 @@ export const PUT: APIRoute = async ({ request }) => {
   const upRes = await fetch(base, {
     method: 'PUT',
     headers: { ...headers, 'Content-Type': 'application/json' },
-    body: JSON.stringify({ message: body.message ?? `admin-tools: update ${ghPath}`, content: Buffer.from(body.content, 'utf8').toString('base64'), sha, branch }),
+    body: JSON.stringify({ message: body.message ?? `admin-tools: update ${ghPath}`, content: ghPayloadContent, sha, branch }),
   });
   if (!upRes.ok) {
     const detail = await upRes.text();
     return Response.json({ error: 'GitHub write failed', detail }, { status: 502, headers: NO_STORE });
+  }
+  return Response.json({ ok: true, mode: 'github' }, { headers: NO_STORE });
+};
+
+export const DELETE: APIRoute = async ({ request }) => {
+  const authed = await auth(request); if (authed.error) return authed.error;
+  const body = await request.json().catch(() => null) as { file?: string; message?: string } | null;
+  if (!body?.file) return Response.json({ error: 'Missing file' }, { status: 400, headers: NO_STORE });
+  const cwd = process.cwd();
+  const abs = resolveAllowed(cwd, body.file);
+  if (!abs) return Response.json({ error: 'Invalid file path' }, { status: 400, headers: NO_STORE });
+
+  if (authed.devBypass) {
+    try {
+      const lstat = await fs.lstat(abs);
+      if (lstat.isSymbolicLink()) return Response.json({ error: 'Invalid file path' }, { status: 400, headers: NO_STORE });
+      await fs.unlink(abs);
+      return Response.json({ ok: true, mode: 'local-dev' }, { headers: NO_STORE });
+    } catch {
+      return Response.json({ error: 'Not found' }, { status: 404, headers: NO_STORE });
+    }
+  }
+
+  const owner = repoOwner(); const repo = repoName(); const branch = repoBranch();
+  if (!owner || !repo || !authed.accessToken) return Response.json({ error: 'Repo/auth misconfiguration' }, { status: 500, headers: NO_STORE });
+
+  const ghPath = body.file.replace(/^\/+/, '');
+  const base = `https://api.github.com/repos/${owner}/${repo}/contents/${encodeURIComponent(ghPath).replace(/%2F/g, '/')}`;
+  const headers = { Authorization: `Bearer ${authed.accessToken}`, Accept: 'application/vnd.github+json', 'User-Agent': 'portfolio-engine-admin-tools', 'Content-Type': 'application/json' };
+  const currentRes = await fetch(`${base}?ref=${encodeURIComponent(branch)}`, { headers });
+  if (!currentRes.ok) return Response.json({ error: 'Not found' }, { status: 404, headers: NO_STORE });
+  const current = await currentRes.json() as { sha?: string };
+  if (!current.sha) return Response.json({ error: 'Unexpected GitHub response' }, { status: 502, headers: NO_STORE });
+
+  const delRes = await fetch(base, {
+    method: 'DELETE',
+    headers,
+    body: JSON.stringify({
+      message: body.message ?? `admin-tools: delete ${ghPath}`,
+      sha: current.sha,
+      branch,
+    }),
+  });
+  if (!delRes.ok) {
+    const detail = await delRes.text();
+    return Response.json({ error: 'GitHub delete failed', detail }, { status: 502, headers: NO_STORE });
   }
   return Response.json({ ok: true, mode: 'github' }, { headers: NO_STORE });
 };

--- a/packages/editorial-theme/package.json
+++ b/packages/editorial-theme/package.json
@@ -11,7 +11,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
-    }
+    },
+    "./styles/global.css": "./dist/styles/global.css",
+    "./styles/design-tokens.css": "./dist/styles/design-tokens.css",
+    "./components/ThemeTypographyOverrides.astro": "./dist/components/ThemeTypographyOverrides.astro"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/editorial-theme/src/components/ThemeTypographyOverrides.astro
+++ b/packages/editorial-theme/src/components/ThemeTypographyOverrides.astro
@@ -1,0 +1,26 @@
+---
+/**
+ * Applies optional typography from src/config/theme.json so the public site and
+ * admin preview stay aligned with consumer configuration.
+ */
+import { config } from '@portfolio-engine:config';
+
+const typo = config.theme?.typography;
+
+/** Strip characters that could break a single CSS declaration block. */
+function sanitizeFragment(v: string): string {
+  return v.replace(/[;{}<>]/g, '').trim();
+}
+
+const lines: string[] = [];
+if (typo?.fontFamily) {
+  lines.push(`  --font-serif-stack: ${sanitizeFragment(typo.fontFamily)}, ui-serif, Georgia, serif;`);
+}
+if (typo?.fontSize) {
+  lines.push(`  font-size: ${sanitizeFragment(typo.fontSize)};`);
+}
+
+const css = lines.length > 0 ? `:root {\n${lines.join('\n')}\n}` : '';
+---
+
+{css && <style is:global set:html={css} />}

--- a/packages/editorial-theme/src/index.ts
+++ b/packages/editorial-theme/src/index.ts
@@ -2,6 +2,7 @@
 
 // Utility exports
 export { getBase, formatDate, sortByDateDesc, resolveAssetUrl } from './lib/utils.js';
+export { EDITORIAL_GOOGLE_FONTS_STYLESHEET_HREF } from './lib/google-fonts.js';
 
 export { editorialTheme } from './integration.js';
 export type { EditorialThemeOptions } from './integration.js';

--- a/packages/editorial-theme/src/layouts/Layout.astro
+++ b/packages/editorial-theme/src/layouts/Layout.astro
@@ -2,7 +2,9 @@
 import Nav from '../components/Nav.astro';
 import AmbientBackground from '../components/AmbientBackground.astro';
 import Footer from '../components/Footer.astro';
+import ThemeTypographyOverrides from '../components/ThemeTypographyOverrides.astro';
 import '../styles/global.css';
+import { EDITORIAL_GOOGLE_FONTS_STYLESHEET_HREF } from '../lib/google-fonts.js';
 import { config } from '@portfolio-engine:config';
 import { overrides } from '@portfolio-engine:overrides';
 import { readFileSync } from 'node:fs';
@@ -57,11 +59,9 @@ const imageUrl = ogImage
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,700;1,400;1,700&family=Inter:wght@300;400;500;600&display=swap"
-      rel="stylesheet"
-    />
+    <link href={EDITORIAL_GOOGLE_FONTS_STYLESHEET_HREF} rel="stylesheet" />
     <title>{title}</title>
+    <ThemeTypographyOverrides />
     {extraCss && <style is:global set:html={extraCss} />}
     <slot name="head" />
   </head>

--- a/packages/editorial-theme/src/lib/google-fonts.ts
+++ b/packages/editorial-theme/src/lib/google-fonts.ts
@@ -1,0 +1,6 @@
+/**
+ * Stylesheet URL for the default editorial font pairing (Cormorant Garamond + Inter).
+ * Keep in sync with `--font-serif-stack` / `--font-sans-stack` in design-tokens.css.
+ */
+export const EDITORIAL_GOOGLE_FONTS_STYLESHEET_HREF =
+  'https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,700;1,400;1,700&family=Inter:wght@300;400;500;600&display=swap';

--- a/packages/editorial-theme/src/styles/design-tokens.css
+++ b/packages/editorial-theme/src/styles/design-tokens.css
@@ -1,0 +1,34 @@
+/**
+ * Shared semantic tokens for the editorial theme and the admin design preview.
+ * Imported by global.css (public site) and may be imported standalone where
+ * Tailwind is not needed.
+ */
+:root {
+  /* Brand palette — warm editorial academic */
+  --paper: #f7f4ef;
+  --paper-light: #fcfbf8;
+  --ink: #1e1a17;
+  --stone-soft: #6b625b;
+  --copper: #9a5a2e;
+  --clay: #b87c5a;
+  --warm-line: #e6ded3;
+  --pale-sand: #efe6da;
+  --olive: #5c6650;
+
+  /**
+   * Font stacks — loaded via Google Fonts in Layout + admin (see google-fonts.ts).
+   * theme.json typography.fontFamily overrides --font-serif-stack via ThemeTypographyOverrides.
+   */
+  --font-sans-stack: "Inter", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
+    "Segoe UI Symbol", "Noto Color Emoji";
+  --font-serif-stack: "Cormorant Garamond", ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
+
+  /* Site map / admin chrome aliases (consumers use var(--adm-*) with fallbacks) */
+  --adm-ink: var(--ink);
+  --adm-muted: var(--stone-soft);
+  --adm-border: var(--warm-line);
+  --adm-paper: var(--paper-light);
+  --adm-paper-2: var(--pale-sand);
+  --adm-accent: var(--copper);
+  --adm-stone: var(--stone-soft);
+}

--- a/packages/editorial-theme/src/styles/global.css
+++ b/packages/editorial-theme/src/styles/global.css
@@ -1,25 +1,111 @@
+@import "./design-tokens.css";
 @import "tailwindcss";
 
-@layer base {
-  :root {
-    /* Brand palette — warm editorial academic */
-    --paper: #f7f4ef;
-    --paper-light: #fcfbf8;
-    --ink: #1e1a17;
-    --stone-soft: #6b625b;
-    --copper: #9a5a2e;
-    --clay: #b87c5a;
-    --warm-line: #e6ded3;
-    --pale-sand: #efe6da;
-    --olive: #5c6650;
-  }
+@theme {
+  --font-sans: var(--font-sans-stack);
+  --font-serif: var(--font-serif-stack);
+}
 
+@layer base {
   html {
     scroll-behavior: smooth;
   }
 }
 
 @layer components {
+  /* ── Admin design preview (mirrors common theme patterns; processed with this CSS file) ── */
+  .admin-shell {
+    @apply min-h-screen antialiased;
+    background: var(--pale-sand);
+    color: var(--ink);
+    font-family: var(--font-sans-stack);
+  }
+
+  .admin-preview-typography-stack {
+    @apply flex flex-col gap-4;
+  }
+
+  .admin-preview-panel {
+    @apply flex flex-col gap-4 rounded-2xl border p-8;
+    border-color: var(--warm-line);
+    background: var(--paper-light);
+  }
+
+  .admin-preview-actions {
+    @apply flex flex-wrap gap-4;
+  }
+
+  .admin-preview-eyebrow {
+    @apply text-xs font-semibold uppercase tracking-[0.14em];
+    color: var(--copper);
+  }
+
+  .admin-preview-serif-aa {
+    @apply font-serif text-6xl font-bold italic leading-none;
+    color: var(--ink);
+  }
+
+  .admin-preview-serif-title {
+    @apply font-serif text-3xl font-bold;
+    color: var(--ink);
+  }
+
+  .admin-preview-serif-italic {
+    @apply font-serif text-2xl italic;
+    color: var(--ink);
+  }
+
+  .admin-preview-serif-section {
+    @apply font-serif text-xl;
+    color: var(--ink);
+  }
+
+  .admin-preview-sans-aa {
+    @apply text-6xl font-semibold leading-none;
+    color: var(--ink);
+  }
+
+  .admin-preview-sans-strong {
+    @apply text-lg font-semibold;
+    color: var(--ink);
+  }
+
+  .admin-preview-body {
+    @apply text-base leading-relaxed;
+    color: var(--stone-soft);
+  }
+
+  .admin-preview-meta {
+    @apply text-sm;
+    color: var(--stone-soft);
+  }
+
+  .admin-preview-meta-spaced {
+    @apply mb-3 text-sm;
+    color: var(--stone-soft);
+  }
+
+  .admin-preview-link {
+    @apply text-sm font-medium underline underline-offset-4;
+    color: var(--copper);
+  }
+
+  .admin-preview-btn-primary {
+    @apply inline-flex rounded-full px-8 py-3 text-sm font-medium text-white;
+    background: var(--ink);
+  }
+
+  .admin-preview-btn-secondary {
+    @apply inline-flex rounded-full border px-8 py-3 text-sm font-medium;
+    border-color: var(--warm-line);
+    color: var(--ink);
+  }
+
+  .admin-preview-interactive-label {
+    @apply mb-1 text-sm;
+    color: var(--stone-soft);
+  }
+
   /* Ambient background — paper atmosphere, not visual feature */
   .ambient-blob {
     @apply absolute rounded-full;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ importers:
 
   packages/admin-tools:
     dependencies:
+      '@portfolio-engine/editorial-theme':
+        specifier: workspace:*
+        version: link:../editorial-theme
       '@portfolio-engine/engine-core':
         specifier: workspace:*
         version: link:../engine-core


### PR DESCRIPTION
## Summary

Non-technical editors get a richer \/admin\ experience (jump nav, color swatches with usage copy, typography and button previews, list cards, edit drawer with image upload, settings form) while staying aligned with the public site design system.

## Shared theme / lock-step

- New \packages/editorial-theme/src/styles/design-tokens.css\ holds the canonical palette and \--font-sans-stack\ / \--font-serif-stack\ (Cormorant Garamond + Inter, matching Layout).
- \global.css\ imports those tokens and maps Tailwind \@theme\ \--font-sans\ / \--font-serif\ to the same stacks so \ont-sans\ / \ont-serif\ utilities on the site and in admin previews match.
- \google-fonts.ts\ centralizes the Google Fonts stylesheet URL; Layout and admin both use it.
- \ThemeTypographyOverrides.astro\ applies optional \	heme.json\ \	ypography.fontFamily\ and \ontSize\ to \:root\ on both Layout and admin.
- Admin imports \@portfolio-engine/editorial-theme/styles/global.css\ and uses shared \dmin-preview-*\ component classes defined in that file (same Tailwind utilities as the rest of the theme CSS pipeline).

## API

- Content \PUT\ accepts \ase64: true\ for binary uploads; new \DELETE\ removes allowed paths (local + GitHub).

## Verification

- \pnpm --filter @portfolio-engine/admin-tools check\
- \pnpm check\ in \examples/demo-site\ (Astro check)
- Context7 consulted for Tailwind v4 \@theme\ font variables and Astro CSS imports from packages.

Please run \pnpm dev\ in \examples/demo-site\ and open \/admin\ locally to visually confirm fonts and swatches (Playwright in this environment may hit a different localhost than the sandbox dev server).

Made with [Cursor](https://cursor.com)