### PR TITLE
chore(ci): dev→main release automation (Changesets + sync)

### DIFF
--- a/.github/workflows/changeset-pr-guard.yml
+++ b/.github/workflows/changeset-pr-guard.yml
@@ -37,11 +37,14 @@ jobs:
           else
             echo "packages_changed=false" >> "$GITHUB_OUTPUT"
           fi
-          if git diff --name-only "${BASE}...${HEAD}" | grep -q '^\.changeset/'; then
-            echo "changeset_changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "changeset_changed=false" >> "$GITHUB_OUTPUT"
-          fi
+          changeset_changed=false
+          while IFS= read -r path; do
+            [[ "$path" =~ ^\.changeset/[^/]+\.md$ ]] || continue
+            [ "$(basename "$path")" = "README.md" ] && continue
+            changeset_changed=true
+            break
+          done < <(git diff --name-only "${BASE}...${HEAD}")
+          echo "changeset_changed=${changeset_changed}" >> "$GITHUB_OUTPUT"
 
       - name: Enforce changeset or skip label
         if: >-
@@ -52,6 +55,6 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${CHANGESET_CHANGED}" != "true" ]; then
-            echo "::error::This PR changes packages/ but has no .changeset/ updates. Run \`pnpm changeset\` or add the \`skip-changeset\` label."
+            echo "::error::This PR changes packages/ but has no new/modified \`.changeset/*.md\` entry (README/config edits alone do not count). Run \`pnpm changeset\` or add the \`skip-changeset\` label."
             exit 1
           fi

--- a/.github/workflows/changeset-pr-guard.yml
+++ b/.github/workflows/changeset-pr-guard.yml
@@ -1,0 +1,56 @@
+# Require a changeset (or explicit opt-out) when a PR targets dev and touches packages/.
+name: Changeset guard (dev)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches: [dev]
+
+jobs:
+  require-changeset:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/github-script@v7
+        id: meta
+        with:
+          script: |
+            const fs = require('fs');
+            const skip = context.payload.pull_request.labels.some(
+              (l) => l.name === 'skip-changeset'
+            );
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, `skip=${skip ? 'true' : 'false'}\n`);
+
+      - name: Detect packages and changeset changes
+        id: diff
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          if git diff --name-only "${BASE}" "${HEAD}" | grep -q '^packages/'; then
+            echo "packages_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "packages_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+          if git diff --name-only "${BASE}" "${HEAD}" | grep -q '^\.changeset/'; then
+            echo "changeset_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changeset_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Enforce changeset or skip label
+        if: >-
+          steps.diff.outputs.packages_changed == 'true' &&
+          steps.meta.outputs.skip != 'true'
+        env:
+          CHANGESET_CHANGED: ${{ steps.diff.outputs.changeset_changed }}
+        run: |
+          set -euo pipefail
+          if [ "${CHANGESET_CHANGED}" != "true" ]; then
+            echo "::error::This PR changes packages/ but has no .changeset/ updates. Run \`pnpm changeset\` or add the \`skip-changeset\` label."
+            exit 1
+          fi

--- a/.github/workflows/changeset-pr-guard.yml
+++ b/.github/workflows/changeset-pr-guard.yml
@@ -31,12 +31,13 @@ jobs:
           HEAD: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          if git diff --name-only "${BASE}" "${HEAD}" | grep -q '^packages/'; then
+          # Three-dot diff (BASE...HEAD): changes on HEAD since merge-base with BASE — matches PR scope.
+          if git diff --name-only "${BASE}...${HEAD}" | grep -q '^packages/'; then
             echo "packages_changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "packages_changed=false" >> "$GITHUB_OUTPUT"
           fi
-          if git diff --name-only "${BASE}" "${HEAD}" | grep -q '^\.changeset/'; then
+          if git diff --name-only "${BASE}...${HEAD}" | grep -q '^\.changeset/'; then
             echo "changeset_changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changeset_changed=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,29 +19,15 @@ jobs:
     permissions:
       contents: write
     outputs:
