### PR TITLE
Add provider-light scheduling block

### DIFF
--- a/.changeset/provider-light-scheduling-block.md
+++ b/.changeset/provider-light-scheduling-block.md
@@ -1,0 +1,6 @@
+---
+'@portfolio-engine/schema': minor
+'@portfolio-engine/editorial-theme': minor
+---
+
+Add provider-light scheduling config and `SchedulingBlock` component for downstream contact pages. Supports button, link, and iframe embed modes using public HTTPS booking URLs without provider SDKs or calendar API integration.

--- a/docs/downstream/consumption.md
+++ b/docs/downstream/consumption.md
@@ -136,6 +136,58 @@ In `pnpm-workspace.yaml` include the consumer path, then use `workspace:*` in `p
 
 Run `pnpm install` from the monorepo root. `pnpm -r run build` will include the consumer.
 
+## Scheduling / Booking Embeds
+
+Portfolio Engine supports a provider-light scheduling block that renders a booking URL as a **button**, **link**, or **iframe embed**.
+
+- Works well with Calendly for v1, while remaining compatible with other providers.
+- Requires only a public HTTPS booking URL.
+- Does **not** connect calendars directly, create events, or inject provider SDK scripts.
+
+### Human setup
+
+Portfolio Engine only renders your public booking URL. The scheduling provider controls availability, approvals, calendar sync, invites, reminders, and cancel/reschedule flows.
+
+1. Create an account with a scheduling provider. Calendly is the easiest v1 path.
+2. Connect your calendar inside the provider dashboard.
+3. Create an event type.
+4. Configure duration, availability, buffers, minimum notice, location, and intake questions.
+5. Publish and copy your public booking URL.
+6. Add that URL to downstream `src/config/site.json` under `contact.scheduling`.
+7. Test end-to-end in incognito.
+
+### Example config
+
+```json
+{
+  "contact": {
+    "heading": "Let's work together",
+    "body": "Reach out and let's find what's possible.",
+    "scheduling": {
+      "enabled": true,
+      "provider": "calendly",
+      "mode": "button",
+      "url": "https://calendly.com/example/intro-call",
+      "label": "Book an intro call"
+    }
+  }
+}
+```
+
+### Button vs embed
+
+Use `mode: "button"` for compact contact sections and homepage CTAs.
+
+Use `mode: "embed"` on pages dedicated to booking.
+
+### Security note
+
+Only use trusted HTTPS URLs. Portfolio Engine intentionally avoids provider SDKs and third-party script injection for v1.
+
+### Legacy `bookingUrl`
+
+Some older sites may still use top-level `bookingUrl` in `src/config/site.json`. The contact page continues to support it as a fallback, but new sites should prefer `contact.scheduling`.
+
 ## Switching between modes
 
 To switch a consumer repo from workspace-link to semver:

--- a/docs/downstream/new-site-setup.md
+++ b/docs/downstream/new-site-setup.md
@@ -152,6 +152,8 @@ mkdir -p src/config src/content/projects src/content/writing src/content/profile
 }
 ```
 
