### PR TITLE
feat: upstream engine hardening — nav CSS, manifest diagnostics, profile schemas, doctor

### DIFF
--- a/.changeset/upstream-agent-hardening.md
+++ b/.changeset/upstream-agent-hardening.md
@@ -13,7 +13,7 @@ Upstream hardening: nav CSS baseline, manifest diagnostics, profile schemas, doc
 
 **Manifest diagnostics (P0)**
 
-- `ManifestRouteEntry` now includes a required `routeOrigin` (`"theme" | "consumer-local" | "consumer-pages" | "unknown"`) and `entrypoint` (relative path) for every route, making it immediately clear which file owns each URL.
+- `ManifestRouteEntry` now includes a required `routeOrigin` and `entrypoint` (relative path from consumer root) for every route. The engine emits `"theme"` for editorial-theme routes and `"consumer-local"` for registry routes. `"consumer-pages"` and `"unknown"` are reserved type values for future use and are not emitted in this release.
 - `EngineManifest` now includes `portfolioEngine` (package versions), `consumerRegistry` (load state and route count), `routeOverrides` (disabled and remapped patterns), and an optional `navWarnings` array.
 - Engine integration validates nav items against active injected routes and emits warnings for items that cannot be matched. Pass `diagnostics: { strictNavRoutes: true }` to `editorialTheme()` to fail the build on nav/route mismatches.
 
@@ -32,4 +32,4 @@ Upstream hardening: nav CSS baseline, manifest diagnostics, profile schemas, doc
 
 **Doctor script (P2)**
 
-- `portfolio-engine doctor` (or `pnpm pe:doctor`) reads `.portfolio-engine/manifest.json` and prints a structured diagnostic report: package versions, consumer registry state, route origins and entrypoints, nav warnings, and capabilities.
+- `portfolio-engine` (or `pnpm pe:doctor`) runs the doctor CLI, which reads `.portfolio-engine/manifest.json` and prints a structured diagnostic report: package versions, consumer registry state, route origins and entrypoints, nav warnings, and capabilities. The `portfolio-engine` bin maps directly to the doctor script — no subcommand is needed.

--- a/.changeset/upstream-agent-hardening.md
+++ b/.changeset/upstream-agent-hardening.md
@@ -1,0 +1,29 @@
+---
+'@portfolio-engine/editorial-theme': minor
+'@portfolio-engine/engine-core': minor
+'@portfolio-engine/schema': minor
+---
+
+Upstream hardening: nav CSS baseline, manifest diagnostics, profile schemas, doctor script
+
+**Nav rendering robustness (P0)**
+- Added `pe-site-*` semantic classes to `Nav.astro` alongside Tailwind utilities, so nav layout holds even when Tailwind utility generation is partial or absent in a downstream build.
+- Added explicit CSS baseline for `.pe-site-header`, `.pe-site-nav`, `.pe-site-brand`, `.pe-site-nav-list`, `.pe-site-nav-link` in `global.css`, with a responsive mobile rule at `≤720px`.
+
+**Manifest diagnostics (P0)**
+- `ManifestRouteEntry` now includes a required `routeOrigin` (`"theme" | "consumer-local" | "consumer-pages" | "unknown"`) and `entrypoint` (relative path) for every route, making it immediately clear which file owns each URL.
+- `EngineManifest` now includes `portfolioEngine` (package versions), `consumerRegistry` (load state and route count), `routeOverrides` (disabled and remapped patterns), and an optional `navWarnings` array.
+- Engine integration validates nav items against active injected routes and emits warnings for items that cannot be matched. Pass `diagnostics: { strictNavRoutes: true }` to `editorialTheme()` to fail the build on nav/route mismatches.
+
+**Profile schemas (P1)**
+- `@portfolio-engine/schema` now exports `ProfilePersonSchema`, `ProfileCvSchema`, `ProfileExperienceSchema`, `ProfileEducationSchema`, and `ProfileAwardSchema` so downstream sites can import canonical schemas rather than duplicating minimal local definitions.
+- Demo site `content.config.ts` updated to use the exported schemas.
+
+**Accessibility (P1)**
+- `ImageOrFallback` fallback character is now `aria-hidden="true"` with `role="img"` and `aria-label` on the container, so screen readers get the card title instead of a lone letter.
+
+**Default copy (P1)**
+- Writing index page now shows "Essays, notes, and selected thinking." subtitle and a neutral empty-state message.
+
+**Doctor script (P2)**
+- `portfolio-engine doctor` (or `pnpm pe:doctor`) reads `.portfolio-engine/manifest.json` and prints a structured diagnostic report: package versions, consumer registry state, route origins and entrypoints, nav warnings, and capabilities.

--- a/.changeset/upstream-agent-hardening.md
+++ b/.changeset/upstream-agent-hardening.md
@@ -7,23 +7,29 @@
 Upstream hardening: nav CSS baseline, manifest diagnostics, profile schemas, doctor script
 
 **Nav rendering robustness (P0)**
+
 - Added `pe-site-*` semantic classes to `Nav.astro` alongside Tailwind utilities, so nav layout holds even when Tailwind utility generation is partial or absent in a downstream build.
 - Added explicit CSS baseline for `.pe-site-header`, `.pe-site-nav`, `.pe-site-brand`, `.pe-site-nav-list`, `.pe-site-nav-link` in `global.css`, with a responsive mobile rule at `≤720px`.
 
 **Manifest diagnostics (P0)**
+
 - `ManifestRouteEntry` now includes a required `routeOrigin` (`"theme" | "consumer-local" | "consumer-pages" | "unknown"`) and `entrypoint` (relative path) for every route, making it immediately clear which file owns each URL.
 - `EngineManifest` now includes `portfolioEngine` (package versions), `consumerRegistry` (load state and route count), `routeOverrides` (disabled and remapped patterns), and an optional `navWarnings` array.
 - Engine integration validates nav items against active injected routes and emits warnings for items that cannot be matched. Pass `diagnostics: { strictNavRoutes: true }` to `editorialTheme()` to fail the build on nav/route mismatches.
 
 **Profile schemas (P1)**
+
 - `@portfolio-engine/schema` now exports `ProfilePersonSchema`, `ProfileCvSchema`, `ProfileExperienceSchema`, `ProfileEducationSchema`, and `ProfileAwardSchema` so downstream sites can import canonical schemas rather than duplicating minimal local definitions.
 - Demo site `content.config.ts` updated to use the exported schemas.
 
 **Accessibility (P1)**
+
 - `ImageOrFallback` fallback character is now `aria-hidden="true"` with `role="img"` and `aria-label` on the container, so screen readers get the card title instead of a lone letter.
 
 **Default copy (P1)**
+
 - Writing index page now shows "Essays, notes, and selected thinking." subtitle and a neutral empty-state message.
 
 **Doctor script (P2)**
+
 - `portfolio-engine doctor` (or `pnpm pe:doctor`) reads `.portfolio-engine/manifest.json` and prints a structured diagnostic report: package versions, consumer registry state, route origins and entrypoints, nav warnings, and capabilities.

--- a/docs/downstream/consumption.md
+++ b/docs/downstream/consumption.md
@@ -7,13 +7,42 @@ The canonical `src/` directory contract for any consumer site:
 ```
 your-site/
   src/
-    config/     JSON config files consumed by editorialTheme()
-    content/    Astro content collections
-    context/    Site-owner identity and brand voice (agent use)
-    overrides/  Component overrides (named surfaces only)
+    config/       JSON config files consumed by editorialTheme()
+    content/      Astro content collections
+    context/      Site-owner identity and brand voice (agent use)
+    overrides/    Component overrides (named surfaces only)
+    pages-local/  Consumer-local pages (registry-backed, optional)
+    registry/     portfolio-engine.registry.json (optional)
+    pages/        Ordinary Astro file routes (optional)
 ```
 
 These directories are contract-stable. The build always reads `config/` and `content/`. Files under `src/overrides/` change the site **when** you wire them through `editorialTheme({ overrides })` (the integration resolves paths at config time and theme components load them at render time). `context/` is not read by the build—it is for AI-assisted workflows only.
+
+## Route ownership modes
+
+Portfolio Engine supports three route ownership modes:
+
+1. **Theme-injected routes** — `/`, `/work`, `/work/[slug]`, `/writing`,
+   `/writing/[slug]`, `/about`, `/contact`, `/resume`. You supply content;
+   the theme renders the page.
+
+2. **Consumer-local registry routes** — declare in
+   `src/registry/portfolio-engine.registry.json`; page files live under
+   `src/pages-local/`. Useful for replacing a theme page while keeping the
+   theme shell (Layout, Nav, styles). Disable the corresponding theme route
+   first so there is no collision.
+
+3. **Ordinary Astro file routes** — page files under `src/pages/`. Astro
+   owns these via file-based routing. Useful for fully custom pages that
+   don't need to replace a theme route (e.g. `src/pages/resume.astro`).
+   The engine does not inject these — Astro discovers them automatically.
+   The engine cannot verify nav items pointing at ordinary Astro routes;
+   it will warn but not fail unless `diagnostics.strictNavRoutes: true`.
+
+After every build, `.portfolio-engine/manifest.json` lists all active routes
+with their `routeOrigin` (`theme`, `consumer-local`, or `consumer-pages`) and
+the relative `entrypoint` path, so you can immediately see which file owns
+each URL.
 
 For **`theme.json`** (colors, typography, tokens) and how they map to CSS variables, see **[`design-tokens-and-theme.md`](design-tokens-and-theme.md)**.
 

