### PR TITLE
chore(release): promote dev -> main (release automation)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,11 +112,13 @@ jobs:
     if: needs.version.outputs.skip_publish != 'true'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      # changeset publish creates @scope/pkg@x.y.z git tags — contents:write is required to push them.
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
 
       - uses: pnpm/action-setup@v4
         with:

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,7 +3,7 @@
   "tasks": [
     {
       "label": "Promote dev → main",
-      "detail": "Create or reuse dev→main PR, wait for CI, merge (requires gh CLI + auth)",
+      "detail": "dev→main PR, CI, merge, then workflow_dispatch Release so npm publish runs (gh CLI + auth)",
       "type": "shell",
       "options": {
         "cwd": "${workspaceFolder}",

--- a/docs/workflows/release-workflow.md
+++ b/docs/workflows/release-workflow.md
@@ -14,6 +14,10 @@ portfolio-engine uses [Changesets](https://github.com/changesets/changesets) for
 
 Manual rescue: **Actions → Release → Run workflow** (`workflow_dispatch`) on `main` re-runs versioning logic (if changesets remain) or publish (when none remain).
 
+The **Promote dev → main** VS Code task (`scripts/promote-dev-to-main.*`) merges the promotion PR and then **queues `Release` via `workflow_dispatch`**, so the npm publish phase always runs even when the automated `RELEASING` push does not start a follow-up workflow (default `GITHUB_TOKEN` limitation).
+
+**Git tags:** `changeset publish` creates tags like `@portfolio-engine/schema@0.3.0`. The **Publish to npm** job uses **`contents: write`** so those tags can be pushed. After a release, refresh locally with `git fetch origin main --tags` if Git Graph does not show new tags.
+
 ## What runs on `main` (`.github/workflows/release.yml`)
 
 Two-phase behavior:

--- a/packages/admin-tools/package.json
+++ b/packages/admin-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@portfolio-engine/admin-tools",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Admin and reviewer UI components for portfolio-engine sites",
   "type": "module",
   "files": [

--- a/packages/admin-tools/src/routes/admin.astro
+++ b/packages/admin-tools/src/routes/admin.astro
@@ -1215,9 +1215,12 @@ const googleFontsHref = editorialGoogleFontsStylesheetHref(config.theme);
       }
     </style>
 
-    <script define:vars={{ contentApiUrl }}>
+    <script>
       import { initAdminApp } from '../client/admin-app.ts';
-      initAdminApp(contentApiUrl);
+
+      const root = document.getElementById('admin-root');
+      const contentApiUrl = root?.dataset.contentApi ?? '';
+      if (contentApiUrl) initAdminApp(contentApiUrl);
     </script>
   </body>
 </html>

--- a/packages/admin-tools/tsup.config.ts
+++ b/packages/admin-tools/tsup.config.ts
@@ -4,7 +4,7 @@ import { cpSync, existsSync, mkdirSync } from 'node:fs';
 /** Routes, components, and server modules are consumed by Astro at consumer build time. */
 function copyAstroAndApiTree() {
   mkdirSync('dist', { recursive: true });
-  for (const dir of ['routes', 'components', 'server', 'lib']) {
+  for (const dir of ['routes', 'components', 'server', 'lib', 'client']) {
     if (existsSync(`src/${dir}`)) {
       cpSync(`src/${dir}`, `dist/${dir}`, { recursive: true });
     }

--- a/scripts/promote-dev-to-main.ps1
+++ b/scripts/promote-dev-to-main.ps1
@@ -41,4 +41,11 @@ gh pr checks $pr --watch
 Write-Host "Merging PR #$pr ..."
 gh pr merge $pr --merge --delete-branch=false
 
-Write-Host 'Done. main should update shortly; Release runs on push to main.'
+# The merge push starts Release (changeset version). That job pushes the RELEASING commit
+# with GITHUB_TOKEN, which does not trigger a second workflow — so npm publish would not
+# run until another Release trigger. Queue publish explicitly (waits behind the in-flight
+# Release run due to workflow concurrency on main).
+Write-Host ''
+Write-Host 'Queuing Release publish phase (workflow_dispatch on main)...'
+gh workflow run Release --ref main
+Write-Host 'Done. Watch Actions -> Release on main; when the follow-up run finishes, run: git fetch origin main --tags'

--- a/scripts/promote-dev-to-main.ps1
+++ b/scripts/promote-dev-to-main.ps1
@@ -41,11 +41,43 @@ gh pr checks $pr --watch
 Write-Host "Merging PR #$pr ..."
 gh pr merge $pr --merge --delete-branch=false
 
-# The merge push starts Release (changeset version). That job pushes the RELEASING commit
-# with GITHUB_TOKEN, which does not trigger a second workflow — so npm publish would not
-# run until another Release trigger. Queue publish explicitly (waits behind the in-flight
-# Release run due to workflow concurrency on main).
+# The merge push starts Release (changeset version when .changeset/*.md exist). That job
+# pushes the RELEASING commit with GITHUB_TOKEN, which does not trigger a second workflow,
+# so npm publish would not run until another Release trigger. Always queue a follow-up
+# Release (waits behind the in-flight run due to workflow concurrency on main).
 Write-Host ''
-Write-Host 'Queuing Release publish phase (workflow_dispatch on main)...'
+Write-Host 'Queuing follow-up Release on main (workflow_dispatch)...'
+$dispatchAfter = [datetime]::UtcNow.AddSeconds(-30)
 gh workflow run Release --ref main
-Write-Host 'Done. Watch Actions -> Release on main; when the follow-up run finishes, run: git fetch origin main --tags'
+
+Write-Host 'Waiting for the workflow_dispatch Release run to finish...'
+$runId = $null
+for ($k = 0; $k -lt 120; $k++) {
+  $rows = gh run list --workflow Release --branch main --limit 15 --json databaseId,event,status,createdAt | ConvertFrom-Json
+  $candidates = @()
+  foreach ($row in $rows) {
+    if ($row.event -ne 'workflow_dispatch') { continue }
+    try {
+      $created = [datetime]::Parse($row.createdAt, $null, [System.Globalization.DateTimeStyles]::RoundtripKind)
+    } catch {
+      continue
+    }
+    if ($created -ge $dispatchAfter) {
+      $candidates += [pscustomobject]@{ Id = $row.databaseId; Created = $created }
+    }
+  }
+  if ($candidates.Count -gt 0) {
+    $runId = ($candidates | Sort-Object Created -Descending | Select-Object -First 1).Id
+    break
+  }
+  Start-Sleep -Seconds 3
+}
+
+if ($null -eq $runId) {
+  Write-Warning 'Could not resolve the workflow_dispatch Release run. Check Actions -> Release on main.'
+  exit 0
+}
+
+gh run watch $runId --exit-status
+Write-Host "Release run $runId completed."
+Write-Host 'Tip: git fetch origin main --tags  (then refresh Git Graph)'

--- a/scripts/promote-dev-to-main.sh
+++ b/scripts/promote-dev-to-main.sh
@@ -35,11 +35,38 @@ gh pr checks "$pr" --watch
 echo "Merging PR #${pr} …"
 gh pr merge "$pr" --merge --delete-branch=false
 
-# The merge push starts Release (changeset version). That job pushes the RELEASING commit
-# with GITHUB_TOKEN, which does not trigger a second workflow — so npm publish would not
-# run until another Release trigger. Queue publish explicitly (waits behind the in-flight
-# Release run due to workflow concurrency on main).
+# The merge push starts Release (changeset version when .changeset/*.md exist). That job
+# pushes the RELEASING commit with GITHUB_TOKEN, which does not trigger a second workflow,
+# so npm publish would not run until another Release trigger. Always queue a follow-up
+# Release (waits behind the in-flight run due to workflow concurrency on main).
 echo ''
-echo 'Queuing Release publish phase (workflow_dispatch on main)…'
+echo 'Queuing follow-up Release on main (workflow_dispatch)…'
+before_sec="$(date -u +%s)"
 gh workflow run Release --ref main
-echo 'Done. Watch Actions → Release on main; when the follow-up run finishes, run: git fetch origin main --tags'
+
+echo 'Waiting for the workflow_dispatch Release run to finish…'
+run_id=""
+sleep 4
+for _ in $(seq 1 120); do
+  run_id="$(
+    gh run list --workflow Release --branch main --limit 15 --json databaseId,event,createdAt |
+      jq -r --argjson b "$before_sec" '
+        [.[] | select(.event == "workflow_dispatch")
+          | select((.createdAt | fromdateiso8601) > ($b - 15))]
+        | sort_by(.createdAt) | reverse | .[0].databaseId // empty
+      '
+  )"
+  if [[ -n "$run_id" ]]; then
+    break
+  fi
+  sleep 3
+done
+
+if [[ -z "$run_id" ]]; then
+  echo 'Warning: could not resolve the workflow_dispatch Release run. Check Actions → Release on main.' >&2
+  exit 0
+fi
+
+gh run watch "$run_id" --exit-status
+echo "Release run ${run_id} completed."
+echo 'Tip: git fetch origin main --tags  (then refresh Git Graph)'

--- a/scripts/promote-dev-to-main.sh
+++ b/scripts/promote-dev-to-main.sh
@@ -35,4 +35,11 @@ gh pr checks "$pr" --watch
 echo "Merging PR #${pr} …"
 gh pr merge "$pr" --merge --delete-branch=false
 
-echo 'Done. main should update shortly; Release runs on push to main.'
+# The merge push starts Release (changeset version). That job pushes the RELEASING commit
+# with GITHUB_TOKEN, which does not trigger a second workflow — so npm publish would not
+# run until another Release trigger. Queue publish explicitly (waits behind the in-flight
+# Release run due to workflow concurrency on main).
+echo ''
+echo 'Queuing Release publish phase (workflow_dispatch on main)…'
+gh workflow run Release --ref main
+echo 'Done. Watch Actions → Release on main; when the follow-up run finishes, run: git fetch origin main --tags'


### PR DESCRIPTION
## Summary

- Release workflow: publish job can push git tags (\contents: write\).
- Promote dev→main scripts: queue follow-up \Release\ via \workflow_dispatch\ and **wait** until it completes (covers GITHUB_TOKEN not re-triggering after RELEASING push).

## After merge

npm may no-op if versions already match registry; the important outcome is **main** has the fixed workflow and **future** promotions publish automatically from the VS Code task.

Made with [Cursor](https://cursor.com)