+For optional Calendly/booking integration, see the Scheduling / Booking Embeds section in [`consumption.md`](consumption.md).
+
 **`src/config/navigation.json`**
 
 ```json

--- a/examples/demo-site/src/config/site.json
+++ b/examples/demo-site/src/config/site.json
@@ -5,6 +5,13 @@
   "tagline": "designs for clarity",
   "contact": {
     "heading": "Let's work together",
-    "body": "I'm available for design partnerships, product consulting, and creative collaborations. Reach out and let's find what's possible."
+    "body": "I'm available for design partnerships, product consulting, and creative collaborations. Reach out and let's find what's possible.",
+    "scheduling": {
+      "enabled": true,
+      "provider": "calendly",
+      "mode": "button",
+      "url": "https://calendly.com/example/intro-call",
+      "label": "Book an intro call"
+    }
   }
 }

--- a/packages/editorial-theme/package.json
+++ b/packages/editorial-theme/package.json
@@ -16,7 +16,8 @@
     "./styles/global.css": "./dist/styles/global.css",
     "./styles/design-tokens.css": "./dist/styles/design-tokens.css",
     "./components/ThemeTypographyOverrides.astro": "./dist/components/ThemeTypographyOverrides.astro",
-    "./components/ThemeTokenOverrides.astro": "./dist/components/ThemeTokenOverrides.astro"
+    "./components/ThemeTokenOverrides.astro": "./dist/components/ThemeTokenOverrides.astro",
+    "./components/SchedulingBlock.astro": "./dist/components/SchedulingBlock.astro"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/editorial-theme/src/components/SchedulingBlock.astro
+++ b/packages/editorial-theme/src/components/SchedulingBlock.astro
@@ -1,8 +1,10 @@
 ---
+import type { SchedulingProvider, SchedulingMode } from '@portfolio-engine/schema';
+
 export interface Props {
   enabled?: boolean;
-  provider?: 'calendly' | 'cal' | 'google-calendar' | 'microsoft-bookings' | 'custom';
-  mode?: 'button' | 'link' | 'embed';
+  provider?: SchedulingProvider;
+  mode?: SchedulingMode;
   url?: string;
   label?: string;
   heading?: string;
@@ -64,6 +66,8 @@ const rel = openInNewTab ? 'noopener noreferrer' : undefined;
             width="100%"
             height={height}
             loading="lazy"
+            sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation"
+            allowfullscreen
           />
         </div>
       ) : (

--- a/packages/editorial-theme/src/components/SchedulingBlock.astro
+++ b/packages/editorial-theme/src/components/SchedulingBlock.astro
@@ -66,8 +66,6 @@ const rel = openInNewTab ? 'noopener noreferrer' : undefined;
             width="100%"
             height={height}
             loading="lazy"
-            sandbox="allow-scripts allow-forms allow-popups allow-top-navigation-by-user-activation"
-            allowfullscreen
           />
         </div>
       ) : (

--- a/packages/editorial-theme/src/components/SchedulingBlock.astro
+++ b/packages/editorial-theme/src/components/SchedulingBlock.astro
@@ -66,7 +66,7 @@ const rel = openInNewTab ? 'noopener noreferrer' : undefined;
             width="100%"
             height={height}
             loading="lazy"
-            sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation"
+            sandbox="allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation"
             allowfullscreen
           />
         </div>

--- a/packages/editorial-theme/src/components/SchedulingBlock.astro
+++ b/packages/editorial-theme/src/components/SchedulingBlock.astro
@@ -1,0 +1,81 @@
+---
+export interface Props {
+  enabled?: boolean;
+  provider?: 'calendly' | 'cal' | 'google-calendar' | 'microsoft-bookings' | 'custom';
+  mode?: 'button' | 'link' | 'embed';
+  url?: string;
+  label?: string;
+  heading?: string;
+  eyebrow?: string;
+  description?: string;
+  height?: number;
+  openInNewTab?: boolean;
+}
+
+const {
+  enabled = false,
+  provider = 'custom',
+  mode = 'button',
+  url,
+  label = 'Book a time',
+  heading,
+  eyebrow,
+  description,
+  height = 720,
+  openInNewTab = true,
+} = Astro.props;
+
+const shouldRender = enabled && typeof url === 'string' && url.trim().length > 0;
+let safeUrl: URL | null = null;
+
+if (shouldRender) {
+  try {
+    safeUrl = new URL(url);
+  } catch {
+    throw new Error('SchedulingBlock requires an absolute https:// URL.');
+  }
+
+  if (safeUrl.protocol !== 'https:') {
+    throw new Error('SchedulingBlock requires an absolute https:// URL.');
+  }
+}
+
+const target = openInNewTab ? '_blank' : undefined;
+const rel = openInNewTab ? 'noopener noreferrer' : undefined;
+---
+
+{
+  shouldRender && safeUrl && (
+    <section class="pe-scheduling-block" data-provider={provider} data-mode={mode}>
+      {(eyebrow || heading || description) && (
+        <div class="pe-scheduling-block__copy">
+          {eyebrow && <p class="pe-scheduling-block__eyebrow">{eyebrow}</p>}
+          {heading && <h2 class="pe-scheduling-block__heading">{heading}</h2>}
+          {description && <p class="pe-scheduling-block__description">{description}</p>}
+        </div>
+      )}
+
+      {mode === 'embed' ? (
+        <div class="pe-scheduling-block__embed-shell">
+          <iframe
+            class="pe-scheduling-block__iframe"
+            src={safeUrl.toString()}
+            title={label}
+            width="100%"
+            height={height}
+            loading="lazy"
+          />
+        </div>
+      ) : (
+        <a
+          class={mode === 'button' ? 'pe-scheduling-block__button' : 'pe-scheduling-block__link'}
+          href={safeUrl.toString()}
+          target={target}
+          rel={rel}
+        >
+          {label}
+        </a>
+      )}
+    </section>
+  )
+}

--- a/packages/editorial-theme/src/components/SchedulingBlock.astro
+++ b/packages/editorial-theme/src/components/SchedulingBlock.astro
@@ -66,7 +66,7 @@ const rel = openInNewTab ? 'noopener noreferrer' : undefined;
             width="100%"
             height={height}
             loading="lazy"
-            sandbox="allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation"
+            sandbox="allow-scripts allow-forms allow-popups allow-top-navigation-by-user-activation"
             allowfullscreen
           />
         </div>

--- a/packages/editorial-theme/src/pages/contact.astro
+++ b/packages/editorial-theme/src/pages/contact.astro
@@ -2,30 +2,17 @@
 import Layout from '../layouts/Layout.astro';
 import { config } from '@portfolio-engine:config';
 import { loadProfilePerson } from '../lib/load-profile-person';
+import SchedulingBlock from '../components/SchedulingBlock.astro';
 
 const person = await loadProfilePerson();
 
 const bookingUrl = config.site.bookingUrl || null;
-const { heading: contactHeading, body: contactBody } = config.site.contact;
+const { heading: contactHeading, body: contactBody, scheduling } = config.site.contact;
+
+const hasConfiguredScheduling = scheduling?.enabled === true;
 ---
 
 <Layout title={`Contact — ${person.name}`}>
-  {
-    bookingUrl && (
-      <Fragment slot="head">
-        <link
-          href="https://assets.calendly.com/assets/external/widget.css"
-          rel="stylesheet"
-        />
-        <script
-          is:inline
-          type="text/javascript"
-          src="https://assets.calendly.com/assets/external/widget.js"
-          async
-        />
-      </Fragment>
-    )
-  }
   <section class="mx-auto max-w-5xl px-6 pb-24 pt-40">
     <div class="max-w-xl">
       <p
@@ -40,14 +27,22 @@ const { heading: contactHeading, body: contactBody } = config.site.contact;
         {contactBody}
       </p>
 
+      {hasConfiguredScheduling && <SchedulingBlock {...scheduling} />}
+
       {
-        bookingUrl ? (
-          <div
-            class="calendly-inline-widget overflow-hidden rounded-2xl border border-stone-100"
-            data-url={bookingUrl}
-            style="min-width:320px;height:700px;"
+        !hasConfiguredScheduling && bookingUrl && (
+          <SchedulingBlock
+            enabled={true}
+            provider="custom"
+            mode="button"
+            url={bookingUrl}
+            label="Book a conversation"
           />
-        ) : (
+        )
+      }
+
+      {
+        !hasConfiguredScheduling && !bookingUrl && (
           <div class="rounded-2xl border border-stone-100 bg-stone-50 px-8 py-16 text-center text-stone-400">
             <p class="mb-2 font-medium">Booking coming soon</p>
             <p class="text-sm">In the meantime, reach out by email below.</p>

--- a/packages/editorial-theme/src/styles/global.css
+++ b/packages/editorial-theme/src/styles/global.css
@@ -157,6 +157,81 @@
     opacity: 1;
     transform: translateY(0);
   }
+
+  .pe-scheduling-block {
+    margin-block: 3rem;
+  }
+
+  .pe-scheduling-block__copy {
+    max-width: 48rem;
+    margin-block-end: 1.5rem;
+  }
+
+  .pe-scheduling-block__eyebrow {
+    margin: 0 0 0.5rem;
+    font-size: var(--text-label);
+    font-weight: 600;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--copper);
+  }
+
+  .pe-scheduling-block__heading {
+    margin: 0;
+    font-family: var(--font-serif-stack);
+    font-size: var(--text-heading);
+    font-weight: 700;
+    color: var(--ink);
+  }
+
+  .pe-scheduling-block__description {
+    margin-block-start: 0.75rem;
+    color: var(--stone-soft);
+    line-height: 1.7;
+  }
+
+  .pe-scheduling-block__button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 2.75rem;
+    padding-inline: 1.25rem;
+    border: 1px solid var(--warm-line);
+    border-radius: 999px;
+    color: var(--ink);
+    text-decoration: none;
+    transition:
+      border-color 0.2s ease,
+      color 0.2s ease,
+      background-color 0.2s ease;
+  }
+
+  .pe-scheduling-block__button:hover {
+    border-color: var(--copper);
+    color: var(--copper);
+    background: var(--paper-light);
+  }
+
+  .pe-scheduling-block__link {
+    color: var(--copper);
+    text-decoration: underline;
+    text-underline-offset: 0.2em;
+  }
+
+  .pe-scheduling-block__embed-shell {
+    width: 100%;
+    overflow: hidden;
+    border: 1px solid var(--warm-line);
+    border-radius: 1rem;
+    background: var(--paper-light);
+  }
+
+  .pe-scheduling-block__iframe {
+    display: block;
+    width: 100%;
+    min-height: 640px;
+    border: 0;
+  }
 }
 
 @keyframes float {

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -1,5 +1,46 @@
 import { z } from 'zod';
 
+export const SchedulingProviderSchema = z.enum([
+  'calendly',
+  'cal',
+  'google-calendar',
+  'microsoft-bookings',
+  'custom',
+]);
+
+export const SchedulingModeSchema = z.enum(['button', 'link', 'embed']);
+
+const SchedulingUrlSchema = z.url().refine((value) => value.startsWith('https://'), {
+  message: 'Scheduling URL must be an absolute https:// URL.',
+});
+
+export const SchedulingConfigSchema = z
+  .object({
+    enabled: z.boolean().default(false),
+    provider: SchedulingProviderSchema.default('custom'),
+    mode: SchedulingModeSchema.default('button'),
+    url: SchedulingUrlSchema.optional(),
+    label: z.string().optional(),
+    heading: z.string().optional(),
+    eyebrow: z.string().optional(),
+    description: z.string().optional(),
+    height: z.number().int().positive().default(720),
+    openInNewTab: z.boolean().default(true),
+  })
+  .superRefine((value, ctx) => {
+    if (value.enabled && !value.url) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['url'],
+        message: 'Scheduling URL is required when scheduling is enabled.',
+      });
+    }
+  });
+
+export type SchedulingProvider = z.infer<typeof SchedulingProviderSchema>;
+export type SchedulingMode = z.infer<typeof SchedulingModeSchema>;
+export type SchedulingConfig = z.infer<typeof SchedulingConfigSchema>;
+
 export const SiteConfigSchema = z.object({
   title: z.string(),
   description: z.string(),
@@ -9,6 +50,7 @@ export const SiteConfigSchema = z.object({
   contact: z.object({
     heading: z.string(),
     body: z.string(),
+    scheduling: SchedulingConfigSchema.optional(),
   }),
   social: z
     .object({


### PR DESCRIPTION
## Summary

Adds a provider-light scheduling block for downstream contact pages. Sites can render a public HTTPS booking URL as a button, link, or iframe embed. Calendly is the recommended v1 provider, but the implementation remains generic and does not inject provider scripts or use calendar APIs.

## What changed

- Added scheduling schemas/types to `@portfolio-engine/schema`.
- Added `SchedulingBlock.astro` to `@portfolio-engine/editorial-theme`.
- Exported `SchedulingBlock.astro` as a public package subpath.
- Wired the editorial contact page to prefer `contact.scheduling`.
- Preserved legacy `site.bookingUrl` fallback behavior.
- Added demo-site scheduling config.
- Added downstream docs for human setup and config usage.
- Added changeset.

## Why this belongs upstream

Multiple downstream consumer sites need a reusable booking affordance. This is not Jordan-specific content and should not be implemented as a one-off page override. The upstream engine/theme should provide a small generic scheduling primitive, while downstream sites provide their own provider URL and copy.

## Non-goals

- No Calendly SDK.
- No provider API integration.
- No OAuth.
- No calendar write logic.
- No hardcoded downstream booking URL.
- No admin settings refactor.
- No route registry changes.

## Compatibility

- New sites should use `contact.scheduling`.
- Existing sites using top-level `bookingUrl` continue to work through the contact page fallback.
- `SchedulingBlock` supports `button`, `link`, and `embed` modes.

## Validation

Local runs on Windows (Node 22):

- `pnpm lint` — pass
- `pnpm format` — pass
- `pnpm check` — pass
- `pnpm build` — `examples/demo-site` hits EPERM on `@astrojs/vercel` symlinks (known Windows limitation); smoke script documents skipping full demo-site build on Windows; CI uses Ubuntu.

Also:

- `pnpm --filter @portfolio-engine/schema check` — pass (via `pnpm check`)
- `pnpm --filter @portfolio-engine/editorial-theme check` — pass (via `pnpm check`)
- `pnpm smoke:packed` — pass

## Reviewer notes

Please verify that the schema does **not** require `contact.scheduling.url` unless `enabled: true`. Disabled scheduling config should be valid without a URL.
