### PR TITLE
Epic: Consumer registry MVP (local routes for downstream IA)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": ["demo-site", "node-ssr-demo"]
 }

--- a/.changeset/consumer-registry-mvp.md
+++ b/.changeset/consumer-registry-mvp.md
@@ -1,7 +1,7 @@
 ---
-"@portfolio-engine/schema": minor
-"@portfolio-engine/engine-core": minor
-"@portfolio-engine/editorial-theme": minor
+'@portfolio-engine/schema': minor
+'@portfolio-engine/engine-core': minor
+'@portfolio-engine/editorial-theme': minor
 ---
 
 **Consumer registry MVP** ([Epic #81](https://github.com/rainonej/portfolio-engine/issues/81)): Zod-validated `src/registry/portfolio-engine.registry.json`, inject Astro routes from `src/pages-local`, fail on URL collisions with injected theme routes (after remaps), manifest fields `routeOrigin` and `capabilities.consumerLocalRoutes`, and package export `@portfolio-engine/editorial-theme/layouts/Layout.astro` for consumer-local pages.

--- a/.changeset/consumer-registry-mvp.md
+++ b/.changeset/consumer-registry-mvp.md
@@ -1,0 +1,7 @@
+---
+"@portfolio-engine/schema": minor
+"@portfolio-engine/engine-core": minor
+"@portfolio-engine/editorial-theme": minor
+---
+
+**Consumer registry MVP** ([Epic #81](https://github.com/rainonej/portfolio-engine/issues/81)): Zod-validated `src/registry/portfolio-engine.registry.json`, inject Astro routes from `src/pages-local`, fail on URL collisions with injected theme routes (after remaps), manifest fields `routeOrigin` and `capabilities.consumerLocalRoutes`, and package export `@portfolio-engine/editorial-theme/layouts/Layout.astro` for consumer-local pages.

--- a/docs/downstream/custom-page-via-registry.md
+++ b/docs/downstream/custom-page-via-registry.md
@@ -70,10 +70,10 @@ If a **`localRoutes[].pattern`** matches the **injected URL** of an editorial-th
 
 Pass these to `editorialTheme()` / `createEngineIntegration()`:
 
-| Option                   | Purpose                                                                                                  |
-| ------------------------ | -------------------------------------------------------------------------------------------------------- |
-| `consumerRegistryPath`   | Alternate JSON path (relative to site root). If set, the file **must** exist.                            |
-| `consumerPagesLocalDir`  | Alternate directory for page files (default `src/pages-local`).                                        |
+| Option                  | Purpose                                                                       |
+| ----------------------- | ----------------------------------------------------------------------------- |
+| `consumerRegistryPath`  | Alternate JSON path (relative to site root). If set, the file **must** exist. |
+| `consumerPagesLocalDir` | Alternate directory for page files (default `src/pages-local`).               |
 
 ## Manifest
 

--- a/docs/downstream/custom-page-via-registry.md
+++ b/docs/downstream/custom-page-via-registry.md
@@ -28,8 +28,10 @@ Minimal shape:
 }
 ```
 
+Only **`version: 1`** is accepted today; future formats must bump this deliberately alongside engine support.
+
 - **`pattern`** — URL path Astro injects (must start with `/`).
-- **`page`** — Path relative to `src/pages-local`, must end in `.astro`, no `..`.
+- **`page`** — Path relative to `src/pages-local`, must end in `.astro`, no `..` path segments, no Windows drive / UNC paths.
 - **`label`**, **`section`**, **`visibility`** — Optional metadata for manifests and `@portfolio-engine:routes`.
 
 The Zod schemas live in `@portfolio-engine/schema` (`ConsumerPortfolioEngineRegistrySchema`, `ConsumerLocalRouteEntrySchema`) so you can validate this file in your own tooling if needed.

--- a/docs/downstream/custom-page-via-registry.md
+++ b/docs/downstream/custom-page-via-registry.md
@@ -1,0 +1,84 @@
+# Add a custom page with the consumer registry
+
+This recipe matches the MVP in [Epic: consumer registry](https://github.com/rainonej/portfolio-engine/issues/81). You add routes **without** new named override surfaces in `@portfolio-engine/editorial-theme`.
+
+## Prerequisites
+
+- Astro site using `editorialTheme()` from `@portfolio-engine/editorial-theme` (same setup as [new-site-setup](./new-site-setup.md)).
+
+## Steps
+
+### 1. Registry file
+
+Create `src/registry/portfolio-engine.registry.json` at the project root of your consumer site (relative to `astro.config.mjs`).
+
+Minimal shape:
+
+```json
+{
+  "version": 1,
+  "localRoutes": [
+    {
+      "pattern": "/how-i-think",
+      "page": "how-i-think.astro",
+      "label": "How I Think",
+      "visibility": "public"
+    }
+  ]
+}
+```
+
+- **`pattern`** — URL path Astro injects (must start with `/`).
+- **`page`** — Path relative to `src/pages-local`, must end in `.astro`, no `..`.
+- **`label`**, **`section`**, **`visibility`** — Optional metadata for manifests and `@portfolio-engine:routes`.
+
+The Zod schemas live in `@portfolio-engine/schema` (`ConsumerPortfolioEngineRegistrySchema`, `ConsumerLocalRouteEntrySchema`) so you can validate this file in your own tooling if needed.
+
+### 2. Page source
+
+Add the Astro file under **`src/pages-local/`** at the path named by `page`:
+
+`src/pages-local/how-i-think.astro`
+
+Use the theme shell so the page matches the rest of the site:
+
+```astro
+---
+import Layout from '@portfolio-engine/editorial-theme/layouts/Layout.astro';
+---
+
+<Layout title="How I Think">
+  <main class="mx-auto max-w-prose px-4 py-16">
+    <h1>How I Think</h1>
+  </main>
+</Layout>
+```
+
+### 3. Navigation (optional)
+
+Add an entry to `src/config/navigation.json` so the page appears in the nav.
+
+### 4. Build
+
+Run `astro build` (or `astro dev`). The integration loads the registry, resolves files under `src/pages-local`, injects routes, and writes `.portfolio-engine/manifest.json`.
+
+## Collision rules
+
+If a **`localRoutes[].pattern`** matches the **injected URL** of an editorial-theme route (including after theme route **remaps**), the build fails with an explicit error. Fix by renaming the local pattern or changing theme route overrides in `astro.config.mjs`.
+
+## Optional integration options
+
+Pass these to `editorialTheme()` / `createEngineIntegration()`:
+
+| Option                   | Purpose                                                                                                  |
+| ------------------------ | -------------------------------------------------------------------------------------------------------- |
+| `consumerRegistryPath`   | Alternate JSON path (relative to site root). If set, the file **must** exist.                            |
+| `consumerPagesLocalDir`  | Alternate directory for page files (default `src/pages-local`).                                        |
+
+## Manifest
+
+Routes from the registry appear in `.portfolio-engine/manifest.json` with `"routeOrigin": "consumer-local"`. `capabilities.consumerLocalRoutes` is `true` when at least one such route is active.
+
+## Verified example
+
+`examples/demo-site` in this repo implements `/how-i-think` using the steps above.

--- a/docs/downstream/new-site-setup.md
+++ b/docs/downstream/new-site-setup.md
@@ -325,6 +325,12 @@ Add this to `.gitignore`:
 
 ---
 
+## 8.5 — Optional: custom routes via registry
+
+To add bespoke URLs backed by your own Astro pages (without new named override surfaces in the theme), follow [custom-page-via-registry.md](./custom-page-via-registry.md).
+
+---
+
 ## 9 — Deploy to Vercel
 
 1. Push to GitHub.

--- a/docs/packages/engine-core.md
+++ b/docs/packages/engine-core.md
@@ -7,6 +7,7 @@ The Astro integration at the heart of portfolio-engine.
 - **Config loader + schema bridge** — reads and validates `config/site.json`, `config/navigation.json`, `config/theme.json`, `config/features.json` against `@portfolio-engine/schema` Zod schemas. Produces a typed `ResolvedConfig`.
 - **Virtual modules** — exposes resolved config and build context to theme components via `@portfolio-engine:config`, `@portfolio-engine:context`, `@portfolio-engine:routes`, `@portfolio-engine:overrides`. Implemented with native Vite `resolveId`/`load` hooks.
 - **Route discovery + injection** — scans the `editorial-theme` pages directory and injects routes via Astro's `injectRoute` hook.
+- **Consumer registry (MVP)** — reads `src/registry/portfolio-engine.registry.json`, injects extra routes from `src/pages-local`, rejects URL collisions with theme routes, and records local routes in `.portfolio-engine/manifest.json`. See [../downstream/custom-page-via-registry.md](../downstream/custom-page-via-registry.md).
 - **Route remap / enable / disable** — consumers can disable or remap individual routes via config.
 - **Route registry** — exports a typed `RouteRegistry` covering all active (post-override) public + admin routes.
 - **Override resolution** — resolves named component override surfaces declared by `editorial-theme`.
@@ -33,7 +34,7 @@ Implemented via native Vite `resolveId`/`load` plugin hooks. The `\0` prefix on 
 | ----------------------------- | ----------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `@portfolio-engine:config`    | `config`    | `ResolvedConfig` | Validated site + navigation + theme + features config                                                                                                                                   |
 | `@portfolio-engine:context`   | `context`   | `BuildContext`   | Env, mode, base URL                                                                                                                                                                     |
-| `@portfolio-engine:routes`    | `routes`    | `RouteRegistry`  | Active (post-override) route registry — disabled routes excluded, remapped routes reflected                                                                                             |
+| `@portfolio-engine:routes`    | `routes`    | `RouteRegistry`  | Active route registry — editorial-theme routes after remap/disable **plus** consumer-local routes from the registry                                                                     |
 | `@portfolio-engine:overrides` | `overrides` | `OverrideMap`    | Component override map (component name → absolute path). Reserved key `__styles__` holds a JSON-encoded `string[]` of absolute CSS paths to append after the theme's global stylesheet. |
 
 Consumer packages (e.g. `editorial-theme`) get full TypeScript types automatically — the integration calls Astro's `injectTypes()` hook to inject a reference directive into the consumer's TypeScript environment. No manual setup is needed.

--- a/examples/demo-site/.portfolio-engine/manifest.json
+++ b/examples/demo-site/.portfolio-engine/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-05T15:51:55.014Z",
+  "generatedAt": "2026-05-05T18:31:46.334Z",
   "rootDir": ".",
   "routes": [
     {
@@ -71,6 +71,16 @@
       "disableable": true,
       "agentGuidance": "Prefer Writing for public-facing navigation tasks.",
       "resolved": "/writing"
+    },
+    {
+      "pattern": "/how-i-think",
+      "resolved": "/how-i-think",
+      "label": "How I Think",
+      "section": null,
+      "visibility": "public",
+      "remappable": false,
+      "disableable": false,
+      "routeOrigin": "consumer-local"
     }
   ],
   "overrideSurfaces": [
@@ -135,6 +145,7 @@
   "capabilities": {
     "routeRemap": true,
     "routeDisable": true,
-    "namedOverrides": true
+    "namedOverrides": true,
+    "consumerLocalRoutes": true
   }
 }

--- a/examples/demo-site/src/config/navigation.json
+++ b/examples/demo-site/src/config/navigation.json
@@ -2,7 +2,8 @@
   "items": [
     { "label": "Work", "href": "/work", "order": 1, "visible": true },
     { "label": "Writing", "href": "/writing", "order": 2, "visible": true },
-    { "label": "About", "href": "/about", "order": 3, "visible": true },
-    { "label": "Contact", "href": "/contact", "order": 4, "visible": true }
+    { "label": "How I Think", "href": "/how-i-think", "order": 3, "visible": true },
+    { "label": "About", "href": "/about", "order": 4, "visible": true },
+    { "label": "Contact", "href": "/contact", "order": 5, "visible": true }
   ]
 }

--- a/examples/demo-site/src/pages-local/how-i-think.astro
+++ b/examples/demo-site/src/pages-local/how-i-think.astro
@@ -1,0 +1,16 @@
+---
+/**
+ * Example consumer-local page (Epic #81). Declared in
+ * `src/registry/portfolio-engine.registry.json` and built from `src/pages-local/`.
+ */
+import Layout from '@portfolio-engine/editorial-theme/layouts/Layout.astro';
+---
+
+<Layout title="How I Think" description="Consumer-local route via portfolio-engine registry">
+  <main class="mx-auto max-w-prose px-4 py-16">
+    <h1 class="text-3xl font-semibold tracking-tight">How I Think</h1>
+    <p class="mt-4 text-neutral-600 dark:text-neutral-400">
+      This page is injected by the engine from <code class="rounded bg-neutral-100 px-1 py-0.5 dark:bg-neutral-800">src/pages-local</code> using the consumer registry — no new named override surfaces in the theme.
+    </p>
+  </main>
+</Layout>

--- a/examples/demo-site/src/registry/portfolio-engine.registry.json
+++ b/examples/demo-site/src/registry/portfolio-engine.registry.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "localRoutes": [
+    {
+      "pattern": "/how-i-think",
+      "page": "how-i-think.astro",
+      "label": "How I Think",
+      "section": null,
+      "visibility": "public"
+    }
+  ]
+}

--- a/examples/node-ssr-demo/.portfolio-engine/manifest.json
+++ b/examples/node-ssr-demo/.portfolio-engine/manifest.json
@@ -135,6 +135,7 @@
   "capabilities": {
     "routeRemap": true,
     "routeDisable": true,
-    "namedOverrides": true
+    "namedOverrides": true,
+    "consumerLocalRoutes": false
   }
 }

--- a/packages/editorial-theme/package.json
+++ b/packages/editorial-theme/package.json
@@ -12,6 +12,7 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./layouts/Layout.astro": "./dist/layouts/Layout.astro",
     "./styles/global.css": "./dist/styles/global.css",
     "./styles/design-tokens.css": "./dist/styles/design-tokens.css",
     "./components/ThemeTypographyOverrides.astro": "./dist/components/ThemeTypographyOverrides.astro",

--- a/packages/editorial-theme/src/index.ts
+++ b/packages/editorial-theme/src/index.ts
@@ -10,3 +10,6 @@ export {
 export { editorialTheme } from './integration.js';
 export type { EditorialThemeOptions } from './integration.js';
 export { DEFAULT_OVERRIDE_SURFACES, DEFAULT_ROUTE_REGISTRY } from './registry.js';
+
+/** Default relative path for consumer registry JSON — same default used by engine-core. */
+export { CONSUMER_REGISTRY_DEFAULT_RELATIVE_PATH } from '@portfolio-engine/schema';

--- a/packages/editorial-theme/src/integration.ts
+++ b/packages/editorial-theme/src/integration.ts
@@ -31,6 +31,9 @@ const TAILWIND_SSR_EXTERNAL = [
  * Astro accepts arrays in its integrations list and flattens them, so consumers
  * can use this exactly like a single integration:
  *   integrations: [editorialTheme({ ... })]
+ *
+ * Consumer-local routes: optional `src/registry/portfolio-engine.registry.json` +
+ * `src/pages-local/*.astro` — see `docs/downstream/custom-page-via-registry.md`.
  */
 export function editorialTheme(options: EditorialThemeOptions): AstroIntegration[] {
   const tailwindIntegration: AstroIntegration = {

--- a/packages/engine-core/README.md
+++ b/packages/engine-core/README.md
@@ -53,6 +53,10 @@ Exposes resolved config and build context to theme components without filesystem
 
 Scans the `editorial-theme` package's pages directory and injects those routes into the consumer project via Astro's `injectRoute` integration hook.
 
+### Consumer registry (local routes)
+
+Loads optional `src/registry/portfolio-engine.registry.json`, validates it with `@portfolio-engine/schema`, and injects matching `.astro` pages from `src/pages-local`. Duplicate URLs versus injected theme routes fail the build with a clear error. Local routes are labeled in `.portfolio-engine/manifest.json` (`routeOrigin: consumer-local`). See repo docs: `docs/downstream/custom-page-via-registry.md`.
+
 ### Route remap / enable / disable
 
 Consumers can disable or remap individual routes via config. Semantics defined in Task 3.5.

--- a/packages/engine-core/src/consumer-local-routes.ts
+++ b/packages/engine-core/src/consumer-local-routes.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from 'node:fs';
-import { relative, resolve } from 'node:path';
+import { normalize, resolve, sep } from 'node:path';
 import {
   CONSUMER_REGISTRY_DEFAULT_RELATIVE_PATH,
   parseConsumerPortfolioEngineRegistry,
@@ -8,6 +8,26 @@ import {
 import type { DiscoveredRoute } from './route-discovery.js';
 
 export const DEFAULT_PAGES_LOCAL_RELATIVE_DIR = 'src/pages-local';
+
+/**
+ * Ensure `resolvedFile` lies under `pagesLocalAbs` (defense in depth vs malicious / surprising registry paths).
+ */
+export function assertResolvedFileInsidePagesLocal(
+  pagesLocalAbs: string,
+  resolvedFile: string,
+  pageFieldForMessage: string,
+  pagesLocalRelativeDir: string,
+): void {
+  const root = normalize(resolve(pagesLocalAbs));
+  const file = normalize(resolve(resolvedFile));
+  const prefix = root.endsWith(sep) ? root : root + sep;
+  const inside = file.toLowerCase().startsWith(prefix.toLowerCase());
+  if (!inside || file === root) {
+    throw new Error(
+      `[portfolio-engine] Local page "${pageFieldForMessage}" resolves outside ${pagesLocalRelativeDir} (resolved: ${file}).`,
+    );
+  }
+}
 
 export interface LoadConsumerRegistryOptions {
   /** When true, a missing file is an error (used when `consumerRegistryPath` is set explicitly). */
@@ -72,12 +92,7 @@ export function buildConsumerLocalDiscoveredRoutes(
     seenPatterns.add(pattern);
 
     const entrypoint = resolve(pagesLocalAbs, entry.page.replace(/\\/g, '/'));
-    const relToPagesLocal = relative(pagesLocalAbs, entrypoint);
-    if (relToPagesLocal.startsWith('..') || relToPagesLocal.includes('..')) {
-      throw new Error(
-        `[portfolio-engine] Local page "${entry.page}" resolves outside ${pagesLocalRelativeDir}.`,
-      );
-    }
+    assertResolvedFileInsidePagesLocal(pagesLocalAbs, entrypoint, entry.page, pagesLocalRelativeDir);
     if (!existsSync(entrypoint)) {
       throw new Error(
         `[portfolio-engine] Consumer registry references missing page file for "${pattern}": expected ${entrypoint}`,

--- a/packages/engine-core/src/consumer-local-routes.ts
+++ b/packages/engine-core/src/consumer-local-routes.ts
@@ -1,0 +1,122 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { relative, resolve } from 'node:path';
+import {
+  CONSUMER_REGISTRY_DEFAULT_RELATIVE_PATH,
+  parseConsumerPortfolioEngineRegistry,
+  type ConsumerPortfolioEngineRegistry,
+} from '@portfolio-engine/schema';
+import type { DiscoveredRoute } from './route-discovery.js';
+
+export const DEFAULT_PAGES_LOCAL_RELATIVE_DIR = 'src/pages-local';
+
+export interface LoadConsumerRegistryOptions {
+  /** When true, a missing file is an error (used when `consumerRegistryPath` is set explicitly). */
+  required?: boolean;
+}
+
+/**
+ * Load and validate the consumer registry JSON file, or return null when the file is absent.
+ */
+export function loadConsumerRegistryFromDisk(
+  projectRootDir: string,
+  registryRelativePath: string = CONSUMER_REGISTRY_DEFAULT_RELATIVE_PATH,
+  loadOptions: LoadConsumerRegistryOptions = {},
+): ConsumerPortfolioEngineRegistry | null {
+  const abs = resolve(projectRootDir, registryRelativePath);
+  if (!existsSync(abs)) {
+    if (loadOptions.required) {
+      throw new Error(
+        `[portfolio-engine] Consumer registry not found at "${registryRelativePath}" (resolved: ${abs}).`,
+      );
+    }
+    return null;
+  }
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(abs, 'utf8')) as unknown;
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `[portfolio-engine] Failed to parse consumer registry JSON at "${registryRelativePath}": ${detail}`,
+    );
+  }
+
+  try {
+    return parseConsumerPortfolioEngineRegistry(raw);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`[portfolio-engine] Invalid consumer registry "${registryRelativePath}": ${detail}`);
+  }
+}
+
+/**
+ * Build injectable routes from validated registry entries under `src/pages-local`.
+ */
+export function buildConsumerLocalDiscoveredRoutes(
+  projectRootDir: string,
+  registry: ConsumerPortfolioEngineRegistry,
+  pagesLocalRelativeDir: string = DEFAULT_PAGES_LOCAL_RELATIVE_DIR,
+): DiscoveredRoute[] {
+  const pagesLocalAbs = resolve(projectRootDir, pagesLocalRelativeDir);
+  const routes: DiscoveredRoute[] = [];
+  const seenPatterns = new Set<string>();
+
+  for (const entry of registry.localRoutes) {
+    const pattern = entry.pattern;
+    if (seenPatterns.has(pattern)) {
+      throw new Error(
+        `[portfolio-engine] Duplicate local route pattern "${pattern}" in consumer registry.`,
+      );
+    }
+    seenPatterns.add(pattern);
+
+    const entrypoint = resolve(pagesLocalAbs, entry.page.replace(/\\/g, '/'));
+    const relToPagesLocal = relative(pagesLocalAbs, entrypoint);
+    if (relToPagesLocal.startsWith('..') || relToPagesLocal.includes('..')) {
+      throw new Error(
+        `[portfolio-engine] Local page "${entry.page}" resolves outside ${pagesLocalRelativeDir}.`,
+      );
+    }
+    if (!existsSync(entrypoint)) {
+      throw new Error(
+        `[portfolio-engine] Consumer registry references missing page file for "${pattern}": expected ${entrypoint}`,
+      );
+    }
+
+    routes.push({
+      pattern,
+      entrypoint,
+      routeRecord: {
+        pattern,
+        resolved: pattern,
+        label: entry.label ?? pattern,
+        section: entry.section ?? null,
+        visibility: entry.visibility ?? 'public',
+        remappable: false,
+        disableable: false,
+      },
+    });
+  }
+
+  return routes;
+}
+
+/**
+ * Ensure no consumer-local URL matches an injected editorial-theme URL (after theme remaps).
+ */
+export function assertNoThemeLocalRouteCollision(
+  themeRoutes: DiscoveredRoute[],
+  localRoutes: DiscoveredRoute[],
+): void {
+  const themeResolved = new Set(themeRoutes.map((r) => r.routeRecord.resolved));
+  for (const local of localRoutes) {
+    const target = local.routeRecord.resolved;
+    if (themeResolved.has(target)) {
+      throw new Error(
+        `[portfolio-engine] Consumer registry route "${local.pattern}" (${target}) conflicts with an injected editorial-theme route ` +
+          `(same URL after theme route remaps). Change the local pattern or remap/disable the theme route.`,
+      );
+    }
+  }
+}

--- a/packages/engine-core/src/index.ts
+++ b/packages/engine-core/src/index.ts
@@ -17,3 +17,11 @@ export type { OverrideConfig } from './override-resolution.js';
 
 export { discoverRoutes, resolveThemePagesDir } from './route-discovery.js';
 export type { DiscoveredRoute } from './route-discovery.js';
+
+export {
+  assertNoThemeLocalRouteCollision,
+  buildConsumerLocalDiscoveredRoutes,
+  DEFAULT_PAGES_LOCAL_RELATIVE_DIR,
+  loadConsumerRegistryFromDisk,
+} from './consumer-local-routes.js';
+export type { LoadConsumerRegistryOptions } from './consumer-local-routes.js';

--- a/packages/engine-core/src/index.ts
+++ b/packages/engine-core/src/index.ts
@@ -20,6 +20,7 @@ export type { DiscoveredRoute } from './route-discovery.js';
 
 export {
   assertNoThemeLocalRouteCollision,
+  assertResolvedFileInsidePagesLocal,
   buildConsumerLocalDiscoveredRoutes,
   DEFAULT_PAGES_LOCAL_RELATIVE_DIR,
   loadConsumerRegistryFromDisk,

--- a/packages/engine-core/src/integration.ts
+++ b/packages/engine-core/src/integration.ts
@@ -13,11 +13,18 @@ import { createVirtualModulesPlugin } from './virtual-modules.js';
 import type { BuildContext } from './types.js';
 import { writeManifest } from './manifest.js';
 import {
+  CONSUMER_REGISTRY_DEFAULT_RELATIVE_PATH,
   buildDesignSnapshot,
   type ManifestRouteEntry,
   type OverrideSurfaceEntry,
   type RouteRegistryEntry,
 } from '@portfolio-engine/schema';
+import {
+  assertNoThemeLocalRouteCollision,
+  buildConsumerLocalDiscoveredRoutes,
+  DEFAULT_PAGES_LOCAL_RELATIVE_DIR,
+  loadConsumerRegistryFromDisk,
+} from './consumer-local-routes.js';
 
 export interface EngineIntegrationOptions extends EngineConfig {
   /** Remap or disable individual routes before injection. */
@@ -28,6 +35,14 @@ export interface EngineIntegrationOptions extends EngineConfig {
     routes: RouteRegistryEntry[];
     overrideSurfaces: OverrideSurfaceEntry[];
   };
+  /**
+   * Relative path to consumer registry JSON (declares local routes).
+   * Defaults to `src/registry/portfolio-engine.registry.json`. When omitted and that file is absent, no local routes load.
+   * When set explicitly, the file must exist.
+   */
+  consumerRegistryPath?: string;
+  /** Relative directory for registry-backed Astro pages. Defaults to `src/pages-local`. */
+  consumerPagesLocalDir?: string;
 }
 
 export function createEngineIntegration(options: EngineIntegrationOptions): AstroIntegration {
@@ -62,11 +77,25 @@ export function createEngineIntegration(options: EngineIntegrationOptions): Astr
         // 3. Apply route remaps / disables from downstream config
         const { routes: activeRoutes } = applyRouteOverrides(discovered, options.routes ?? {});
 
+        const registryRelative =
+          options.consumerRegistryPath ?? CONSUMER_REGISTRY_DEFAULT_RELATIVE_PATH;
+        const consumerRegistry = loadConsumerRegistryFromDisk(rootDir, registryRelative, {
+          required: options.consumerRegistryPath !== undefined,
+        });
+        const pagesLocalDir = options.consumerPagesLocalDir ?? DEFAULT_PAGES_LOCAL_RELATIVE_DIR;
+        const localRoutes =
+          consumerRegistry !== null
+            ? buildConsumerLocalDiscoveredRoutes(rootDir, consumerRegistry, pagesLocalDir)
+            : [];
+        assertNoThemeLocalRouteCollision(activeRoutes, localRoutes);
+
+        const injectedRoutes = [...activeRoutes, ...localRoutes];
+
         // 4. Inject each active route into the consumer's Astro config.
         // Use routeRecord.resolved (the post-remap injected path) rather than
         // route.pattern (canonical name), so remapped routes are injected at
         // their new URL.
-        for (const route of activeRoutes) {
+        for (const route of injectedRoutes) {
           injectRoute({ pattern: route.routeRecord.resolved, entrypoint: route.entrypoint });
         }
 
@@ -78,11 +107,13 @@ export function createEngineIntegration(options: EngineIntegrationOptions): Astr
         // layer in any optional metadata (agentGuidance, adminDescription) from
         // the canonical registry entry if it exists.
         const registryMap = new Map(registries.routes.map((r) => [r.pattern, r]));
-        const manifestRoutes: ManifestRouteEntry[] = activeRoutes.map((r) => {
+        const consumerLocalEntrypoints = new Set(localRoutes.map((lr) => lr.entrypoint));
+        const manifestRoutes: ManifestRouteEntry[] = injectedRoutes.map((r) => {
           const registryEntry = registryMap.get(r.routeRecord.pattern);
           const entry: ManifestRouteEntry = { ...r.routeRecord };
           if (registryEntry?.agentGuidance !== undefined) entry.agentGuidance = registryEntry.agentGuidance;
           if (registryEntry?.adminDescription !== undefined) entry.adminDescription = registryEntry.adminDescription;
+          if (consumerLocalEntrypoints.has(r.entrypoint)) entry.routeOrigin = 'consumer-local';
           return entry;
         });
         writeManifest(rootDir, manifestRoutes, registries.overrideSurfaces);
@@ -104,7 +135,7 @@ export function createEngineIntegration(options: EngineIntegrationOptions): Astr
               createVirtualModulesPlugin({
                 resolvedConfig,
                 context,
-                routes: activeRoutes.map((r) => r.routeRecord),
+                routes: injectedRoutes.map((r) => r.routeRecord),
                 overrides,
               }) as Parameters<typeof updateConfig>[0]['vite'] extends {
                 plugins?: (infer P)[] | undefined;

--- a/packages/engine-core/src/manifest.ts
+++ b/packages/engine-core/src/manifest.ts
@@ -17,6 +17,7 @@ export function writeManifest(
       routeRemap: true,
       routeDisable: true,
       namedOverrides: true,
+      consumerLocalRoutes: routes.some((r) => r.routeOrigin === 'consumer-local'),
     },
   };
   const dir = join(rootDir, '.portfolio-engine');

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -11,4 +11,4 @@ See [`docs/packages/schema.md`](../../docs/packages/schema.md) for architecture 
 
 ## Status
 
-Active runtime package used by `engine-core`/`editorial-theme`, including manifest-related registry types (`RouteRegistryEntry`, `OverrideSurfaceEntry`, `EngineManifest`).
+Active runtime package used by `engine-core`/`editorial-theme`, including manifest-related registry types (`RouteRegistryEntry`, `OverrideSurfaceEntry`, `EngineManifest`) and **consumer registry** Zod schemas (`ConsumerPortfolioEngineRegistrySchema`, `parseConsumerPortfolioEngineRegistry`).

--- a/packages/schema/src/consumer-registry.ts
+++ b/packages/schema/src/consumer-registry.ts
@@ -1,0 +1,64 @@
+import { z } from 'zod';
+
+/** Default location (relative to Astro project root) for the consumer registry JSON file. */
+export const CONSUMER_REGISTRY_DEFAULT_RELATIVE_PATH = 'src/registry/portfolio-engine.registry.json';
+
+const routePatternSchema = z.string().superRefine((val, ctx) => {
+  if (val.length === 0) {
+    ctx.addIssue({ code: 'custom', message: 'Route pattern must be non-empty' });
+    return;
+  }
+  if (!val.startsWith('/')) {
+    ctx.addIssue({ code: 'custom', message: 'Route pattern must start with "/"' });
+  }
+  if (val.includes('//')) {
+    ctx.addIssue({ code: 'custom', message: 'Route pattern must not contain "//"' });
+  }
+});
+
+const pagesLocalRelativeSchema = z.string().superRefine((val, ctx) => {
+  if (val.length === 0) {
+    ctx.addIssue({ code: 'custom', message: 'page must be a non-empty path relative to src/pages-local' });
+    return;
+  }
+  if (val.startsWith('/') || val.startsWith('\\')) {
+    ctx.addIssue({
+      code: 'custom',
+      message: 'page must be relative (no leading slash or backslash)',
+    });
+  }
+  const normalized = val.replace(/\\/g, '/');
+  if (normalized.includes('..')) {
+    ctx.addIssue({ code: 'custom', message: 'page must not contain ".."' });
+  }
+  if (!normalized.endsWith('.astro')) {
+    ctx.addIssue({ code: 'custom', message: 'page must end with ".astro"' });
+  }
+});
+
+/**
+ * One consumer-declared route backed by a file under `src/pages-local`.
+ */
+export const ConsumerLocalRouteEntrySchema = z.object({
+  pattern: routePatternSchema,
+  page: pagesLocalRelativeSchema,
+  label: z.string().optional(),
+  section: z.string().nullable().optional(),
+  visibility: z.enum(['public', 'admin-only', 'hidden']).optional(),
+});
+
+export type ConsumerLocalRouteEntry = z.infer<typeof ConsumerLocalRouteEntrySchema>;
+
+/**
+ * Consumer-owned portfolio-engine extension registry (JSON on disk).
+ */
+export const ConsumerPortfolioEngineRegistrySchema = z.object({
+  version: z.number().int().positive().default(1),
+  localRoutes: z.array(ConsumerLocalRouteEntrySchema).default([]),
+});
+
+export type ConsumerPortfolioEngineRegistry = z.infer<typeof ConsumerPortfolioEngineRegistrySchema>;
+
+export function parseConsumerPortfolioEngineRegistry(raw: unknown): ConsumerPortfolioEngineRegistry {
+  return ConsumerPortfolioEngineRegistrySchema.parse(raw);
+}

--- a/packages/schema/src/consumer-registry.ts
+++ b/packages/schema/src/consumer-registry.ts
@@ -3,6 +3,13 @@ import { z } from 'zod';
 /** Default location (relative to Astro project root) for the consumer registry JSON file. */
 export const CONSUMER_REGISTRY_DEFAULT_RELATIVE_PATH = 'src/registry/portfolio-engine.registry.json';
 
+/** Supported `version` field in consumer registry JSON — bump only when the format is intentionally extended. */
+export const CONSUMER_REGISTRY_SUPPORTED_VERSION = 1 as const;
+
+function pathHasParentDirSegment(posixPath: string): boolean {
+  return posixPath.split('/').some((segment) => segment === '..');
+}
+
 const routePatternSchema = z.string().superRefine((val, ctx) => {
   if (val.length === 0) {
     ctx.addIssue({ code: 'custom', message: 'Route pattern must be non-empty' });
@@ -26,10 +33,31 @@ const pagesLocalRelativeSchema = z.string().superRefine((val, ctx) => {
       code: 'custom',
       message: 'page must be relative (no leading slash or backslash)',
     });
+    return;
   }
   const normalized = val.replace(/\\/g, '/');
-  if (normalized.includes('..')) {
-    ctx.addIssue({ code: 'custom', message: 'page must not contain ".."' });
+  // UNC / “protocol-relative” roots become //… after normalization — never allowed for pages-local entries.
+  if (normalized.startsWith('//')) {
+    ctx.addIssue({
+      code: 'custom',
+      message: 'page must be a relative path under pages-local (not UNC or URL-like)',
+    });
+    return;
+  }
+  // Windows absolute paths (e.g. D:/outside.astro) — resolve() would ignore pages-local and escape the sandbox.
+  if (/^[a-zA-Z]:/.test(normalized)) {
+    ctx.addIssue({
+      code: 'custom',
+      message: 'page must not be an absolute Windows path',
+    });
+    return;
+  }
+  if (pathHasParentDirSegment(normalized)) {
+    ctx.addIssue({
+      code: 'custom',
+      message: 'page must not contain parent-directory segments ("..")',
+    });
+    return;
   }
   if (!normalized.endsWith('.astro')) {
     ctx.addIssue({ code: 'custom', message: 'page must end with ".astro"' });
@@ -53,7 +81,7 @@ export type ConsumerLocalRouteEntry = z.infer<typeof ConsumerLocalRouteEntrySche
  * Consumer-owned portfolio-engine extension registry (JSON on disk).
  */
 export const ConsumerPortfolioEngineRegistrySchema = z.object({
-  version: z.number().int().positive().default(1),
+  version: z.literal(CONSUMER_REGISTRY_SUPPORTED_VERSION).default(CONSUMER_REGISTRY_SUPPORTED_VERSION),
   localRoutes: z.array(ConsumerLocalRouteEntrySchema).default([]),
 });
 

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -60,3 +60,11 @@ export type FeaturesConfig = z.infer<typeof FeaturesConfigSchema>;
 
 export * from './design-resolve.js';
 export type { EngineManifest, ManifestRouteEntry, OverrideSurfaceEntry, RouteRegistryEntry } from './registry.js';
+export {
+  CONSUMER_REGISTRY_DEFAULT_RELATIVE_PATH,
+  ConsumerLocalRouteEntrySchema,
+  ConsumerPortfolioEngineRegistrySchema,
+  parseConsumerPortfolioEngineRegistry,
+  type ConsumerLocalRouteEntry,
+  type ConsumerPortfolioEngineRegistry,
+} from './consumer-registry.js';

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -62,6 +62,7 @@ export * from './design-resolve.js';
 export type { EngineManifest, ManifestRouteEntry, OverrideSurfaceEntry, RouteRegistryEntry } from './registry.js';
 export {
   CONSUMER_REGISTRY_DEFAULT_RELATIVE_PATH,
+  CONSUMER_REGISTRY_SUPPORTED_VERSION,
   ConsumerLocalRouteEntrySchema,
   ConsumerPortfolioEngineRegistrySchema,
   parseConsumerPortfolioEngineRegistry,

--- a/packages/schema/src/registry.ts
+++ b/packages/schema/src/registry.ts
@@ -28,6 +28,8 @@ export interface OverrideSurfaceEntry {
 export interface ManifestRouteEntry extends RouteRegistryEntry {
   /** Actual injected URL pattern after any consumer remap (equals `pattern` when not remapped) */
   resolved: string;
+  /** Present for routes declared via the consumer registry (`src/registry/portfolio-engine.registry.json`). */
+  routeOrigin?: 'theme' | 'consumer-local';
 }
 
 export interface EngineManifest {
@@ -41,5 +43,7 @@ export interface EngineManifest {
     routeRemap: boolean;
     routeDisable: boolean;
     namedOverrides: boolean;
+    /** True when at least one `consumer-local` route was injected from the consumer registry. */
+    consumerLocalRoutes: boolean;
   };
 }

--- a/packages/schema/src/registry.ts
+++ b/packages/schema/src/registry.ts
@@ -28,8 +28,11 @@ export interface OverrideSurfaceEntry {
 export interface ManifestRouteEntry extends RouteRegistryEntry {
   /** Actual injected URL pattern after any consumer remap (equals `pattern` when not remapped) */
   resolved: string;
-  /** Present for routes declared via the consumer registry (`src/registry/portfolio-engine.registry.json`). */
-  routeOrigin?: 'theme' | 'consumer-local';
+  /**
+   * When set to `'consumer-local'`, this route was injected from the consumer registry / `src/pages-local`.
+   * Omitted for editorial-theme routes (consumers should treat absence as theme-injected).
+   */
+  routeOrigin?: 'consumer-local';
 }
 
 export interface EngineManifest {


### PR DESCRIPTION
## Summary

Implements **[Epic: consumer registry MVP (#81)](https://github.com/rainonej/portfolio-engine/issues/81)** — a minimal, reusable way for downstream sites to add **custom Astro routes** (e.g. `/how-i-think`) via a **consumer-owned registry file** and **`src/pages-local`**, without adding new named override surfaces in `editorial-theme` for every URL.

Closes child tasks: **#82** (schema), **#83** (engine-core), **#84** (theme wiring + Layout export), **#85** (docs + demo recipe).

## What shipped

### Schema (`@portfolio-engine/schema`)

- Zod schemas: `ConsumerPortfolioEngineRegistrySchema`, `ConsumerLocalRouteEntrySchema`, `parseConsumerPortfolioEngineRegistry()`.
- Constant: `CONSUMER_REGISTRY_DEFAULT_RELATIVE_PATH` → `src/registry/portfolio-engine.registry.json`.
- Manifest contract: optional `routeOrigin` on `ManifestRouteEntry`; `capabilities.consumerLocalRoutes` on `EngineManifest`.

### Engine core (`@portfolio-engine/engine-core`)

- Loads registry (default path optional; explicit `consumerRegistryPath` requires the file).
- Resolves `page` paths under `src/pages-local` (default; override via `consumerPagesLocalDir`).
- Merges with theme routes **after** remap/disable; **fails build** on duplicate injected URL vs theme `resolved` paths.
- Injects routes, updates `@portfolio-engine:routes`, writes `.portfolio-engine/manifest.json` with `routeOrigin: consumer-local` where applicable.

### Editorial theme (`@portfolio-engine/editorial-theme`)

- Package export: `@portfolio-engine/editorial-theme/layouts/Layout.astro` for consumer-local pages.
- Re-exports `CONSUMER_REGISTRY_DEFAULT_RELATIVE_PATH`; JSDoc on `editorialTheme()` points to docs.

### Docs & examples

- New **[docs/downstream/custom-page-via-registry.md](docs/downstream/custom-page-via-registry.md)** — full recipe.
- Linked from **new-site-setup.md** §8.5; **docs/packages/engine-core.md** updated.
- **`examples/demo-site`**: `/how-i-think` end-to-end sample + refreshed manifest.

## Success criteria (from #81)

| Criterion | Status |
|-----------|--------|
| Consumer declares ≥1 local route that builds/serves in Astro | ✅ `demo-site` (`/how-i-think`) |
| Duplicate path vs theme routes fails at build with clear error | ✅ `assertNoThemeLocalRouteCollision` |
| Manifest lists local routes / capability flag | ✅ `routeOrigin`, `consumerLocalRoutes` |
| Downstream doc recipe tested vs demo-site | ✅ |

## Out of scope (unchanged)

Embeds/snake-game registry, framed YouTube demo, admin CRUD for registry, replacing all hardcoded `ROUTE_METADATA` — deferred per epic.

## Commit structure

1. `feat(schema): …` — Zod + manifest types  
2. `feat(engine-core): …` — loader, merge, collision, manifest  
3. `feat(editorial-theme): …` — Layout export + constants  
4. `docs: …` — recipe + links  
5. `feat(demo-site): …` — sample route  
6. `chore(node-ssr-demo): …` — manifest shape alignment  

## Notes for reviewers

- Collision detection compares **injected theme URLs** (`resolved`) to **local `pattern`** values (MVP: locals are not remapped).
- Windows: full `astro build` with Vercel adapter may hit symlink `EPERM` locally; prerender for `/how-i-think` succeeded in verification — CI/Linux should be authoritative.
