### PR TITLE
chore: sync dev — fix Release workflow race

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   version:
@@ -66,9 +68,13 @@ jobs:
         run: |
           set -euo pipefail
           echo "Pending changesets detected — running changeset version."
-          before=$(git rev-parse HEAD)
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          ref="${GITHUB_REF_NAME}"
+          git fetch origin "${ref}"
+          git reset --hard "origin/${ref}"
+
+          before=$(git rev-parse HEAD)
           pnpm exec changeset version
           pnpm install --no-frozen-lockfile
           git add pnpm-lock.yaml
@@ -80,7 +86,14 @@ jobs:
             echo "::error::changeset version did not create a commit — check .changeset/config.json commit settings."
             exit 1
           fi
-          git push "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${GITHUB_REF_NAME}"
+
+          git fetch origin "${ref}"
+          if ! git rebase "origin/${ref}"; then
+            echo "::error::Could not rebase version commits onto origin/${ref}. Another push landed on ${ref}; re-run Release after resolving."
+            exit 1
+          fi
+
+          git push "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${ref}"
           echo "Version commit pushed — npm publish runs on the next workflow run."
           echo "skip_publish=true" >> "$GITHUB_OUTPUT"
 

--- a/docs/workflows/release-workflow.md
+++ b/docs/workflows/release-workflow.md
@@ -24,10 +24,10 @@ The **Promote dev → main** VS Code task (`scripts/promote-dev-to-main.*`) merg
 
 Two-phase behavior:
 
-| Phase   | Trigger                                                                      | What happens                                                                                                                                      |
-| ------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Phase   | Trigger                                                                      | What happens                                                                                                                                                                   |
+| ------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Version | Push / dispatch on `main`, pending `.changeset/*.md` (excluding `README.md`) | Sync `HEAD` to remote tip, `pnpm exec changeset version`, lockfile refresh (`pnpm install --no-frozen-lockfile` + lockfile commit if needed), **rebase onto remote**, **push** |
-| Publish | Next push on `main` when no pending changesets                               | `pnpm build`, verify `dist/`, then **`pnpm release`** with `NODE_AUTH_TOKEN`                                                                      |
+| Publish | Next push on `main` when no pending changesets                               | `pnpm build`, verify `dist/`, then **`pnpm release`** with `NODE_AUTH_TOKEN`                                                                                                   |
 
 `changeset publish` no-ops when local versions already match the registry.
 

--- a/docs/workflows/release-workflow.md
+++ b/docs/workflows/release-workflow.md
@@ -14,6 +14,8 @@ portfolio-engine uses [Changesets](https://github.com/changesets/changesets) for
 
 Manual rescue: **Actions → Release → Run workflow** (`workflow_dispatch`) on `main` re-runs versioning logic (if changesets remain) or publish (when none remain).
 
+If **Apply changesets** fails with a **non-fast-forward** push, something else updated `main` while the job ran. The workflow now **resets to `origin/main` before versioning** and **rebases version commits before push**; re-run Release once `main` is calm.
+
 The **Promote dev → main** VS Code task (`scripts/promote-dev-to-main.*`) merges the promotion PR and then **queues `Release` via `workflow_dispatch`**, so the npm publish phase always runs even when the automated `RELEASING` push does not start a follow-up workflow (default `GITHUB_TOKEN` limitation).
 
 **Git tags:** `changeset publish` creates tags like `@portfolio-engine/schema@0.3.0`. The **Publish to npm** job uses **`contents: write`** so those tags can be pushed. After a release, refresh locally with `git fetch origin main --tags` if Git Graph does not show new tags.
@@ -24,7 +26,7 @@ Two-phase behavior:
 
 | Phase   | Trigger                                                                      | What happens                                                                                                                                      |
 | ------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Version | Push / dispatch on `main`, pending `.changeset/*.md` (excluding `README.md`) | `pnpm exec changeset version`, lockfile refresh (`pnpm install --no-frozen-lockfile` + lockfile commit if needed), **commit(s) pushed to `main`** |
+| Version | Push / dispatch on `main`, pending `.changeset/*.md` (excluding `README.md`) | Sync `HEAD` to remote tip, `pnpm exec changeset version`, lockfile refresh (`pnpm install --no-frozen-lockfile` + lockfile commit if needed), **rebase onto remote**, **push** |
 | Publish | Next push on `main` when no pending changesets                               | `pnpm build`, verify `dist/`, then **`pnpm release`** with `NODE_AUTH_TOKEN`                                                                      |
 
 `changeset publish` no-ops when local versions already match the registry.


### PR DESCRIPTION
Hardens [.github/workflows/release.yml](.github/workflows/release.yml): reset to remote tip before \changeset version\, then rebase version commits onto remote before push (fixes non-fast-forward failures when \main\ advances mid-job). Updates [docs/workflows/release-workflow.md](docs/workflows/release-workflow.md).

Made with [Cursor](https://cursor.com)