-      skip_publish: ${{ steps.version.outputs.skip_publish }}
+      skip_publish: ${{ steps.export_gate.outputs.skip_publish }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Apply changesets (push) or pass through to publish
-        id: version
-        env:
-          PUSH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+      - name: Detect pending changesets (no install)
+        id: detect
         run: |
           set -euo pipefail
           pending=0
@@ -55,13 +41,30 @@ jobs:
             break
           done
           shopt -u nullglob
+          echo "pending=${pending}" >> "$GITHUB_OUTPUT"
 
-          if [ "$pending" -eq 0 ]; then
-            echo "No pending changesets — publishing phase may run."
-            echo "skip_publish=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+      - uses: pnpm/action-setup@v4
+        if: steps.detect.outputs.pending == '1'
+        with:
+          version: 10
 
+      - uses: actions/setup-node@v4
+        if: steps.detect.outputs.pending == '1'
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        if: steps.detect.outputs.pending == '1'
+        run: pnpm install --frozen-lockfile
+
+      - name: Apply changesets (push)
+        id: version
+        if: steps.detect.outputs.pending == '1'
+        env:
+          PUSH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
           echo "Pending changesets detected — running changeset version."
           before=$(git rev-parse HEAD)
           git config user.name "github-actions[bot]"
@@ -80,6 +83,28 @@ jobs:
           git push "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${GITHUB_REF_NAME}"
           echo "Version commit pushed — npm publish runs on the next workflow run."
           echo "skip_publish=true" >> "$GITHUB_OUTPUT"
+
+      - name: No pending changesets — publish may run
+        id: version_pass
+        if: steps.detect.outputs.pending == '0'
+        run: |
+          echo "No pending changesets — publishing phase may run."
+          echo "skip_publish=false" >> "$GITHUB_OUTPUT"
+
+      - name: Export skip_publish for publish job
+        id: export_gate
+        if: success()
+        env:
+          PENDING: ${{ steps.detect.outputs.pending }}
+          FROM_VERSION: ${{ steps.version.outputs.skip_publish }}
+          FROM_PASS: ${{ steps.version_pass.outputs.skip_publish }}
+        run: |
+          set -euo pipefail
+          if [ "$PENDING" = "0" ]; then
+            echo "skip_publish=${FROM_PASS}" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip_publish=${FROM_VERSION}" >> "$GITHUB_OUTPUT"
+          fi
 
   publish:
     name: Publish to npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,8 @@
+# Two-phase release on main:
+# 1) Pending `.changeset/*.md` (from dev→main promotion) → `changeset version` + push (triggers this workflow again).
+# 2) No pending changesets → build + `changeset publish` to npm.
+#
+# Use RELEASE_BOT_TOKEN when GitHub Actions cannot push to protected `main` (see docs/workflows/release-workflow.md).
 name: Release
 
 on:
@@ -8,12 +13,81 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
-  release:
-    name: Release
+  version:
+    name: Version packages (Changesets)
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write
+    outputs:
+      skip_publish: ${{ steps.version.outputs.skip_publish }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Apply changesets (push) or pass through to publish
+        id: version
+        env:
+          PUSH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          pending=0
+          shopt -s nullglob
+          for f in .changeset/*.md; do
+            base=$(basename "$f")
+            if [ "$base" = "README.md" ]; then
+              continue
+            fi
+            pending=1
+            break
+          done
+          shopt -u nullglob
+
+          if [ "$pending" -eq 0 ]; then
+            echo "No pending changesets — publishing phase may run."
+            echo "skip_publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Pending changesets detected — running changeset version."
+          before=$(git rev-parse HEAD)
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          pnpm exec changeset version
+          pnpm install --no-frozen-lockfile
+          git add pnpm-lock.yaml
+          if ! git diff --cached --quiet; then
+            git commit -m "chore: sync lockfile after version bump"
+          fi
+          after=$(git rev-parse HEAD)
+          if [ "$before" = "$after" ]; then
+            echo "::error::changeset version did not create a commit — check .changeset/config.json commit settings."
+            exit 1
+          fi
+          git push "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${GITHUB_REF_NAME}"
+          echo "Version commit pushed — npm publish runs on the next workflow run."
+          echo "skip_publish=true" >> "$GITHUB_OUTPUT"
+
+  publish:
+    name: Publish to npm
+    needs: version
+    if: needs.version.outputs.skip_publish != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -55,12 +129,7 @@ jobs:
             exit 1
           fi
 
-      - name: Create release PR or publish
-        uses: changesets/action@v1
-        with:
-          publish: pnpm release
-          title: 'chore: version packages'
-          commit: 'chore: version packages'
+      - name: Publish packages
+        run: pnpm release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -1,0 +1,35 @@
+# After a successful Release on main, merge main into dev so dev picks up version bumps and changelog.
+name: Sync main into dev
+
+on:
+  workflow_run:
+    workflows:
+      - Release
+    types:
+      - completed
+
+jobs:
+  merge-main-into-dev:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'main'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Merge main into dev
+        env:
+          PUSH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin main dev
+          git checkout dev
+          git merge origin/main --no-edit -m "chore: sync main into dev [automated]"
+          git push "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:dev"

--- a/docs/workflows/release-workflow.md
+++ b/docs/workflows/release-workflow.md
@@ -18,10 +18,10 @@ Manual rescue: **Actions → Release → Run workflow** (`workflow_dispatch`) on
 
 Two-phase behavior:
 
-| Phase | Trigger | What happens |
-| ----- | ------- | ------------- |
+| Phase   | Trigger                                                                      | What happens                                                                                                                                      |
+| ------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Version | Push / dispatch on `main`, pending `.changeset/*.md` (excluding `README.md`) | `pnpm exec changeset version`, lockfile refresh (`pnpm install --no-frozen-lockfile` + lockfile commit if needed), **commit(s) pushed to `main`** |
-| Publish | Next push on `main` when no pending changesets | `pnpm build`, verify `dist/`, then **`pnpm release`** with `NODE_AUTH_TOKEN` |
+| Publish | Next push on `main` when no pending changesets                               | `pnpm build`, verify `dist/`, then **`pnpm release`** with `NODE_AUTH_TOKEN`                                                                      |
 
 `changeset publish` no-ops when local versions already match the registry.
 
@@ -62,11 +62,11 @@ Squash-merging **`dev` → `main`** normally keeps `.changeset/*.md` files as lo
 
 ## Required secrets
 
-| Secret | Where | Purpose |
-| ------ | ----- | ------- |
-| `NPM_TOKEN` | Repo → Settings → Secrets and variables → Actions | Publish to npm (automation token) |
+| Secret              | Where                                                      | Purpose                                                 |
+| ------------------- | ---------------------------------------------------------- | ------------------------------------------------------- |
+| `NPM_TOKEN`         | Repo → Settings → Secrets and variables → Actions          | Publish to npm (automation token)                       |
 | `RELEASE_BOT_TOKEN` | Same (optional but usually required on protected branches) | Push version commits to `main` and sync merges to `dev` |
-| `GITHUB_TOKEN` | Provided by Actions | Fallback when `RELEASE_BOT_TOKEN` is not set |
+| `GITHUB_TOKEN`      | Provided by Actions                                        | Fallback when `RELEASE_BOT_TOKEN` is not set            |
 
 ## Fork / dry-run verification
 

--- a/docs/workflows/release-workflow.md
+++ b/docs/workflows/release-workflow.md
@@ -47,7 +47,7 @@ Squash-merging **`dev` → `main`** normally keeps `.changeset/*.md` files as lo
 
 ## PR guard on `dev`
 
-`.github/workflows/changeset-pr-guard.yml` runs on PRs targeting **`dev`**. If the diff touches **`packages/`**, the PR must either:
+`.github/workflows/changeset-pr-guard.yml` runs on PRs targeting **`dev`**. File detection uses `git diff` **`base...head`** (merge-base range), so only changes introduced by the PR count—not unrelated drift on `dev`. If that scoped diff touches **`packages/`**, the PR must either:
 
 - include changes under **`.changeset/`**, or
 - carry the **`skip-changeset`** label (explicit opt-out).

--- a/docs/workflows/release-workflow.md
+++ b/docs/workflows/release-workflow.md
@@ -49,7 +49,7 @@ Squash-merging **`dev` → `main`** normally keeps `.changeset/*.md` files as lo
 
 `.github/workflows/changeset-pr-guard.yml` runs on PRs targeting **`dev`**. File detection uses `git diff` **`base...head`** (merge-base range), so only changes introduced by the PR count—not unrelated drift on `dev`. If that scoped diff touches **`packages/`**, the PR must either:
 
-- include changes under **`.changeset/`**, or
+- add or modify a **`.changeset/*.md`** entry (excluding `README.md`; config-only edits do not satisfy the guard), or
 - carry the **`skip-changeset`** label (explicit opt-out).
 
 ## Packages published

--- a/docs/workflows/release-workflow.md
+++ b/docs/workflows/release-workflow.md
@@ -1,20 +1,56 @@
-# Release Workflow
+# Release workflow
 
-portfolio-engine uses [Changesets](https://github.com/changesets/changesets) for version management and npm publishing.
+portfolio-engine uses [Changesets](https://github.com/changesets/changesets) for versioning and npm publishing. Promotion stays **feature branches → `dev` → `main`** (squash merge is fine). Maintainers ship by merging **`dev` into `main`**; CI applies versions and publishes—there is no manual “Version packages” PR step.
 
-## Normal release cycle
+## Ship checklist
 
-1. **During development** — every PR that changes a publishable package adds a changeset: `pnpm changeset`
-2. **Changesets bot** — automatically opens a "Version Packages" PR accumulating all changesets
-3. **Merge to main** — merging the version PR triggers `.github/workflows/release.yml`, which publishes all bumped packages to npm
+1. Confirm `.changeset/*.md` files are on **`dev`** before promotion (see **Squash merges and changesets** below).
+2. Open and merge a **`dev` → `main`** PR when ready to release.
+3. Wait for **Actions → Release** on `main`:
+   - First run with pending changesets: **`changeset version`** commits are pushed to `main`, then the workflow ends without publishing.
+   - Next run (triggered by that push): **build** + **`pnpm release`** (`changeset publish`) publishes to npm when versions are new.
+4. Confirm packages on npm (`npm view @portfolio-engine/<pkg> version`) after green Release runs.
+5. **Sync main → dev**: after each successful Release, **Sync main into dev** merges `main` into `dev` so version bumps and changelogs flow back. Resolve conflicts locally if that job fails.
 
-### Critical: `[skip ci]` blocks npm publishing
+Manual rescue: **Actions → Release → Run workflow** (`workflow_dispatch`) on `main` re-runs versioning logic (if changesets remain) or publish (when none remain).
 
-GitHub Actions **does not run** on pushes whose **HEAD commit message/body** contains `[skip ci]` (case-insensitive). The Changesets CLI’s version commit can include that marker when `skipCI` is enabled for **version** commits.
+## What runs on `main` (`.github/workflows/release.yml`)
 
-This repo sets **`"commit": ["@changesets/cli/commit", { "skipCI": false }]`** in `.changeset/config.json` so `pnpm changeset version` commits **still trigger** the Release workflow.
+Two-phase behavior:
 
-If packages were version-bumped on `main` but never appeared on npm, check Actions for a missing Release run; you can re-run publishing via **Actions → Release → Run workflow** (`workflow_dispatch`).
+| Phase | Trigger | What happens |
+| ----- | ------- | ------------- |
+| Version | Push / dispatch on `main`, pending `.changeset/*.md` (excluding `README.md`) | `pnpm exec changeset version`, lockfile refresh (`pnpm install --no-frozen-lockfile` + lockfile commit if needed), **commit(s) pushed to `main`** |
+| Publish | Next push on `main` when no pending changesets | `pnpm build`, verify `dist/`, then **`pnpm release`** with `NODE_AUTH_TOKEN` |
+
+`changeset publish` no-ops when local versions already match the registry.
+
+Do **not** run `changeset version` locally for routine releases; CI owns version commits on `main`.
+
+## Branch protection and bot pushes
+
+The default **`GITHUB_TOKEN`** often **cannot push** to protected `main`, even with `permissions: contents: write`.
+
+**Recommended:** add repository **Ruleset bypass** for **GitHub Actions** (narrowly if your plan allows), **or** store a **`RELEASE_BOT_TOKEN`** secret (fine-grained PAT or GitHub App installation token with **contents: write** on this repo). The Release workflow uses `RELEASE_BOT_TOKEN` when set; otherwise it falls back to `GITHUB_TOKEN`.
+
+Use the same bypass pattern for **`dev`** if **Sync main into dev** must push merge commits through protection.
+
+## Critical: `[skip ci]` blocks Actions
+
+GitHub Actions skips workflows when the **HEAD** commit message/body contains `[skip ci]` (case-insensitive).
+
+This repo sets **`"commit": ["@changesets/cli/commit", { "skipCI": false }]`** in `.changeset/config.json` so automated version commits **still trigger** the Release workflow.
+
+## Squash merges and changesets
+
+Squash-merging **`dev` → `main`** normally keeps `.changeset/*.md` files as long as they exist on the **`dev`** tip you squash. If the promotion PR omits those files (or `dev` never had them), the Release workflow will not version—verify the squash result includes `.changeset/` before merging.
+
+## PR guard on `dev`
+
+`.github/workflows/changeset-pr-guard.yml` runs on PRs targeting **`dev`**. If the diff touches **`packages/`**, the PR must either:
+
+- include changes under **`.changeset/`**, or
+- carry the **`skip-changeset`** label (explicit opt-out).
 
 ## Packages published
 
@@ -26,13 +62,25 @@ If packages were version-bumped on `main` but never appeared on npm, check Actio
 
 ## Required secrets
 
-| Secret         | Where                            | Purpose              |
-| -------------- | -------------------------------- | -------------------- |
-| `NPM_TOKEN`    | GitHub repo → Settings → Secrets | Publishing to npm    |
-| `GITHUB_TOKEN` | Auto-provided by Actions         | Creating version PRs |
+| Secret | Where | Purpose |
+| ------ | ----- | ------- |
+| `NPM_TOKEN` | Repo → Settings → Secrets and variables → Actions | Publish to npm (automation token) |
+| `RELEASE_BOT_TOKEN` | Same (optional but usually required on protected branches) | Push version commits to `main` and sync merges to `dev` |
+| `GITHUB_TOKEN` | Provided by Actions | Fallback when `RELEASE_BOT_TOKEN` is not set |
+
+## Fork / dry-run verification
+
+On a fork (with test npm scope or `publishConfig`/`--dry-run` adjustments if you need zero publishes):
+
+1. Add **`NPM_TOKEN`** and **`RELEASE_BOT_TOKEN`** (or relax branch protection) so CI can push `main`.
+2. Land a patch changeset on **`dev`**, merge **`dev` → `main`** (squash OK).
+3. Confirm **Release** run #1 pushes version/changelog commits and **does not** publish yet.
+4. Confirm **Release** run #2 builds and publishes (or no-ops if versions match registry).
+5. Inspect commit messages: automated version commits must **not** contain `[skip ci]` (see `.changeset/config.json`).
+6. Optionally run `npm view @portfolio-engine/<pkg> version` against your published tags.
 
 ## Patch reconciliation
 
-When `agreni-site` applies a local patch to fix a bug before it's upstreamed, the patch tracking workflow (Epic 9) opens a PR in `portfolio-engine` automatically. When the fix ships in a new release, Epic 10 automation opens a cleanup PR in `agreni-site` to remove the patch.
+When `agreni-site` applies a local patch before upstream lands the fix, patch tracking (Epic 9) opens a PR here. After a release ships, Epic 10 automation opens cleanup in `agreni-site`.
 
-See [../../docs/downstream/upgrade-path.md](../downstream/upgrade-path.md).
+See [../downstream/upgrade-path.md](../downstream/upgrade-path.md).


### PR DESCRIPTION
## Summary

This implements hands-off **dev → main** release automation: CI versions packages on `main` when `.changeset/*.md` are present, then publishes on the following run. Documentation describes secrets, branch protection, and verification.

## Changes

- **Release** (`.github/workflows/release.yml`): explicit `changeset version`, lockfile refresh when needed, push via `RELEASE_BOT_TOKEN` fallback to `GITHUB_TOKEN`; publish job runs when there are no pending changesets.
- **Changeset guard** (`.github/workflows/changeset-pr-guard.yml`): PRs to `dev` that touch `packages/` require `.changeset/` updates or the `skip-changeset` label.
- **Sync main → dev** (`.github/workflows/sync-main-to-dev.yml`): after a successful **Release** run on `main`, merge `main` into `dev`.
- **Docs** (`docs/workflows/release-workflow.md`): ship checklist, secrets, squash/changeset notes, fork dry-run steps.

## Maintainer notes

Configure **`RELEASE_BOT_TOKEN`** (or ruleset bypass) if protected branches block automated pushes. **`NPM_TOKEN`** remains required for publish.