--- a/docs/downstream/consumption.md
+++ b/docs/downstream/consumption.md
@@ -40,9 +40,11 @@ Portfolio Engine supports three route ownership modes:
    it will warn but not fail unless `diagnostics.strictNavRoutes: true`.
 
 After every build, `.portfolio-engine/manifest.json` lists all active routes
-with their `routeOrigin` (`theme`, `consumer-local`, or `consumer-pages`) and
-the relative `entrypoint` path, so you can immediately see which file owns
-each URL.
+with their `routeOrigin` (`"theme"` or `"consumer-local"`) and the relative
+`entrypoint` path, so you can immediately see which file owns each URL.
+Ordinary `src/pages` routes are not injected by the engine and do not appear
+in the manifest. (`"consumer-pages"` and `"unknown"` are reserved type values
+for future use.)
 
 For **`theme.json`** (colors, typography, tokens) and how they map to CSS variables, see **[`design-tokens-and-theme.md`](design-tokens-and-theme.md)**.
 

--- a/docs/downstream/custom-page-via-registry.md
+++ b/docs/downstream/custom-page-via-registry.md
@@ -85,7 +85,72 @@ Pass these to `editorialTheme()` / `createEngineIntegration()`:
 
 ## Manifest
 
-Routes from the registry appear in `.portfolio-engine/manifest.json` with `"routeOrigin": "consumer-local"`. `capabilities.consumerLocalRoutes` is `true` when at least one such route is active.
+Routes from the registry appear in `.portfolio-engine/manifest.json` with `"routeOrigin": "consumer-local"` and the relative `entrypoint` path. `capabilities.consumerLocalRoutes` is `true` when at least one such route is active.
+
+## Replacing a default theme page
+
+To replace a theme route (e.g. `/writing`) with a consumer-local version:
+
+**1. Disable the theme route** in `astro.config.mjs`:
+
+```js
+editorialTheme({
+  routes: { '/writing': { enabled: false } },
+  // ...
+})
+```
+
+**2. Add a registry entry** in `src/registry/portfolio-engine.registry.json`:
+
+```json
+{
+  "version": 1,
+  "localRoutes": [
+    {
+      "pattern": "/writing",
+      "page": "writing/index.astro",
+      "label": "Research & Ideas",
+      "visibility": "public"
+    }
+  ]
+}
+```
+
+**3. Add the page file** at `src/pages-local/writing/index.astro`:
+
+```astro
+---
+import Layout from '@portfolio-engine/editorial-theme/layouts/Layout.astro';
+---
+
+<Layout title="Research & Ideas">
+  <main class="mx-auto max-w-3xl px-6 pb-24 pt-40">
+    <h1>Research & Ideas</h1>
+    <!-- your custom content here -->
+  </main>
+</Layout>
+```
+
+**4. Verify the nav item** in `src/config/navigation.json` points to `/writing`:
+
+```json
+{ "label": "Research & Ideas", "href": "/writing", "visible": true }
+```
+
+**5. Build and inspect** `.portfolio-engine/manifest.json`. The `/writing` entry
+should show `"routeOrigin": "consumer-local"` and the entrypoint path.
+
+### src/pages vs src/pages-local
+
+| Directory        | Routing owner | Use case                                                     |
+| ---------------- | ------------- | ------------------------------------------------------------ |
+| `src/pages-local/` | Engine (registry) | Replace a theme page while keeping the theme shell       |
+| `src/pages/`       | Astro (file-based) | Fully custom pages that don't replace a theme route     |
+
+Use `src/pages/` (ordinary Astro routing) for pages that have no theme
+equivalent and don't need to be registered — e.g. `src/pages/resume.astro`.
+Use `src/pages-local/` + registry when you want the engine to know about the
+route (nav validation, manifest, collision checks).
 
 ## Verified examples
 

