### PR TITLE
Phase 7: consumer registry format ADR + SSR local-route fixture

### DIFF
--- a/docs/downstream/custom-page-via-registry.md
+++ b/docs/downstream/custom-page-via-registry.md
@@ -6,6 +6,12 @@ This recipe matches the MVP in [Epic: consumer registry](https://github.com/rain
 
 - Astro site using `editorialTheme()` from `@portfolio-engine/editorial-theme` (same setup as [new-site-setup](./new-site-setup.md)).
 
+## Registry format (Phase 7)
+
+The contract on disk is **JSON** under `src/registry/`; **`@portfolio-engine/schema`** provides Zod validation and inferred types (`parseConsumerPortfolioEngineRegistry`). Rationale, versioning, and admin-tools considerations are recorded in **ADR-005** (`portfolio_engine_v5_report_pack/source/decisions/ADR-005-consumer-extension-registry-format.md`).
+
+**Admin-tools:** with the default admin-tools setup, `src/registry/portfolio-engine.registry.json` is an allowed path for inventory, read, and save (local `devBypass` or GitHub API mode), so editors do not need a separate “registry editor” to adjust routes.
+
 ## Steps
 
 ### 1. Registry file
@@ -81,6 +87,7 @@ Pass these to `editorialTheme()` / `createEngineIntegration()`:
 
 Routes from the registry appear in `.portfolio-engine/manifest.json` with `"routeOrigin": "consumer-local"`. `capabilities.consumerLocalRoutes` is `true` when at least one such route is active.
 
-## Verified example
+## Verified examples
 
-`examples/demo-site` in this repo implements `/how-i-think` using the steps above.
+- `examples/demo-site` — static output; route `/how-i-think`.
+- `examples/node-ssr-demo` — `output: 'server'` with `@astrojs/node`; route `/ssr-registry-smoke`.

--- a/docs/downstream/custom-page-via-registry.md
+++ b/docs/downstream/custom-page-via-registry.md
@@ -10,7 +10,7 @@ This recipe matches the MVP in [Epic: consumer registry](https://github.com/rain
 
 The contract on disk is **JSON** under `src/registry/`; **`@portfolio-engine/schema`** provides Zod validation and inferred types (`parseConsumerPortfolioEngineRegistry`). Rationale, versioning, and admin-tools considerations are recorded in **ADR-005** (`portfolio_engine_v5_report_pack/source/decisions/ADR-005-consumer-extension-registry-format.md`).
 
-**Admin-tools:** with the default admin-tools setup, `src/registry/portfolio-engine.registry.json` is an allowed path for inventory, read, and save (local `devBypass` or GitHub API mode), so editors do not need a separate “registry editor” to adjust routes.
+**Admin-tools:** `src/registry/` is an allowed root. In **local `devBypass` development**, registry file **listing**, read, and save all use your working tree on disk. In **OAuth (GitHub Contents API) mode**, **read and save** for a known file path (for example `src/registry/portfolio-engine.registry.json`) go through GitHub; **directory listings** for the registry section still use `node:fs` under `process.cwd()` (see `packages/admin-tools/src/routes/api/content.ts`), so they only reflect files present on that server—typically your laptop when running `astro dev`, not a remote tree listing from GitHub.
 
 ## Steps
 

--- a/docs/downstream/custom-page-via-registry.md
+++ b/docs/downstream/custom-page-via-registry.md
@@ -8,9 +8,9 @@ This recipe matches the MVP in [Epic: consumer registry](https://github.com/rain
 
 ## Registry format (Phase 7)
 
-The contract on disk is **JSON** under `src/registry/`; **`@portfolio-engine/schema`** provides Zod validation and inferred types (`parseConsumerPortfolioEngineRegistry`). Rationale, versioning, and admin-tools considerations are recorded in **ADR-005** (`portfolio_engine_v5_report_pack/source/decisions/ADR-005-consumer-extension-registry-format.md`).
+The contract on disk is **JSON** under `src/registry/`; **`@portfolio-engine/schema`** provides Zod validation and inferred types (`parseConsumerPortfolioEngineRegistry`). Rationale, versioning, and admin-tools trade-offs are summarized in [ADR-005 (consumer extension registry format)](https://github.com/rainonej/portfolio-engine/blob/main/portfolio_engine_v5_report_pack/source/decisions/ADR-005-consumer-extension-registry-format.md) in the upstream repo (stable URL for copies of this doc).
 
-**Admin-tools:** `src/registry/` is an allowed root. In **local `devBypass` development**, registry file **listing**, read, and save all use your working tree on disk. In **OAuth (GitHub Contents API) mode**, **read and save** for a known file path (for example `src/registry/portfolio-engine.registry.json`) go through GitHub; **directory listings** for the registry section still use `node:fs` under `process.cwd()` (see `packages/admin-tools/src/routes/api/content.ts`), so they only reflect files present on that server—typically your laptop when running `astro dev`, not a remote tree listing from GitHub.
+**Admin-tools:** `src/registry/` is an allowed root. In **local `devBypass` development**, registry file **listing**, read, and save all use your working tree on disk. In **OAuth (GitHub Contents API) mode**, **read and save** for a known file path (for example `src/registry/portfolio-engine.registry.json`) go through GitHub; **directory listings** for the registry section still use `node:fs` under `process.cwd()` in admin-tools (see [content API route source](https://github.com/rainonej/portfolio-engine/blob/main/packages/admin-tools/src/routes/api/content.ts)), so they only reflect files present on that server—typically your laptop when running `astro dev`, not a remote tree listing from GitHub.
 
 ## Steps
 

--- a/docs/downstream/templates/vscode/tasks.json
+++ b/docs/downstream/templates/vscode/tasks.json
@@ -20,15 +20,11 @@
       },
       "linux": {
         "command": "bash",
-        "args": [
-          "${workspaceFolder}/docs/downstream/scripts/upgrade-portfolio-engine.sh"
-        ]
+        "args": ["${workspaceFolder}/docs/downstream/scripts/upgrade-portfolio-engine.sh"]
       },
       "osx": {
         "command": "bash",
-        "args": [
-          "${workspaceFolder}/docs/downstream/scripts/upgrade-portfolio-engine.sh"
-        ]
+        "args": ["${workspaceFolder}/docs/downstream/scripts/upgrade-portfolio-engine.sh"]
       },
       "problemMatcher": [],
       "presentation": {

--- a/examples/node-ssr-demo/.portfolio-engine/manifest.json
+++ b/examples/node-ssr-demo/.portfolio-engine/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-05T15:51:55.006Z",
+  "generatedAt": "2026-05-06T01:18:39.483Z",
   "rootDir": ".",
   "routes": [
     {
@@ -71,6 +71,16 @@
       "disableable": true,
       "agentGuidance": "Prefer Writing for public-facing navigation tasks.",
       "resolved": "/writing"
+    },
+    {
+      "pattern": "/ssr-registry-smoke",
+      "resolved": "/ssr-registry-smoke",
+      "label": "Registry smoke (SSR)",
+      "section": null,
+      "visibility": "public",
+      "remappable": false,
+      "disableable": false,
+      "routeOrigin": "consumer-local"
     }
   ],
   "overrideSurfaces": [
@@ -136,6 +146,6 @@
     "routeRemap": true,
     "routeDisable": true,
     "namedOverrides": true,
-    "consumerLocalRoutes": false
+    "consumerLocalRoutes": true
   }
 }

--- a/examples/node-ssr-demo/src/config/navigation.json
+++ b/examples/node-ssr-demo/src/config/navigation.json
@@ -3,6 +3,7 @@
     { "label": "Work", "href": "/work", "order": 1, "visible": true },
     { "label": "Writing", "href": "/writing", "order": 2, "visible": true },
     { "label": "About", "href": "/about", "order": 3, "visible": true },
-    { "label": "Contact", "href": "/contact", "order": 4, "visible": true }
+    { "label": "Contact", "href": "/contact", "order": 4, "visible": true },
+    { "label": "SSR registry", "href": "/ssr-registry-smoke", "order": 5, "visible": true }
   ]
 }

--- a/examples/node-ssr-demo/src/pages-local/ssr-registry-smoke.astro
+++ b/examples/node-ssr-demo/src/pages-local/ssr-registry-smoke.astro
@@ -1,0 +1,23 @@
+---
+/**
+ * Consumer-local page for the node SSR fixture: proves registry injection works
+ * with `output: 'server'` + `@astrojs/node`, not only static demo-site builds.
+ */
+import Layout from '@portfolio-engine/editorial-theme/layouts/Layout.astro';
+---
+
+<Layout
+  title="SSR registry smoke"
+  description="Consumer-local route via portfolio-engine registry on output: server"
+>
+  <main class="mx-auto max-w-prose px-4 py-16">
+    <h1 class="text-3xl font-semibold tracking-tight">SSR + consumer registry</h1>
+    <p class="mt-4 text-neutral-600 dark:text-neutral-400">
+      This route is declared in <code class="rounded bg-neutral-100 px-1 py-0.5 dark:bg-neutral-800"
+        >src/registry/portfolio-engine.registry.json</code
+      > and rendered from <code class="rounded bg-neutral-100 px-1 py-0.5 dark:bg-neutral-800"
+        >src/pages-local/</code
+      > on the <code class="rounded bg-neutral-100 px-1 py-0.5 dark:bg-neutral-800">node-ssr-demo</code> example.
+    </p>
+  </main>
+</Layout>

--- a/examples/node-ssr-demo/src/registry/portfolio-engine.registry.json
+++ b/examples/node-ssr-demo/src/registry/portfolio-engine.registry.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "localRoutes": [
+    {
+      "pattern": "/ssr-registry-smoke",
+      "page": "ssr-registry-smoke.astro",
+      "label": "Registry smoke (SSR)",
+      "section": null,
+      "visibility": "public"
+    }
+  ]
+}

--- a/portfolio_engine_v5_report_pack/scripts/validate_report.mjs
+++ b/portfolio_engine_v5_report_pack/scripts/validate_report.mjs
@@ -63,11 +63,18 @@ if (epics.length < 18) {
   msgs.push('OK: found ' + epics.length + ' epic source files.');
 }
 
-if (sections.length < 8) {
+if (sections.length < 9) {
   ok = false;
-  msgs.push('ERROR: expected >=8 section files, found ' + sections.length);
+  msgs.push('ERROR: expected >=9 section files (00–08 incl. 00_repo_status_checklist), found ' + sections.length);
 } else {
   msgs.push('OK: found ' + sections.length + ' section source files.');
+}
+
+if (!sections.includes('00_repo_status_checklist.md')) {
+  ok = false;
+  msgs.push('ERROR: missing required section source/sections/00_repo_status_checklist.md');
+} else {
+  msgs.push('OK: 00_repo_status_checklist.md present.');
 }
 
 if (!html.includes('class="phase-timeline"')) {

--- a/portfolio_engine_v5_report_pack/scripts/validate_report.mjs
+++ b/portfolio_engine_v5_report_pack/scripts/validate_report.mjs
@@ -65,7 +65,10 @@ if (epics.length < 18) {
 
 if (sections.length < 9) {
   ok = false;
-  msgs.push('ERROR: expected >=9 section files (00–08 incl. 00_repo_status_checklist), found ' + sections.length);
+  msgs.push(
+    'ERROR: expected >=9 section files (00–08 incl. 00_repo_status_checklist), found ' +
+      sections.length,
+  );
 } else {
   msgs.push('OK: found ' + sections.length + ' section source files.');
 }

--- a/portfolio_engine_v5_report_pack/source/decisions/ADR-005-consumer-extension-registry-format.md
+++ b/portfolio_engine_v5_report_pack/source/decisions/ADR-005-consumer-extension-registry-format.md
@@ -1,0 +1,23 @@
+# ADR-005 — Consumer extension registry: JSON on disk + Zod in `@portfolio-engine/schema`
+
+## Decision
+
+The consumer extension registry is a **JSON file** at the default path `src/registry/portfolio-engine.registry.json` (configurable via integration options). **Validation and TypeScript types** come from **Zod** schemas exported by `@portfolio-engine/schema` (`ConsumerPortfolioEngineRegistrySchema`, `parseConsumerPortfolioEngineRegistry`).
+
+We intentionally use a **hybrid** shape: human-editable JSON for the contract on disk; machine-checked parsing at build time in `engine-core` and optional reuse in consumer tooling.
+
+## Rationale
+
+- **Safety without executing consumer code** — the Astro integration can validate structure without loading arbitrary TypeScript from the consumer repo at integration setup time.
+- **Admin-tools readability** — `@portfolio-engine/admin-tools` already treats `src/registry` as an allowed edit root; JSON is straightforward to load, diff, and save in the admin file editor and in GitHub Contents API flows.
+- **Version gate** — the top-level `version` field (currently literal `1`) allows coordinated format evolution alongside engine releases.
+
+## Non-goals (for this ADR)
+
+- Registry-authored **local components/embeds** (separate epic tasks).
+- Replacing JSON with a TypeScript-only registry module (rejected for the reasons above; consumers may still wrap `parseConsumerPortfolioEngineRegistry` in their own scripts).
+
+## Consequences
+
+- New fields require bumping `CONSUMER_REGISTRY_SUPPORTED_VERSION` / schema literals and engine handling in lockstep.
+- Downstream docs: `docs/downstream/custom-page-via-registry.md`.

--- a/portfolio_engine_v5_report_pack/source/epics/epic_consumer_registry.md
+++ b/portfolio_engine_v5_report_pack/source/epics/epic_consumer_registry.md
@@ -23,8 +23,8 @@ Choose TypeScript, JSON, or hybrid for `src/registry/portfolio-engine.registry.*
 
 **Acceptance criteria**
 
-- [ ] Decision recorded.
-- [ ] Admin-tools readability considered.
+- [x] Decision recorded.
+- [x] Admin-tools readability considered.
 
 ### Add local route extension support
 
@@ -34,9 +34,9 @@ Allow registry entries to add local pages backed by `src/pages-local`.
 
 **Acceptance criteria**
 
-- [ ] Local route renders.
-- [ ] Duplicate paths fail clearly.
-- [ ] Manifest includes local route.
+- [x] Local route renders.
+- [x] Duplicate paths fail clearly.
+- [x] Manifest includes local route.
 
 ### Add local component/embed support
 

--- a/portfolio_engine_v5_report_pack/source/sections/00_repo_status_checklist.md
+++ b/portfolio_engine_v5_report_pack/source/sections/00_repo_status_checklist.md
@@ -65,7 +65,8 @@ _Product MVP is **not** reached until both consumers are real, buildable sites o
 
 ## Phase 7 — Consumer extension registry
 
-- 🔄 **Shipped for local routes:** JSON registry + Zod (`packages/schema/src/consumer-registry.ts`), load + inject in `engine-core` (`consumer-local-routes.ts`, `integration.ts` options), demo `src/registry/portfolio-engine.registry.json` + `src/pages-local/how-i-think.astro`
+- ✅ **Registry format decision:** ADR-005 (`portfolio_engine_v5_report_pack/source/decisions/ADR-005-consumer-extension-registry-format.md`) — JSON on disk + Zod in schema; admin-tools can edit `src/registry/*.json`.
+- ✅ **Local route extensions:** JSON registry + Zod (`packages/schema/src/consumer-registry.ts`), load + inject in `engine-core` (`consumer-local-routes.ts`, `integration.ts` options); verified on `examples/demo-site` and `examples/node-ssr-demo` (`src/registry/portfolio-engine.registry.json` + `src/pages-local/`).
 - ⬜ Registry entries for **local components/embeds** (epic tickets still open)
 - ⬜ Framed YouTube / richer showcase (overlaps demo-site teaching goals)
 

--- a/portfolio_engine_v5_report_pack/validation/validation_log.txt
+++ b/portfolio_engine_v5_report_pack/validation/validation_log.txt
@@ -3,6 +3,7 @@ OK: doctype present.
 OK: stylesheet exists.
 OK: found 18 epic source files.
 OK: found 9 section source files.
+OK: 00_repo_status_checklist.md present.
 OK: phase timeline rendered.
 OK: 2 milestone banners present.
 OK: 18 epic anchor IDs present.


### PR DESCRIPTION
## Summary

Completes the first two tickets from Phase 7 (consumer extension registry epic):

1. **Registry file format** — Decision recorded as **ADR-005** (JSON on disk + Zod in \@portfolio-engine/schema\; admin-tools can edit \src/registry/*.json\). Linked from \docs/downstream/custom-page-via-registry.md\.
2. **Local route extension support** — Already implemented in engine; this PR **extends verification** to the **SSR fixture** (\examples/node-ssr-demo\): \portfolio-engine.registry.json\ + \src/pages-local/ssr-registry-smoke.astro\, nav link, regenerated manifest. Static coverage remains on \examples/demo-site\.

Epic and repo status checklists updated accordingly.

## Notes

- PR targets \origin/dev\ as requested.
- **Not** set to auto-merge.

Made with [Cursor](https://cursor.com)