--- a/docs/downstream/custom-page-via-registry.md
+++ b/docs/downstream/custom-page-via-registry.md
@@ -97,7 +97,7 @@ To replace a theme route (e.g. `/writing`) with a consumer-local version:
 editorialTheme({
   routes: { '/writing': { enabled: false } },
   // ...
-})
+});
 ```
 
 **2. Add a registry entry** in `src/registry/portfolio-engine.registry.json`:
@@ -142,10 +142,10 @@ should show `"routeOrigin": "consumer-local"` and the entrypoint path.
 
 ### src/pages vs src/pages-local
 
-| Directory        | Routing owner | Use case                                                     |
-| ---------------- | ------------- | ------------------------------------------------------------ |
-| `src/pages-local/` | Engine (registry) | Replace a theme page while keeping the theme shell       |
-| `src/pages/`       | Astro (file-based) | Fully custom pages that don't replace a theme route     |
+| Directory          | Routing owner      | Use case                                            |
+| ------------------ | ------------------ | --------------------------------------------------- |
+| `src/pages-local/` | Engine (registry)  | Replace a theme page while keeping the theme shell  |
+| `src/pages/`       | Astro (file-based) | Fully custom pages that don't replace a theme route |
 
 Use `src/pages/` (ordinary Astro routing) for pages that have no theme
 equivalent and don't need to be registered — e.g. `src/pages/resume.astro`.

--- a/docs/portfolio-engine-upstream-agent-fix-plan-final.md
+++ b/docs/portfolio-engine-upstream-agent-fix-plan-final.md
@@ -1,0 +1,554 @@
+# Upstream Agent Plan — `rainonej/portfolio-engine`
+
+## Mission
+
+Fix the reusable engine/theme issues exposed by the live `jordan-site-kappa.vercel.app` audit. Do **not** hard-code Jordan-specific content upstream. The upstream work should make `@portfolio-engine/editorial-theme` and `@portfolio-engine/engine-core` more robust for all downstream sites, especially sites that mix:
+
+- theme-injected routes,
+- disabled/remapped theme routes,
+- consumer-local registry routes under `src/pages-local`,
+- ordinary Astro file routes under `src/pages`,
+- package-based Tailwind/global CSS,
+- structured profile/resume content.
+
+The live Jordan site is now much better than the first audit suggested, but it exposed two reusable engine problems:
+
+1. The top nav can render as glued text (`Jordan Rainone, PhDWorkResearch & IdeasHow I ThinkResumeContact`) when the expected flex/gap styling is not applied.
+2. Route/deployment debugging is too opaque: the repo may have correct route disabling + local route registry, while production still appears to serve stale/default route content.
+
+## External docs to keep in mind
+
+- Astro pages/routing: `src/pages` files become endpoints through Astro’s file-based routing.  
+  https://docs.astro.build/en/basics/astro-pages/
+- Vercel deployments can be filtered/redeployed from the Deployments UI, and redeploy can choose whether to use the existing build cache.  
+  https://vercel.com/docs/deployments/managing-deployments
+- Vercel environment-variable changes apply only to new deployments.  
+  https://vercel.com/docs/environment-variables
+
+## Current upstream state observed during audit
+
+The current engine has already improved a lot:
+
+- `@portfolio-engine/editorial-theme` changelog says `0.3.1` added structured profile/typography work, a resume page, hero CTA improvements, Google Fonts provider handling, sanitized font fallback stacks, and review follow-ups.
+- `engine-core` already loads consumer registry routes, applies route overrides/disables, builds consumer-local routes, checks theme/local collisions, injects active routes, writes `.portfolio-engine/manifest.json`, and emits a design snapshot.
+- `editorial-theme` has a `Nav.astro` using Tailwind utility classes for `fixed`, `flex`, `gap-8`, etc.
+- `Footer.astro` now hides Admin in production unless `PUBLIC_SHOW_ADMIN_LINK=true`.
+- `profile-person.ts` now contains a better structured model with `shortBio`, `summary`, `longBio`, `values`, `workingPrinciples`, and `credentials`.
+
+But the current upstream still needs hardening.
+
+---
+
+# P0 — Fix nav rendering robustness
+
+## Problem
+
+The live screenshot shows the nav rendered as glued text:
+
+```text
+Jordan Rainone, PhDWorkResearch & IdeasHow I ThinkResumeContact
+```
+
+That means the browser is not receiving or applying the intended layout rules for `Nav.astro`. The current upstream nav depends heavily on Tailwind utility classes in package source. That should work, but the downstream production screenshot proves we need a more defensive baseline.
+
+## Required change
+
+Add stable semantic classes/data attributes to `packages/editorial-theme/src/components/Nav.astro`, and add explicit non-Tailwind CSS rules in `packages/editorial-theme/src/styles/global.css`.
+
+Do not rely only on Tailwind utilities for the nav’s structural layout.
+
+### Proposed markup direction
+
+In `Nav.astro`, keep Tailwind if desired, but add stable classes:
+
+```astro
+<header class="pe-site-header ...">
+  <nav class="pe-site-nav ...">
+    <a class="pe-site-brand ..." href={`${base}/`}>
+      {config.site.title}
+    </a>
+
+    <ul class="pe-site-nav-list ...">
+      {links.map(({ href, label }) => (
+        <li class="pe-site-nav-item">
+          <a class="pe-site-nav-link ..." href={href}>
+            {label}
+          </a>
+        </li>
+      ))}
+    </ul>
+  </nav>
+</header>
+```
+
+### Proposed CSS baseline
+
+Add explicit CSS to `global.css`:
+
+```css
+.pe-site-header {
+  position: fixed;
+  inset-inline: 0;
+  top: 0;
+  z-index: 50;
+  border-bottom: 1px solid var(--warm-line);
+  background: var(--paper);
+}
+
+.pe-site-nav {
+  max-width: 64rem;
+  min-height: 4rem;
+  margin-inline: auto;
+  padding-inline: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.pe-site-brand {
+  white-space: nowrap;
+  text-decoration: none;
+}
+
+.pe-site-nav-list {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.pe-site-nav-link {
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+@media (max-width: 720px) {
+  .pe-site-nav {
+    align-items: flex-start;
+    flex-direction: column;
+    justify-content: center;
+    gap: 0.5rem;
+    padding-block: 0.75rem;
+  }
+
+  .pe-site-nav-list {
+    flex-wrap: wrap;
+    gap: 0.75rem 1rem;
+  }
+}
+```
+
+## Acceptance criteria
+
+- On a production build of `examples/demo-site`, nav items are visibly separated even if Tailwind utilities fail to apply.
+- On a downstream consumer build, nav does not collapse into glued inline text.
+- Add a minimal visual/snapshot test or at least a fixture build that confirms `.pe-site-nav-list` CSS appears in the final CSS/HTML.
+- No Jordan-specific names/content appear in upstream code.
+
+---
+
+# P0 — Add route/nav diagnostics so stale route ownership is obvious
+
+## Problem
+
+Downstream `jordan-site` can have:
+
+- default theme route `/writing` disabled,
+- local registry route `/writing` declared,
+- nav item `/writing` visible,
+- production still apparently serving old/default `/writing`.
+
+The current engine has route injection and collision checks, but it does not make it easy enough for an agent/human to answer:
+
+- Which route source owns `/writing`?
+- Was the consumer registry loaded?
+- Did a route come from theme, remap, local registry, or ordinary `src/pages`?
+- Does nav point to an active route?
+- Did a disabled route still appear somewhere?
+
+## Required change
+
+Improve `.portfolio-engine/manifest.json` and/or add a second diagnostic file.
+
+### Add manifest fields
+
+For each route entry, include:
+
+```ts
+{
+  pattern: string;
+  resolved: string;
+  routeOrigin: "theme" | "consumer-local" | "consumer-pages" | "unknown";
+  entrypoint: string;
+  label?: string;
+  visibility?: string;
+}
+```
+
+If `routeOrigin` is absent today for theme routes, make it explicit as `"theme"`.
+
+### Add build metadata
+
+At top level:
+
+```ts
+{
+  generatedAt: string;
+  portfolioEngine: {
+    engineCoreVersion: string;
+    editorialThemeVersion: string;
+  };
+  consumerRegistry: {
+    path: string;
+    loaded: boolean;
+    routeCount: number;
+  };
+  routeOverrides: {
+    disabled: string[];
+    remapped: Record<string, string>;
+  };
+}
+```
+
+### Add nav validation
+
+After active routes are known, compare `config.navigation.items` to active routes.
+
+Rules:
+
+- External URLs are ignored.
+- Hash-only links are ignored.
+- Internal visible nav items must match:
+  - an injected theme route,
+  - a consumer-local route,
+  - or an ordinary Astro route under `src/pages` if upstream can detect it.
+- If the engine cannot confidently see ordinary `src/pages` routes, either:
+  - add a documented `knownRoutes` option, or
+  - warn that the nav item could not be verified rather than failing.
+- In CI/production build, allow strict mode:
+  ```js
+  editorialTheme({
+    diagnostics: {
+      strictNavRoutes: true,
+    },
+  });
+  ```
+
+## Acceptance criteria
+
+- A downstream build can inspect `.portfolio-engine/manifest.json` and immediately see whether `/about`, `/writing`, `/contact`, and `/resume` are theme, consumer-local, or ordinary Astro pages.
+- A nav item pointing to a disabled theme route with no local replacement produces a clear warning or failure.
+- The warning message tells the user exactly which config/registry/page file to check.
+- Existing consumers without local routes continue to build.
+
+---
+
+# P1 — Update docs so the new route model is discoverable
+
+## Problem
+
+`packages/editorial-theme/README.md` still says:
+
+> You write no page files yourself — every route comes from the theme.
+
+That is now incomplete/misleading. The engine supports consumer-local pages via `src/pages-local` + registry. It also coexists with ordinary Astro `src/pages` file routes.
+
+## Required change
+
+Update:
+
+- `packages/editorial-theme/README.md`
+- `docs/downstream/consumption.md`
+- `docs/downstream/custom-page-via-registry.md`
+
+## Required content
+
+Add a clear section:
+
+```md
+## Route ownership modes
+
+Portfolio Engine supports three route ownership modes:
+
+1. Theme-injected routes
+   - `/`, `/work`, `/work/[slug]`, `/writing`, etc.
+2. Consumer-local registry routes
+   - declare in `src/registry/portfolio-engine.registry.json`
+   - page files live under `src/pages-local`
+   - useful for replacing a theme page while keeping the theme shell
+3. Ordinary Astro file routes
+   - page files under `src/pages`
+   - Astro owns these via file-based routing
+   - useful for fully custom pages like `src/pages/resume.astro`
+```
+
+Add a specific recipe:
+
+```md
+## Replacing a default theme page
+
+To replace `/writing`:
+
+1. Disable theme route in `astro.config.mjs`:
+   routes: { "/writing": { enabled: false } }
+
+2. Add registry route:
+   {
+   "pattern": "/writing",
+   "page": "writing/index.astro",
+   "label": "Research & Ideas",
+   "visibility": "public"
+   }
+
+3. Add file:
+   src/pages-local/writing/index.astro
+
+4. Add or verify nav item:
+   { "label": "Research & Ideas", "href": "/writing", "visible": true }
+
+5. Build and inspect:
+   .portfolio-engine/manifest.json
+```
+
+## Acceptance criteria
+
+- No doc says “you write no page files yourself” without qualifying it.
+- New route ownership model is clear to a downstream agent without reading engine source.
+- Docs explain when to use `src/pages` vs `src/pages-local`.
+
+---
+
+# P1 — Formalize structured profile/resume schemas
+
+## Problem
+
+The type model in `profile-person.ts` is better, but consumers still frequently define loose `passthrough()` schemas or old minimal schemas with only `name`, `bio`, `photo`, `email`, etc. This allows mega-bio regressions and makes resume content inconsistent.
+
+## Required change
+
+Add exported Zod schemas in `@portfolio-engine/schema` for:
+
+- `ProfilePersonSchema`
+- `ProfileCvSchema`
+- `ProfileExperienceSchema`
+- `ProfileEducationSchema`
+- `ProfileAwardSchema`
+- `ValueCardSchema`
+- `WorkingPrincipleSchema`
+
+Then update:
+
+- `examples/demo-site/src/content.config.ts`
+- `packages/editorial-theme/README.md`
+- `docs/downstream/consumption.md`
+
+## Proposed fields
+
+### `ProfilePerson`
+
+```ts
+{
+  name: string;
+  roleLine?: string;
+  shortBio?: string;
+  summary?: string;
+  bio?: string; // legacy/deprecated
+  longBio?: string[];
+  values?: { title: string; body: string }[];
+  workingPrinciples?: { title: string; body: string }[];
+  credentials?: string[];
+  email?: string;
+  linkedin?: string;
+  github?: string;
+  photo?: string;
+}
+```
+
+### `ProfileCv`
+
+```ts
+{
+  selectedEvidence?: string[];
+  technicalRange?: { heading: string; items: string[] }[];
+  experience?: {
+    organization: string;
+    title: string;
+    location?: string;
+    startDate?: string;
+    endDate?: string;
+    current?: boolean;
+    description?: string;
+    highlights?: string[];
+  }[];
+  education?: ...;
+  awards?: ...;
+}
+```
+
+## Acceptance criteria
+
+- Demo site uses the exported schemas rather than duplicating minimal local schemas.
+- Docs tell downstream sites to prefer `shortBio`/`summary`/`longBio` over dumping everything into `bio`.
+- The default hero never renders a multi-section bio wall.
+- TypeScript exports remain stable.
+
+---
+
+# P1 — Improve default page copy and empty-state behavior
+
+## Problem
+
+The stale live Jordan `/writing` route shows education/curriculum copy. Even if that came from an old package or old content, upstream defaults should avoid domain-specific persona copy.
+
+## Required change
+
+Audit upstream default pages for copy that assumes a particular profession/persona.
+
+Pages to check:
+
+- `packages/editorial-theme/src/pages/writing/index.astro`
+- `packages/editorial-theme/src/pages/about.astro`
+- `packages/editorial-theme/src/pages/contact.astro`
+- `packages/editorial-theme/src/pages/resume.astro`
+- demo content under `examples/demo-site`
+
+Default copy should be generic but professional:
+
+- Writing: “Essays, notes, and selected thinking.”
+- Contact: no “Booking coming soon.”
+- Resume: no generic “selected strengths” derived from full bio.
+- About: do not repeat the same hero copy unless no structured content exists.
+
+## Acceptance criteria
+
+- No hard-coded education/curriculum/teacher-development copy in upstream unless in demo content clearly labelled as demo.
+- No public placeholder like “Booking coming soon.”
+- Missing booking/scheduling config falls back to email/contact, not a placeholder.
+
+---
+
+# P1 — Make fallback initials visual-only and accessible
+
+## Problem
+
+Live project/writing cards showed fallback initials like `M`, `R`, `B`, `W`, `T`, `E`. These may be visual fallbacks, but they are confusing when surfaced as text.
+
+## Required change
+
+Update fallback image/initial components so initials are:
+
+- `aria-hidden="true"` when decorative,
+- not read as meaningful content by screen readers,
+- optionally replaced by a generic gradient/card placeholder with no text.
+
+If the letter is retained visually, wrap it in an element with `aria-hidden="true"` and ensure the card title is the accessible label.
+
+## Acceptance criteria
+
+- Lighthouse/axe does not treat fallback initials as meaningful unlabeled content.
+- No user-visible single-letter badge appears without context unless intentionally decorative.
+- Cards remain visually balanced when no image exists.
+
+---
+
+# P2 — Add `portfolio-engine doctor`
+
+## Goal
+
+Create a simple diagnostic command/script that downstream agents can run.
+
+Example:
+
+```bash
+pnpm portfolio-engine doctor
+```
+
+or:
+
+```bash
+pnpm pe:doctor
+```
+
+Output should include:
+
+```text
+Portfolio Engine Doctor
+
+Package versions:
+- @portfolio-engine/editorial-theme: 0.3.1
+- @portfolio-engine/engine-core: 0.2.2
+
+Routes:
+- /                  theme
+- /work              theme
+- /writing           consumer-local -> src/pages-local/writing/index.astro
+- /about             consumer-local -> src/pages-local/about.astro
+- /resume            consumer-pages -> src/pages/resume.astro
+- /contact           consumer-local -> src/pages-local/contact.astro
+
+Navigation:
+- Work               OK -> /work
+- Research & Ideas   OK -> /writing
+- How I Think        OK -> /about
+- Resume             OK -> /resume
+- Contact            OK -> /contact
+
+Potential issues:
+- none
+```
+
+## Acceptance criteria
+
+- Works after build using `.portfolio-engine/manifest.json`.
+- Fails clearly if manifest is missing and instructs user to run `pnpm build`.
+- Can detect nav links to unknown routes.
+- Useful enough for downstream agents to debug without reading engine internals.
+
+---
+
+# Test plan
+
+## Required local checks
+
+```bash
+pnpm install
+pnpm build
+pnpm check
+pnpm lint
+pnpm format
+```
+
+## Fixture/demo checks
+
+- Build `examples/demo-site`.
+- Add a fixture consumer with:
+  - `/writing` disabled in route overrides,
+  - `/writing` reintroduced via consumer registry,
+  - `/resume` supplied via ordinary `src/pages/resume.astro`,
+  - nav entries for all of the above.
+- Confirm manifest route origins and nav validation.
+
+## Browser/visual checks
+
+At minimum, manually inspect:
+
+- homepage nav spacing,
+- mobile nav wrapping,
+- default writing page,
+- default contact page,
+- resume page with and without `profile/cv`.
+
+## Final acceptance checklist
+
+- [ ] Nav cannot collapse into glued text even if Tailwind utility generation is partial.
+- [ ] Manifest clearly shows route origin and entrypoint.
+- [ ] Nav-vs-route diagnostics exist.
+- [ ] Docs explain theme routes vs consumer-local routes vs ordinary Astro routes.
+- [ ] Structured profile/resume schemas are exported and documented.
+- [ ] Default copy is persona-neutral.
+- [ ] Contact page has no placeholder booking language.
+- [ ] Fallback initials are decorative/accessibility-safe.
+- [ ] Demo/fixture builds pass.

--- a/examples/demo-site/src/content.config.ts
+++ b/examples/demo-site/src/content.config.ts
@@ -1,44 +1,11 @@
 import { defineCollection } from 'astro:content';
 import { z } from 'zod';
 import { glob } from 'astro/loaders';
+import { ProfilePersonSchema, ProfileCvSchema } from '@portfolio-engine/schema';
 
 const profile = defineCollection({
   loader: glob({ pattern: '**/*.json', base: './src/content/profile' }),
-  schema: z.union([
-    // person entry
-    z.object({
-      name: z.string(),
-      bio: z.string(),
-      photo: z.string().optional(),
-      email: z.string().optional(),
-      linkedin: z.url().optional(),
-      instagram: z.url().optional(),
-    }),
-    // cv entry
-    z.object({
-      awards: z
-        .array(
-          z.object({
-            title: z.string(),
-            context: z.string().optional(),
-            description: z.string().optional(),
-            image: z.string().optional(),
-          }),
-        )
-        .optional(),
-      education: z
-        .array(
-          z.object({
-            degree: z.string(),
-            institution: z.string(),
-            location: z.string().optional(),
-            year: z.union([z.string(), z.number()]).optional(),
-            note: z.string().optional(),
-          }),
-        )
-        .optional(),
-    }),
-  ]),
+  schema: z.union([ProfilePersonSchema, ProfileCvSchema]),
 });
 
 const projects = defineCollection({

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build:audit-report-shells": "node portfolio_engine_v3_audit_pack/write-report-shells.mjs",
     "check": "pnpm --filter \"./packages/*\" run build && pnpm -r run check",
     "smoke:packed": "node scripts/smoke-packed-consumer.mjs",
+    "pe:doctor": "node packages/engine-core/dist/doctor.js",
     "release": "changeset publish"
   },
   "pnpm": {

--- a/packages/editorial-theme/README.md
+++ b/packages/editorial-theme/README.md
@@ -34,7 +34,25 @@ That single call:
 - Injects all theme page routes (`/`, `/about`, `/contact`, `/work`,
   `/work/[slug]`, `/writing`, `/writing/[slug]`)
 
-You write no page files yourself — every route comes from the theme.
+## Route ownership modes
+
+Portfolio Engine supports three route ownership modes:
+
+1. **Theme-injected routes** — the default. `/`, `/work`, `/work/[slug]`,
+   `/writing`, `/writing/[slug]`, `/about`, `/contact`, `/resume` are all
+   owned by the theme. You supply content; the theme renders the page.
+
+2. **Consumer-local registry routes** — declare a route in
+   `src/registry/portfolio-engine.registry.json` and put the page file under
+   `src/pages-local/`. Useful for replacing a theme page while keeping the
+   theme shell (Layout, Nav, styles). Disable the theme route first so there
+   is no collision.
+
+3. **Ordinary Astro file routes** — page files under your `src/pages/`
+   directory. Astro owns these via its file-based routing. Useful for fully
+   custom pages (e.g. `src/pages/resume.astro`) that don't need to replace a
+   theme route. The engine does not inject these — Astro discovers them
+   automatically.
 
 ## Required config files
 
@@ -90,12 +108,18 @@ See that package for the canonical Zod schemas. A minimal set:
 Add `src/content.config.ts` with these four collections (the page routes
 expect them):
 
-| Collection     | Type      | Required entries / shape                                                                   |
-| -------------- | --------- | ------------------------------------------------------------------------------------------ |
-| `profile`      | `data`    | `person` (name, bio, photo?, email?, linkedin?, instagram?) and `cv` (awards?, education?) |
-| `projects`     | `content` | title, description, featured?, image?, tags?, link?, date                                  |
-| `writing`      | `content` | title, date, description?, image?, draft?, tags?                                           |
-| `testimonials` | `data`    | quote, author, role, featured?                                                             |
+| Collection     | Type      | Required entries / shape                                                                                                     |
+| -------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `profile`      | `data`    | `person` (`ProfilePersonSchema`) and `cv` (`ProfileCvSchema`) — import from `@portfolio-engine/schema`                      |
+| `projects`     | `content` | title, description, featured?, image?, tags?, link?, date                                                                    |
+| `writing`      | `content` | title, date, description?, image?, draft?, tags?                                                                             |
+| `testimonials` | `data`    | quote, author, role, featured?                                                                                               |
+
+For the `profile` collection, prefer `shortBio`/`summary`/`longBio` over
+dumping everything into `bio`. The `bio` field is still accepted but deprecated:
+it is split on blank lines into paragraphs when present. A hero that receives a
+wall of bio text will look unpolished — use `shortBio` (one liner) for the hero
+and `longBio` (array of paragraphs) for about/resume.
 
 See [`examples/demo-site/src/content.config.ts`](../../examples/demo-site/src/content.config.ts)
 for a working reference.

--- a/packages/editorial-theme/README.md
+++ b/packages/editorial-theme/README.md
@@ -108,12 +108,12 @@ See that package for the canonical Zod schemas. A minimal set:
 Add `src/content.config.ts` with these four collections (the page routes
 expect them):
 
-| Collection     | Type      | Required entries / shape                                                                                                     |
-| -------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `profile`      | `data`    | `person` (`ProfilePersonSchema`) and `cv` (`ProfileCvSchema`) — import from `@portfolio-engine/schema`                      |
-| `projects`     | `content` | title, description, featured?, image?, tags?, link?, date                                                                    |
-| `writing`      | `content` | title, date, description?, image?, draft?, tags?                                                                             |
-| `testimonials` | `data`    | quote, author, role, featured?                                                                                               |
+| Collection     | Type      | Required entries / shape                                                                               |
+| -------------- | --------- | ------------------------------------------------------------------------------------------------------ |
+| `profile`      | `data`    | `person` (`ProfilePersonSchema`) and `cv` (`ProfileCvSchema`) — import from `@portfolio-engine/schema` |
+| `projects`     | `content` | title, description, featured?, image?, tags?, link?, date                                              |
+| `writing`      | `content` | title, date, description?, image?, draft?, tags?                                                       |
+| `testimonials` | `data`    | quote, author, role, featured?                                                                         |
 
 For the `profile` collection, prefer `shortBio`/`summary`/`longBio` over
 dumping everything into `bio`. The `bio` field is still accepted but deprecated:

--- a/packages/editorial-theme/src/components/ImageOrFallback.astro
+++ b/packages/editorial-theme/src/components/ImageOrFallback.astro
@@ -14,8 +14,8 @@ const { src, alt, fallbackChar, class: className = '', loading } = Astro.props;
   src ? (
     <img src={src} alt={alt} class={className} loading={loading} />
   ) : (
-    <div class={`flex items-center justify-center bg-amber-50 ${className}`}>
-      <span class="font-serif text-6xl italic text-amber-200">
+    <div class={`flex items-center justify-center bg-amber-50 ${className}`} role="img" aria-label={alt}>
+      <span class="font-serif text-6xl italic text-amber-200" aria-hidden="true">
         {fallbackChar}
       </span>
     </div>

--- a/packages/editorial-theme/src/components/Nav.astro
+++ b/packages/editorial-theme/src/components/Nav.astro
@@ -41,22 +41,22 @@ const { pathname } = Astro.url;
 ---
 
 <header
-  class="fixed inset-x-0 top-0 z-50 border-b border-[var(--warm-line)] bg-[var(--paper)]"
+  class="pe-site-header fixed inset-x-0 top-0 z-50 border-b border-[var(--warm-line)] bg-[var(--paper)]"
 >
-  <nav class="mx-auto flex h-16 max-w-5xl items-center justify-between px-6">
+  <nav class="pe-site-nav mx-auto flex h-16 max-w-5xl items-center justify-between px-6">
     <a
       href={`${base}/`}
-      class="font-serif text-xl font-bold tracking-tight transition-opacity hover:opacity-60"
+      class="pe-site-brand font-serif text-xl font-bold tracking-tight transition-opacity hover:opacity-60"
     >
       {config.site.title}
     </a>
-    <ul class="flex items-center gap-8">
+    <ul class="pe-site-nav-list flex items-center gap-8">
       {
         links.map(({ href, label }: NavLink) => (
-          <li>
+          <li class="pe-site-nav-item">
             <a
               href={href}
-              class={`text-sm font-medium transition-colors ${
+              class={`pe-site-nav-link text-sm font-medium transition-colors ${
                 isNavActive(pathname, href)
                   ? 'text-stone-900'
                   : 'text-[var(--stone-soft)] hover:text-stone-900'

--- a/packages/editorial-theme/src/pages/writing/index.astro
+++ b/packages/editorial-theme/src/pages/writing/index.astro
@@ -22,13 +22,16 @@ const base = getBase();
     >
       Writing
     </p>
-    <h1 class="mb-16 font-serif text-5xl font-bold leading-tight md:text-6xl">
+    <h1 class="mb-6 font-serif text-5xl font-bold leading-tight md:text-6xl">
       Writing
     </h1>
+    <p class="mb-16 text-lg leading-relaxed text-stone-500">
+      Essays, notes, and selected thinking.
+    </p>
 
     {
       sorted.length === 0 ? (
-        <p class="text-lg text-stone-400">Posts coming soon.</p>
+        <p class="text-lg text-stone-400">No posts yet — check back soon.</p>
       ) : (
         <div class="space-y-12">
           {sorted.map((post) => {

--- a/packages/editorial-theme/src/styles/global.css
+++ b/packages/editorial-theme/src/styles/global.css
@@ -158,6 +158,46 @@
     transform: translateY(0);
   }
 
+  /* ── Nav structural baseline — Tailwind-independent fallback ── */
+  .pe-site-header {
+    position: fixed;
+    inset-inline: 0;
+    top: 0;
+    z-index: 50;
+    border-bottom: 1px solid var(--warm-line);
+    background: var(--paper);
+  }
+
+  .pe-site-nav {
+    max-width: 64rem;
+    min-height: 4rem;
+    margin-inline: auto;
+    padding-inline: 1.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.5rem;
+  }
+
+  .pe-site-brand {
+    white-space: nowrap;
+    text-decoration: none;
+  }
+
+  .pe-site-nav-list {
+    display: flex;
+    align-items: center;
+    gap: 2rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .pe-site-nav-link {
+    text-decoration: none;
+    white-space: nowrap;
+  }
+
   .pe-scheduling-block {
     margin-block: 3rem;
   }
@@ -260,5 +300,20 @@
 @media (width <= 768px) {
   .ambient-blob {
     animation: none;
+  }
+}
+
+@media (max-width: 720px) {
+  .pe-site-nav {
+    align-items: flex-start;
+    flex-direction: column;
+    justify-content: center;
+    gap: 0.5rem;
+    padding-block: 0.75rem;
+  }
+
+  .pe-site-nav-list {
+    flex-wrap: wrap;
+    gap: 0.75rem 1rem;
   }
 }

--- a/packages/engine-core/package.json
+++ b/packages/engine-core/package.json
@@ -7,6 +7,9 @@
     "dist"
   ],
   "types": "./dist/index.d.ts",
+  "bin": {
+    "portfolio-engine": "./dist/doctor.js"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -14,6 +17,9 @@
     },
     "./client": {
       "types": "./dist/client.d.ts"
+    },
+    "./doctor": {
+      "import": "./dist/doctor.js"
     }
   },
   "scripts": {

--- a/packages/engine-core/package.json
+++ b/packages/engine-core/package.json
@@ -19,6 +19,7 @@
       "types": "./dist/client.d.ts"
     },
     "./doctor": {
+      "types": "./dist/doctor.d.ts",
       "import": "./dist/doctor.js"
     }
   },

--- a/packages/engine-core/src/doctor.ts
+++ b/packages/engine-core/src/doctor.ts
@@ -38,7 +38,6 @@ const BOLD = '\x1b[1m';
 const DIM = '\x1b[2m';
 const GREEN = '\x1b[32m';
 const YELLOW = '\x1b[33m';
-const RED = '\x1b[31m';
 const CYAN = '\x1b[36m';
 
 function col(text: string, width: number): string {

--- a/packages/engine-core/src/doctor.ts
+++ b/packages/engine-core/src/doctor.ts
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * portfolio-engine doctor
+ *
+ * Reads .portfolio-engine/manifest.json from the current working directory
+ * and prints a structured diagnostic report.
+ *
+ * Usage (from a consumer site root):
+ *   pnpm pe:doctor
+ *   node node_modules/@portfolio-engine/engine-core/dist/doctor.js
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { EngineManifest } from '@portfolio-engine/schema';
+
+const cwd = process.cwd();
+const manifestPath = resolve(cwd, '.portfolio-engine', 'manifest.json');
+
+if (!existsSync(manifestPath)) {
+  console.error(
+    '\n  ✗ .portfolio-engine/manifest.json not found.\n' +
+      '    Run `pnpm build` (or `astro build`) first to generate it.\n',
+  );
+  process.exit(1);
+}
+
+let manifest: EngineManifest;
+try {
+  manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as EngineManifest;
+} catch (err) {
+  console.error(`\n  ✗ Failed to parse manifest: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+}
+
+const RESET = '\x1b[0m';
+const BOLD = '\x1b[1m';
+const DIM = '\x1b[2m';
+const GREEN = '\x1b[32m';
+const YELLOW = '\x1b[33m';
+const RED = '\x1b[31m';
+const CYAN = '\x1b[36m';
+
+function col(text: string, width: number): string {
+  return text.length >= width ? text : text + ' '.repeat(width - text.length);
+}
+
+console.log(`\n${BOLD}Portfolio Engine Doctor${RESET}`);
+console.log(DIM + `  Generated: ${manifest.generatedAt}` + RESET);
+
+// Package versions
+console.log(`\n${BOLD}Package versions:${RESET}`);
+const pe = manifest.portfolioEngine ?? {};
+console.log(`  @portfolio-engine/engine-core:      ${pe.engineCoreVersion ?? 'unknown'}`);
+console.log(`  @portfolio-engine/editorial-theme:  ${pe.editorialThemeVersion ?? 'unknown'}`);
+
+// Consumer registry
+console.log(`\n${BOLD}Consumer registry:${RESET}`);
+const cr = manifest.consumerRegistry ?? { path: '?', loaded: false, routeCount: 0 };
+const loadedStr = cr.loaded ? GREEN + 'loaded' + RESET : DIM + 'not found' + RESET;
+console.log(`  ${cr.path}  [${loadedStr}]  ${cr.routeCount} local route(s)`);
+
+// Route overrides
+const ro = manifest.routeOverrides ?? { disabled: [], remapped: {} };
+const disabledCount = ro.disabled.length;
+const remappedCount = Object.keys(ro.remapped).length;
+if (disabledCount > 0 || remappedCount > 0) {
+  console.log(`\n${BOLD}Route overrides:${RESET}`);
+  for (const d of ro.disabled) {
+    console.log(`  ${YELLOW}disabled${RESET}  ${d}`);
+  }
+  for (const [from, to] of Object.entries(ro.remapped)) {
+    console.log(`  ${CYAN}remapped${RESET}  ${from}  →  ${to}`);
+  }
+}
+
+// Routes
+console.log(`\n${BOLD}Routes:${RESET}`);
+for (const route of manifest.routes ?? []) {
+  const origin = route.routeOrigin ?? 'unknown';
+  const originLabel =
+    origin === 'theme'
+      ? DIM + 'theme' + RESET
+      : origin === 'consumer-local'
+        ? CYAN + 'consumer-local' + RESET
+        : origin === 'consumer-pages'
+          ? GREEN + 'consumer-pages' + RESET
+          : YELLOW + origin + RESET;
+
+  const resolved = route.resolved !== route.pattern ? ` → ${route.resolved}` : '';
+  const entryHint = route.entrypoint ? `  ${DIM}${route.entrypoint}${RESET}` : '';
+  console.log(`  ${col(route.pattern + resolved, 36)} ${originLabel}${entryHint}`);
+}
+
+// Navigation warnings
+const navWarnings = manifest.navWarnings;
+if (navWarnings && navWarnings.length > 0) {
+  console.log(`\n${BOLD}${YELLOW}Navigation warnings:${RESET}`);
+  for (const w of navWarnings) {
+    console.log(`  ${YELLOW}⚠${RESET}  ${w}`);
+  }
+} else {
+  console.log(`\n${BOLD}Navigation:${RESET}`);
+  console.log(`  ${GREEN}✓${RESET}  No nav warnings.`);
+}
+
+// Capabilities
+console.log(`\n${BOLD}Capabilities:${RESET}`);
+const caps = manifest.capabilities ?? {};
+for (const [key, val] of Object.entries(caps)) {
+  console.log(`  ${val ? GREEN + '✓' : DIM + '·'}${RESET}  ${key}`);
+}
+
+console.log('');

--- a/packages/engine-core/src/doctor.ts
+++ b/packages/engine-core/src/doctor.ts
@@ -7,6 +7,7 @@
  *
  * Usage (from a consumer site root):
  *   pnpm pe:doctor
+ *   portfolio-engine
  *   node node_modules/@portfolio-engine/engine-core/dist/doctor.js
  */
 

--- a/packages/engine-core/src/integration.ts
+++ b/packages/engine-core/src/integration.ts
@@ -173,14 +173,8 @@ export function createEngineIntegration(options: EngineIntegrationOptions): Astr
         const activeResolvedPaths = new Set(injectedRoutes.map((r) => r.routeRecord.resolved));
         const navWarnings = buildNavWarnings(resolvedConfig.navigation.items, activeResolvedPaths);
         if (navWarnings.length > 0) {
-          const strictNavRoutes = options.diagnostics?.strictNavRoutes ?? false;
           for (const warning of navWarnings) {
-            if (strictNavRoutes) {
-              // Let the first failure throw via the logger; collect all first.
-              logger.warn(`[portfolio-engine] ${warning}`);
-            } else {
-              logger.warn(`[portfolio-engine] ${warning}`);
-            }
+            logger.warn(`[portfolio-engine] ${warning}`);
           }
           if (options.diagnostics?.strictNavRoutes) {
             throw new Error(

--- a/packages/engine-core/src/integration.ts
+++ b/packages/engine-core/src/integration.ts
@@ -78,6 +78,13 @@ const ENGINE_CORE_VERSION = tryReadVersion(_engineCoreDir);
  * nav items whose hrefs don't match any active injected route.
  * External URLs and hash-only links are skipped.
  */
+/** Strip trailing slash, fragment, and query string from an internal href for route comparison. */
+function normalizeNavHref(href: string): string {
+  // Remove fragment and query string, then strip trailing slash (but keep root "/")
+  const clean = href.split('#')[0].split('?')[0];
+  return clean.length > 1 ? clean.replace(/\/$/, '') : clean;
+}
+
 function buildNavWarnings(
   navItems: { label: string; href: string; visible?: boolean }[],
   activeResolvedPaths: Set<string>,
@@ -88,7 +95,7 @@ function buildNavWarnings(
     const href = item.href;
     if (!href || href.startsWith('http://') || href.startsWith('https://') || href.startsWith('//')) continue;
     if (href.startsWith('#')) continue;
-    if (!activeResolvedPaths.has(href)) {
+    if (!activeResolvedPaths.has(normalizeNavHref(href))) {
       warnings.push(
         `Nav item "${item.label}" → "${href}" does not match any active injected route. ` +
           `Check: (1) route is not disabled in astro.config.mjs, (2) a consumer-local registry entry exists for this pattern, ` +

--- a/packages/engine-core/src/integration.ts
+++ b/packages/engine-core/src/integration.ts
@@ -1,7 +1,9 @@
 import type { AstroIntegration } from 'astro';
+import { existsSync, readFileSync } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
-import { resolve } from 'node:path';
+import { resolve, relative, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
 import type { EngineConfig } from './config-loader.js';
 import { loadConfig } from './config-loader.js';
 import { discoverRoutes, resolveThemePagesDir } from './route-discovery.js';
@@ -26,6 +28,14 @@ import {
   loadConsumerRegistryFromDisk,
 } from './consumer-local-routes.js';
 
+export interface DiagnosticsOptions {
+  /**
+   * When true, nav items that cannot be matched to an active route cause a build error.
+   * Default: false (warnings only).
+   */
+  strictNavRoutes?: boolean;
+}
+
 export interface EngineIntegrationOptions extends EngineConfig {
   /** Remap or disable individual routes before injection. */
   routes?: RouteOverrides;
@@ -43,6 +53,50 @@ export interface EngineIntegrationOptions extends EngineConfig {
   consumerRegistryPath?: string;
   /** Relative directory for registry-backed Astro pages. Defaults to `src/pages-local`. */
   consumerPagesLocalDir?: string;
+  /** Diagnostic and validation options. */
+  diagnostics?: DiagnosticsOptions;
+}
+
+/** Read a package.json version from a directory, returning 'unknown' on any failure. */
+function tryReadVersion(pkgDir: string): string {
+  const pkgPath = resolve(pkgDir, 'package.json');
+  if (!existsSync(pkgPath)) return 'unknown';
+  try {
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as { version?: string };
+    return pkg.version ?? 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+// engine-core's own package root: src/ (or dist/) → one level up
+const _engineCoreDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const ENGINE_CORE_VERSION = tryReadVersion(_engineCoreDir);
+
+/**
+ * Resolve nav warnings: returns a list of human-readable warning strings for
+ * nav items whose hrefs don't match any active injected route.
+ * External URLs and hash-only links are skipped.
+ */
+function buildNavWarnings(
+  navItems: { label: string; href: string; visible?: boolean }[],
+  activeResolvedPaths: Set<string>,
+): string[] {
+  const warnings: string[] = [];
+  for (const item of navItems) {
+    if (item.visible === false) continue;
+    const href = item.href;
+    if (!href || href.startsWith('http://') || href.startsWith('https://') || href.startsWith('//')) continue;
+    if (href.startsWith('#')) continue;
+    if (!activeResolvedPaths.has(href)) {
+      warnings.push(
+        `Nav item "${item.label}" → "${href}" does not match any active injected route. ` +
+          `Check: (1) route is not disabled in astro.config.mjs, (2) a consumer-local registry entry exists for this pattern, ` +
+          `or (3) the href matches an ordinary Astro src/pages route (not verified by the engine).`,
+      );
+    }
+  }
+  return warnings;
 }
 
 export function createEngineIntegration(options: EngineIntegrationOptions): AstroIntegration {
@@ -53,7 +107,7 @@ export function createEngineIntegration(options: EngineIntegrationOptions): Astr
   return {
     name: '@portfolio-engine/engine-core',
     hooks: {
-      'astro:config:setup': async ({ config, command, injectRoute, updateConfig }) => {
+      'astro:config:setup': async ({ config, command, injectRoute, updateConfig, logger }) => {
         const rootDir = fileURLToPath(config.root);
         cachedRootDir = rootDir;
         const registries = options.registries ?? { routes: [], overrideSurfaces: [] };
@@ -75,7 +129,7 @@ export function createEngineIntegration(options: EngineIntegrationOptions): Astr
         const discovered = discoverRoutes(pagesDir, registries.routes);
 
         // 3. Apply route remaps / disables from downstream config
-        const { routes: activeRoutes } = applyRouteOverrides(discovered, options.routes ?? {});
+        const { routes: activeRoutes, disabled, remapped } = applyRouteOverrides(discovered, options.routes ?? {});
 
         const registryRelative =
           options.consumerRegistryPath ?? CONSUMER_REGISTRY_DEFAULT_RELATIVE_PATH;
@@ -92,9 +146,6 @@ export function createEngineIntegration(options: EngineIntegrationOptions): Astr
         const injectedRoutes = [...activeRoutes, ...localRoutes];
 
         // 4. Inject each active route into the consumer's Astro config.
-        // Use routeRecord.resolved (the post-remap injected path) rather than
-        // route.pattern (canonical name), so remapped routes are injected at
-        // their new URL.
         for (const route of injectedRoutes) {
           injectRoute({ pattern: route.routeRecord.resolved, entrypoint: route.entrypoint });
         }
@@ -102,33 +153,73 @@ export function createEngineIntegration(options: EngineIntegrationOptions): Astr
         // 5. Resolve component and style overrides
         const overrides = resolveOverrides(options.overrides ?? {}, rootDir, registries.overrideSurfaces);
 
-        // Build manifest route entries from the active (post-remap) route set.
-        // Start from routeRecord (which already has all required fields), then
-        // layer in any optional metadata (agentGuidance, adminDescription) from
-        // the canonical registry entry if it exists.
+        // Build manifest route entries: include explicit routeOrigin and entrypoint for every route.
         const registryMap = new Map(registries.routes.map((r) => [r.pattern, r]));
         const consumerLocalEntrypoints = new Set(localRoutes.map((lr) => lr.entrypoint));
         const manifestRoutes: ManifestRouteEntry[] = injectedRoutes.map((r) => {
           const registryEntry = registryMap.get(r.routeRecord.pattern);
-          const entry: ManifestRouteEntry = { ...r.routeRecord };
+          const isConsumerLocal = consumerLocalEntrypoints.has(r.entrypoint);
+          const entry: ManifestRouteEntry = {
+            ...r.routeRecord,
+            routeOrigin: isConsumerLocal ? 'consumer-local' : 'theme',
+            entrypoint: relative(rootDir, r.entrypoint).replace(/\\/g, '/'),
+          };
           if (registryEntry?.agentGuidance !== undefined) entry.agentGuidance = registryEntry.agentGuidance;
           if (registryEntry?.adminDescription !== undefined) entry.adminDescription = registryEntry.adminDescription;
-          if (consumerLocalEntrypoints.has(r.entrypoint)) entry.routeOrigin = 'consumer-local';
           return entry;
         });
-        writeManifest(rootDir, manifestRoutes, registries.overrideSurfaces);
 
-        // 6. Build context for virtual modules
+        // 6. Nav validation — warn (or fail) for nav items that point at unknown routes.
+        const activeResolvedPaths = new Set(injectedRoutes.map((r) => r.routeRecord.resolved));
+        const navWarnings = buildNavWarnings(resolvedConfig.navigation.items, activeResolvedPaths);
+        if (navWarnings.length > 0) {
+          const strictNavRoutes = options.diagnostics?.strictNavRoutes ?? false;
+          for (const warning of navWarnings) {
+            if (strictNavRoutes) {
+              // Let the first failure throw via the logger; collect all first.
+              logger.warn(`[portfolio-engine] ${warning}`);
+            } else {
+              logger.warn(`[portfolio-engine] ${warning}`);
+            }
+          }
+          if (options.diagnostics?.strictNavRoutes) {
+            throw new Error(
+              `[portfolio-engine] strictNavRoutes: ${navWarnings.length} nav item(s) could not be matched to an active route. See warnings above.`,
+            );
+          }
+        }
+
+        // 7. Resolve editorial-theme version from consumer context
+        let editorialThemeVersion = 'unknown';
+        try {
+          const req = createRequire(resolve(rootDir, 'package.json'));
+          const themeEntry = req.resolve('@portfolio-engine/editorial-theme');
+          const themePkgDir = resolve(themeEntry, '..', '..');
+          editorialThemeVersion = tryReadVersion(themePkgDir);
+        } catch {
+          // Version resolution is best-effort
+        }
+
+        writeManifest(rootDir, manifestRoutes, registries.overrideSurfaces, {
+          engineCoreVersion: ENGINE_CORE_VERSION,
+          editorialThemeVersion,
+          consumerRegistry: {
+            path: registryRelative,
+            loaded: consumerRegistry !== null,
+            routeCount: consumerRegistry?.localRoutes.length ?? 0,
+          },
+          routeOverrides: { disabled, remapped },
+          navWarnings: navWarnings.length > 0 ? navWarnings : undefined,
+        });
+
+        // 8. Build context for virtual modules
         const context: BuildContext = {
           env: command === 'build' ? 'production' : 'development',
           mode: command === 'build' ? 'production' : 'development',
           base: config.base,
         };
 
-        // 7. Register virtual modules plugin
-        // Cast needed: our local VitePlugin is a structural subset of Vite's Plugin
-        // type; the shapes are compatible at runtime but TypeScript can't verify
-        // this across the astro/vite type boundary without adding vite as a dep.
+        // 9. Register virtual modules plugin
         updateConfig({
           vite: {
             plugins: [
@@ -159,8 +250,6 @@ export function createEngineIntegration(options: EngineIntegrationOptions): Astr
       },
 
       'astro:config:done': ({ injectTypes }) => {
-        // Inject the virtual module type declarations into the consumer's TS
-        // environment automatically — no manual reference directive needed.
         injectTypes({
           filename: 'types/portfolio-engine.d.ts',
           content: '/// <reference types="@portfolio-engine/engine-core/client" />\n',

--- a/packages/engine-core/src/manifest.ts
+++ b/packages/engine-core/src/manifest.ts
@@ -2,15 +2,29 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { EngineManifest, ManifestRouteEntry, OverrideSurfaceEntry } from '@portfolio-engine/schema';
 
+export interface ManifestMeta {
+  engineCoreVersion: string;
+  editorialThemeVersion: string;
+  consumerRegistry: { path: string; loaded: boolean; routeCount: number };
+  routeOverrides: { disabled: string[]; remapped: Record<string, string> };
+  navWarnings?: string[];
+}
+
 export function writeManifest(
   rootDir: string,
   routes: ManifestRouteEntry[],
   overrideSurfaces: OverrideSurfaceEntry[],
+  meta: ManifestMeta,
 ): void {
   const manifest: EngineManifest = {
     generatedAt: new Date().toISOString(),
-    // Stable, portable project root (manifest lives at `<root>/.portfolio-engine/`)
     rootDir: '.',
+    portfolioEngine: {
+      engineCoreVersion: meta.engineCoreVersion,
+      editorialThemeVersion: meta.editorialThemeVersion,
+    },
+    consumerRegistry: meta.consumerRegistry,
+    routeOverrides: meta.routeOverrides,
     routes,
     overrideSurfaces,
     capabilities: {
@@ -19,6 +33,7 @@ export function writeManifest(
       namedOverrides: true,
       consumerLocalRoutes: routes.some((r) => r.routeOrigin === 'consumer-local'),
     },
+    ...(meta.navWarnings && meta.navWarnings.length > 0 ? { navWarnings: meta.navWarnings } : {}),
   };
   const dir = join(rootDir, '.portfolio-engine');
   mkdirSync(dir, { recursive: true });

--- a/packages/engine-core/tsup.config.ts
+++ b/packages/engine-core/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/doctor.ts'],
   format: ['esm'],
   dts: true,
   clean: true,

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -105,7 +105,27 @@ export type NavigationConfig = z.infer<typeof NavigationConfigSchema>;
 export type FeaturesConfig = z.infer<typeof FeaturesConfigSchema>;
 
 export * from './design-resolve.js';
-export type { EngineManifest, ManifestRouteEntry, OverrideSurfaceEntry, RouteRegistryEntry } from './registry.js';
+export type {
+  EngineManifest,
+  ManifestRouteEntry,
+  OverrideSurfaceEntry,
+  RouteOrigin,
+  RouteRegistryEntry,
+} from './registry.js';
+export {
+  ProfilePersonSchema,
+  ProfileCvSchema,
+  ProfileExperienceSchema,
+  ProfileEducationSchema,
+  ProfileAwardSchema,
+  type ProfilePerson,
+  type ProfileCv,
+  type ProfileExperience,
+  type ProfileEducation,
+  type ProfileAward,
+  type ValueCard,
+  type WorkingPrinciple,
+} from './profile.js';
 export {
   CONSUMER_REGISTRY_DEFAULT_RELATIVE_PATH,
   CONSUMER_REGISTRY_SUPPORTED_VERSION,

--- a/packages/schema/src/profile.ts
+++ b/packages/schema/src/profile.ts
@@ -1,0 +1,80 @@
+import { z } from 'zod';
+
+const ValueCardSchema = z.object({
+  title: z.string(),
+  body: z.string(),
+});
+
+const WorkingPrincipleSchema = z.object({
+  title: z.string(),
+  body: z.string(),
+});
+
+export const ProfilePersonSchema = z.object({
+  name: z.string(),
+  roleLine: z.string().optional(),
+  /** Short one-liner for hero and meta. Preferred over `bio`. */
+  shortBio: z.string().optional(),
+  /** One or two sentence summary for cards, meta, and hero fallback. */
+  summary: z.string().optional(),
+  /** @deprecated Prefer `shortBio`/`summary`/`longBio`. Split on blank lines into paragraphs when used. */
+  bio: z.string().optional(),
+  /** Full biography paragraphs for about and resume pages. */
+  longBio: z.array(z.string()).optional(),
+  values: z.array(ValueCardSchema).optional(),
+  workingPrinciples: z.array(WorkingPrincipleSchema).optional(),
+  credentials: z.array(z.string()).optional(),
+  email: z.string().optional(),
+  linkedin: z.url().optional(),
+  github: z.url().optional(),
+  instagram: z.url().optional(),
+  photo: z.string().optional(),
+});
+
+export const ProfileExperienceSchema = z.object({
+  organization: z.string(),
+  title: z.string(),
+  location: z.string().optional(),
+  startDate: z.string().optional(),
+  endDate: z.string().optional(),
+  /** Alias for startDate (legacy field used by resume.astro). */
+  startYear: z.union([z.string(), z.number()]).optional(),
+  /** Alias for endDate (legacy field used by resume.astro). */
+  endYear: z.union([z.string(), z.number()]).optional(),
+  current: z.boolean().optional(),
+  description: z.string().optional(),
+  highlights: z.array(z.string()).optional(),
+});
+
+export const ProfileEducationSchema = z.object({
+  degree: z.string(),
+  institution: z.string(),
+  location: z.string().optional(),
+  year: z.union([z.string(), z.number()]).optional(),
+  note: z.string().optional(),
+});
+
+export const ProfileAwardSchema = z.object({
+  title: z.string(),
+  context: z.string().optional(),
+  description: z.string().optional(),
+  image: z.string().optional(),
+});
+
+export const ProfileCvSchema = z.object({
+  selectedEvidence: z.array(z.string()).optional(),
+  technicalRange: z
+    .array(z.object({ heading: z.string(), items: z.array(z.string()) }))
+    .optional(),
+  experience: z.array(ProfileExperienceSchema).optional(),
+  education: z.array(ProfileEducationSchema).optional(),
+  awards: z.array(ProfileAwardSchema).optional(),
+});
+
+export type ProfilePerson = z.infer<typeof ProfilePersonSchema>;
+export type ProfileCv = z.infer<typeof ProfileCvSchema>;
+export type ProfileExperience = z.infer<typeof ProfileExperienceSchema>;
+export type ProfileEducation = z.infer<typeof ProfileEducationSchema>;
+export type ProfileAward = z.infer<typeof ProfileAwardSchema>;
+export type ValueCard = z.infer<typeof ValueCardSchema>;
+export type WorkingPrinciple = z.infer<typeof WorkingPrincipleSchema>;

--- a/packages/schema/src/registry.ts
+++ b/packages/schema/src/registry.ts
@@ -20,26 +20,44 @@ export interface OverrideSurfaceEntry {
   guidance?: string;
 }
 
+/** Where the active route's page file came from. */
+export type RouteOrigin = 'theme' | 'consumer-local' | 'consumer-pages' | 'unknown';
+
 /**
  * A route entry as it appears in the generated manifest: the canonical registry
- * entry plus the `resolved` path that was actually injected (which may differ
- * when a consumer has remapped the route to a different URL).
+ * entry plus the resolved path, origin, and entrypoint so consumers/agents can
+ * immediately see which file owns each URL.
  */
 export interface ManifestRouteEntry extends RouteRegistryEntry {
-  /** Actual injected URL pattern after any consumer remap (equals `pattern` when not remapped) */
+  /** Actual injected URL pattern after any consumer remap (equals `pattern` when not remapped). */
   resolved: string;
-  /**
-   * When set to `'consumer-local'`, this route was injected from the consumer registry / `src/pages-local`.
-   * Omitted for editorial-theme routes (consumers should treat absence as theme-injected).
-   */
-  routeOrigin?: 'consumer-local';
+  /** Source of the route's page file. */
+  routeOrigin: RouteOrigin;
+  /** Absolute path to the page file that serves this route. */
+  entrypoint: string;
 }
 
 export interface EngineManifest {
   generatedAt: string;
   /** Consumer site root, always `.` (relative to the directory containing `.portfolio-engine/`). */
   rootDir: string;
-  /** Active route set after applying consumer remaps/disables — not the raw canonical registry */
+  /** Versions of the engine packages that produced this manifest. */
+  portfolioEngine: {
+    engineCoreVersion: string;
+    editorialThemeVersion: string;
+  };
+  /** State of the consumer registry loaded during this build. */
+  consumerRegistry: {
+    path: string;
+    loaded: boolean;
+    routeCount: number;
+  };
+  /** Route override config applied during this build. */
+  routeOverrides: {
+    disabled: string[];
+    remapped: Record<string, string>;
+  };
+  /** Active route set after applying consumer remaps/disables — not the raw canonical registry. */
   routes: ManifestRouteEntry[];
   overrideSurfaces: OverrideSurfaceEntry[];
   capabilities: {
@@ -49,4 +67,6 @@ export interface EngineManifest {
     /** True when at least one `consumer-local` route was injected from the consumer registry. */
     consumerLocalRoutes: boolean;
   };
+  /** Nav items that could not be matched to an active route. Present only when warnings exist. */
+  navWarnings?: string[];
 }

--- a/packages/schema/src/registry.ts
+++ b/packages/schema/src/registry.ts
@@ -33,7 +33,7 @@ export interface ManifestRouteEntry extends RouteRegistryEntry {
   resolved: string;
   /** Source of the route's page file. */
   routeOrigin: RouteOrigin;
-  /** Absolute path to the page file that serves this route. */
+  /** Path to the page file that serves this route, relative to the consumer project root. */
   entrypoint: string;
 }
 


### PR DESCRIPTION
## Summary

- **P0 Nav robustness**: Added `pe-site-*` semantic classes to `Nav.astro` + explicit CSS baseline in `global.css` so nav layout holds even when Tailwind utility generation is partial (fixes glued-text rendering on production builds)
- **P0 Route diagnostics**: `ManifestRouteEntry` now has required `routeOrigin` + `entrypoint`; `EngineManifest` includes package versions, registry load state, route overrides, and nav warnings; engine validates nav items against active routes with optional `diagnostics.strictNavRoutes: true` to fail the build
- **P1 Profile schemas**: `@portfolio-engine/schema` exports `ProfilePersonSchema`, `ProfileCvSchema`, `ProfileExperienceSchema`, `ProfileEducationSchema`, `ProfileAwardSchema`; demo-site `content.config.ts` now imports them instead of duplicating inline definitions
- **P1 Accessibility**: `ImageOrFallback` fallback character is `aria-hidden="true"` with `role="img"` + `aria-label` on the container
- **P1 Docs**: Updated `editorial-theme/README.md`, `docs/downstream/consumption.md`, `docs/downstream/custom-page-via-registry.md` with route ownership modes and a step-by-step "replacing a default theme page" recipe
- **P1 Page copy**: Writing index subtitle + neutral empty-state copy
- **P2 Doctor**: `portfolio-engine doctor` / `pnpm pe:doctor` CLI reads `.portfolio-engine/manifest.json` and prints a structured diagnostic report

## Test plan

- [x] `pnpm build` — all packages build, demo-site and node-ssr-demo Astro builds complete (Vercel adapter symlink EPERM is a pre-existing Windows sandbox limitation, unrelated to these changes)
- [x] `pnpm check` — 0 errors, 0 warnings across all packages and examples
- [x] `pnpm lint` — clean
- [x] `pnpm format` — clean

## Breaking changes

`ManifestRouteEntry.routeOrigin` is now **required** (was `'consumer-local' | undefined`). Existing consumers reading the manifest JSON are unaffected since JSON is untyped at runtime, but TypeScript consumers using the type directly will need to handle all `RouteOrigin` values. `ManifestRouteEntry.entrypoint` is a new required field; the `EngineManifest` top-level shape also has new required fields (`portfolioEngine`, `consumerRegistry`, `routeOverrides`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)