### PR TITLE
Standardize editorial profile bio handling; remove broken script, add root scripts, and add repo audit

### DIFF
--- a/.changeset/profile-bio-standardization.md
+++ b/.changeset/profile-bio-standardization.md
@@ -1,7 +1,9 @@
 ---
 '@portfolio-engine/schema': minor
-'@portfolio-engine/editorial-theme': patch
+'@portfolio-engine/editorial-theme': minor
 '@portfolio-engine/admin-tools': patch
 ---
 
 **Breaking (schema):** `ProfilePersonSchema` drops `bio` and is now `.strict()` — use `shortBio`, `summary`, and `longBio` only. Editorial theme resolvers and admin settings UI follow the same model; TypeScript `ProfilePerson` keeps `@deprecated bio?` as a compile-time warning only (never read).
+
+**Breaking (editorial-theme):** Import the Astro integration from `@portfolio-engine/editorial-theme/integration` (not the package root). The root entry no longer exports `editorialTheme`, so SSR bundles do not pull Tailwind’s native Oxide binaries — fixes Vercel/Linux builds with `@astrojs/vercel`.

--- a/.changeset/profile-bio-standardization.md
+++ b/.changeset/profile-bio-standardization.md
@@ -1,0 +1,7 @@
+---
+'@portfolio-engine/schema': minor
+'@portfolio-engine/editorial-theme': patch
+'@portfolio-engine/admin-tools': patch
+---
+
+**Breaking (schema):** `ProfilePersonSchema` drops `bio` and is now `.strict()` — use `shortBio`, `summary`, and `longBio` only. Editorial theme resolvers and admin settings UI follow the same model; TypeScript `ProfilePerson` keeps `@deprecated bio?` as a compile-time warning only (never read).

--- a/docs/downstream/consumption.md
+++ b/docs/downstream/consumption.md
@@ -64,7 +64,7 @@ pnpm add @portfolio-engine/editorial-theme@latest
 
 ```js
 import { defineConfig } from 'astro/config';
-import { editorialTheme } from '@portfolio-engine/editorial-theme';
+import { editorialTheme } from '@portfolio-engine/editorial-theme/integration';
 
 export default defineConfig({
   integrations: [
@@ -257,7 +257,7 @@ You may also pass `styles` (array of CSS file paths) to append extra CSS after t
 
 ```js
 import { defineConfig } from 'astro/config';
-import { editorialTheme } from '@portfolio-engine/editorial-theme';
+import { editorialTheme } from '@portfolio-engine/editorial-theme/integration';
 
 export default defineConfig({
   integrations: [

--- a/docs/downstream/new-site-setup.md
+++ b/docs/downstream/new-site-setup.md
@@ -98,7 +98,7 @@ pnpm add @portfolio-engine/editorial-theme @portfolio-engine/admin-tools @astroj
 // @ts-check
 import { defineConfig } from 'astro/config';
 import vercel from '@astrojs/vercel';
-import { editorialTheme } from '@portfolio-engine/editorial-theme';
+import { editorialTheme } from '@portfolio-engine/editorial-theme/integration';
 import { adminTools } from '@portfolio-engine/admin-tools';
 
 // Production sets SITE_URL in Vercel env vars. Previews fall back to VERCEL_URL.

--- a/docs/downstream/new-site-setup.md
+++ b/docs/downstream/new-site-setup.md
@@ -209,6 +209,7 @@ Create `src/content.config.ts`:
 import { defineCollection } from 'astro:content';
 import { glob } from 'astro/loaders';
 import { z } from 'zod';
+import { ProfilePersonSchema, ProfileCvSchema } from '@portfolio-engine/schema';
 
 const projects = defineCollection({
   loader: glob({ pattern: '**/*.{md,mdx}', base: './src/content/projects' }),
@@ -244,13 +245,7 @@ const testimonials = defineCollection({
 
 const profile = defineCollection({
   loader: glob({ pattern: '**/*.json', base: './src/content/profile' }),
-  schema: z
-    .object({
-      name: z.string().optional(),
-      bio: z.string().optional(),
-      email: z.string().optional(),
-    })
-    .passthrough(),
+  schema: z.union([ProfilePersonSchema, ProfileCvSchema]),
 });
 
 export const collections = { projects, writing, testimonials, profile };
@@ -294,7 +289,8 @@ Replace this with a real post.
 ```json
 {
   "name": "Your Full Name",
-  "bio": "One paragraph about you.",
+  "shortBio": "One line for the hero and meta.",
+  "longBio": ["First paragraph about you.", "Optional second paragraph."],
   "email": "you@example.com"
 }
 ```

--- a/docs/repo-audit-2026-05-06.md
+++ b/docs/repo-audit-2026-05-06.md
@@ -26,12 +26,12 @@ That path does not exist.
 
 Different pages mixed `shortBio`, `summary`, `longBio`, and deprecated legacy-string fallback behavior.
 
-**Resolution:** standardized on one model everywhere:
+**Resolution:** one biography model everywhere (see `ProfilePersonSchema` + `ProfilePerson` in editorial-theme):
 
-- `shortBio` for hero/meta preference
-- `summary` as second fallback
-- `longBio[]` as the only paragraph source
-- no legacy `bio` fallback behavior
+- `shortBio` for hero/meta
+- `summary` as second hero/meta fallback
+- `longBio[]` for about/resume paragraphs
+- the old `bio` string is not in the Zod schema (`.strict()` rejects it). The TS type keeps `@deprecated bio?` so agents get a warning if code still references it; the theme never reads it.
 
 ### 3) Missing conventional root scripts
 

--- a/docs/repo-audit-2026-05-06.md
+++ b/docs/repo-audit-2026-05-06.md
@@ -1,0 +1,49 @@
+# Repository Audit — May 6, 2026
+
+This audit was run across the full monorepo with a focus on build correctness, tooling consistency, and documentation clarity.
+
+## What was checked
+
+- Workspace linting (`pnpm lint`)
+- Workspace build + checks (`pnpm check`)
+- Root script inventory in `package.json`
+- Editorial theme profile API consistency across pages/utilities
+- Contributor command discoverability (`test`, `typecheck`, `check`)
+
+## Issues found and resolved
+
+### 1) Broken root npm script reference
+
+Root `package.json` previously included:
+
+- `build:audit-report-shells`: `node portfolio_engine_v3_audit_pack/write-report-shells.mjs`
+
+That path does not exist.
+
+**Resolution:** removed the script.
+
+### 2) Inconsistent bio-field strategy across editorial theme pages
+
+Different pages mixed `shortBio`, `summary`, `longBio`, and deprecated legacy-string fallback behavior.
+
+**Resolution:** standardized on one model everywhere:
+
+- `shortBio` for hero/meta preference
+- `summary` as second fallback
+- `longBio[]` as the only paragraph source
+- no legacy `bio` fallback behavior
+
+### 3) Missing conventional root scripts
+
+The repo lacked root-level `typecheck`/`test` commands, which can surprise contributors.
+
+**Resolution:** added:
+
+- `typecheck`: `pnpm -r run check`
+- `test`: `pnpm -r --if-present run test`
+
+## Additional noteworthy findings (easy to overlook)
+
+1. `packages/workflow-kit` still has placeholder scripts (`build`/`dev` output `not yet configured`), which can look like a successful workflow without producing artifacts.
+2. CI/checks currently pass under Node 22 in this environment, but the repo requires Node `>=24 <25`; contributors may miss this mismatch unless they read warnings.
+3. Several docs files describe historical/report-pack context; there is still value in a short “current vs archived docs” index if the repo keeps growing.

--- a/examples/demo-site/.portfolio-engine/manifest.json
+++ b/examples/demo-site/.portfolio-engine/manifest.json
@@ -1,6 +1,19 @@
 {
-  "generatedAt": "2026-05-05T18:31:46.334Z",
+  "generatedAt": "2026-05-06T04:28:47.580Z",
   "rootDir": ".",
+  "portfolioEngine": {
+    "engineCoreVersion": "0.3.0",
+    "editorialThemeVersion": "unknown"
+  },
+  "consumerRegistry": {
+    "path": "src/registry/portfolio-engine.registry.json",
+    "loaded": true,
+    "routeCount": 1
+  },
+  "routeOverrides": {
+    "disabled": [],
+    "remapped": {}
+  },
   "routes": [
     {
       "pattern": "/about",
@@ -10,7 +23,9 @@
       "remappable": true,
       "disableable": true,
       "agentGuidance": "Prefer About for public-facing navigation tasks.",
-      "resolved": "/about"
+      "resolved": "/about",
+      "routeOrigin": "theme",
+      "entrypoint": "node_modules/@portfolio-engine/editorial-theme/dist/pages/about.astro"
     },
     {
       "pattern": "/contact",
@@ -20,7 +35,9 @@
       "remappable": true,
       "disableable": true,
       "agentGuidance": "Prefer Contact for public-facing navigation tasks.",
-      "resolved": "/contact"
+      "resolved": "/contact",
+      "routeOrigin": "theme",
+      "entrypoint": "node_modules/@portfolio-engine/editorial-theme/dist/pages/contact.astro"
     },
     {
       "pattern": "/",
@@ -30,7 +47,21 @@
       "remappable": true,
       "disableable": false,
       "agentGuidance": "Prefer Home for public-facing navigation tasks.",
-      "resolved": "/"
+      "resolved": "/",
+      "routeOrigin": "theme",
+      "entrypoint": "node_modules/@portfolio-engine/editorial-theme/dist/pages/index.astro"
+    },
+    {
+      "pattern": "/resume",
+      "label": "Résumé",
+      "section": null,
+      "visibility": "public",
+      "remappable": true,
+      "disableable": true,
+      "agentGuidance": "Prefer Résumé for public-facing navigation tasks.",
+      "resolved": "/resume",
+      "routeOrigin": "theme",
+      "entrypoint": "node_modules/@portfolio-engine/editorial-theme/dist/pages/resume.astro"
     },
     {
       "pattern": "/work/[slug]",
@@ -40,7 +71,9 @@
       "remappable": false,
       "disableable": false,
       "agentGuidance": "Prefer Work detail for internal navigation tasks.",
-      "resolved": "/work/[slug]"
+      "resolved": "/work/[slug]",
+      "routeOrigin": "theme",
+      "entrypoint": "node_modules/@portfolio-engine/editorial-theme/dist/pages/work/[slug].astro"
     },
     {
       "pattern": "/work",
@@ -50,7 +83,9 @@
       "remappable": true,
       "disableable": true,
       "agentGuidance": "Prefer Work for public-facing navigation tasks.",
-      "resolved": "/work"
+      "resolved": "/work",
+      "routeOrigin": "theme",
+      "entrypoint": "node_modules/@portfolio-engine/editorial-theme/dist/pages/work.astro"
     },
     {
       "pattern": "/writing/[slug]",
@@ -60,7 +95,9 @@
       "remappable": false,
       "disableable": false,
       "agentGuidance": "Prefer Writing detail for internal navigation tasks.",
-      "resolved": "/writing/[slug]"
+      "resolved": "/writing/[slug]",
+      "routeOrigin": "theme",
+      "entrypoint": "node_modules/@portfolio-engine/editorial-theme/dist/pages/writing/[slug].astro"
     },
     {
       "pattern": "/writing",
@@ -70,7 +107,9 @@
       "remappable": true,
       "disableable": true,
       "agentGuidance": "Prefer Writing for public-facing navigation tasks.",
-      "resolved": "/writing"
+      "resolved": "/writing",
+      "routeOrigin": "theme",
+      "entrypoint": "node_modules/@portfolio-engine/editorial-theme/dist/pages/writing/index.astro"
     },
     {
       "pattern": "/how-i-think",
@@ -80,7 +119,8 @@
       "visibility": "public",
       "remappable": false,
       "disableable": false,
-      "routeOrigin": "consumer-local"
+      "routeOrigin": "consumer-local",
+      "entrypoint": "src/pages-local/how-i-think.astro"
     }
   ],
   "overrideSurfaces": [
@@ -91,7 +131,8 @@
         "bookingUrl",
         "pillars",
         "base",
-        "tagline"
+        "tagline",
+        "ctas"
       ],
       "defaultComponentPath": "src/components/sections/HeroSection.astro",
       "hostPage": "src/pages/index.astro",

--- a/examples/demo-site/.portfolio-engine/manifest.json
+++ b/examples/demo-site/.portfolio-engine/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-06T04:28:47.580Z",
+  "generatedAt": "2026-05-06T04:55:24.127Z",
   "rootDir": ".",
   "portfolioEngine": {
     "engineCoreVersion": "0.3.0",

--- a/examples/demo-site/astro.config.mjs
+++ b/examples/demo-site/astro.config.mjs
@@ -5,8 +5,8 @@ import { adminTools } from '@portfolio-engine/admin-tools';
 import {
   DEFAULT_OVERRIDE_SURFACES,
   DEFAULT_ROUTE_REGISTRY,
-  editorialTheme,
 } from '@portfolio-engine/editorial-theme';
+import { editorialTheme } from '@portfolio-engine/editorial-theme/integration';
 
 const routeRegistry = DEFAULT_ROUTE_REGISTRY.map((route) => ({
   ...route,

--- a/examples/demo-site/src/content/profile/person.json
+++ b/examples/demo-site/src/content/profile/person.json
@@ -1,5 +1,8 @@
 {
   "name": "Alex Morgan",
-  "bio": "Independent designer and technologist working at the intersection of clarity and craft. I help teams ship products that respect people's time and attention.",
+  "shortBio": "Independent designer and technologist at the intersection of clarity and craft.",
+  "longBio": [
+    "Independent designer and technologist working at the intersection of clarity and craft. I help teams ship products that respect people's time and attention."
+  ],
   "email": "alex@demo.example"
 }

--- a/examples/demo-site/src/overrides/Hero.astro
+++ b/examples/demo-site/src/overrides/Hero.astro
@@ -1,4 +1,7 @@
 ---
+import type { ProfilePerson } from '@portfolio-engine/editorial-theme';
+import { resolveHeroBio } from '@portfolio-engine/editorial-theme';
+
 /**
  * Demo override for the Hero surface.
  *
@@ -14,11 +17,7 @@ interface Pillar {
   image?: string;
 }
 
-interface Person {
-  name: string;
-  bio: string;
-  photo?: string;
-}
+type Person = Pick<ProfilePerson, 'name' | 'shortBio' | 'summary' | 'longBio' | 'photo'>;
 
 interface Props {
   person: Person;
@@ -29,6 +28,7 @@ interface Props {
 }
 
 const { person, tagline } = Astro.props;
+const heroLine = resolveHeroBio(person);
 ---
 
 <section
@@ -43,6 +43,6 @@ const { person, tagline } = Astro.props;
       {person.name}
       {tagline && <span class="block text-3xl font-normal text-[var(--stone-soft)]">{tagline}</span>}
     </h1>
-    <p class="text-lg leading-relaxed text-[var(--stone-soft)]">{person.bio}</p>
+    <p class="text-lg leading-relaxed text-[var(--stone-soft)]">{heroLine}</p>
   </div>
 </section>

--- a/examples/node-ssr-demo/.portfolio-engine/manifest.json
+++ b/examples/node-ssr-demo/.portfolio-engine/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-06T04:28:47.580Z",
+  "generatedAt": "2026-05-06T04:55:24.126Z",
   "rootDir": ".",
   "portfolioEngine": {
     "engineCoreVersion": "0.3.0",

--- a/examples/node-ssr-demo/.portfolio-engine/manifest.json
+++ b/examples/node-ssr-demo/.portfolio-engine/manifest.json
@@ -1,6 +1,19 @@
 {
-  "generatedAt": "2026-05-06T01:18:39.483Z",
+  "generatedAt": "2026-05-06T04:28:47.580Z",
   "rootDir": ".",
+  "portfolioEngine": {
+    "engineCoreVersion": "0.3.0",
+    "editorialThemeVersion": "unknown"
+  },
+  "consumerRegistry": {
+    "path": "src/registry/portfolio-engine.registry.json",
+    "loaded": true,
+    "routeCount": 1
+  },
+  "routeOverrides": {
+    "disabled": [],
+    "remapped": {}
+  },
   "routes": [
     {
       "pattern": "/about",
@@ -10,7 +23,9 @@
       "remappable": true,
       "disableable": true,
       "agentGuidance": "Prefer About for public-facing navigation tasks.",
-      "resolved": "/about"
+      "resolved": "/about",
+      "routeOrigin": "theme",
+      "entrypoint": "node_modules/@portfolio-engine/editorial-theme/dist/pages/about.astro"
     },
     {
       "pattern": "/contact",
@@ -20,7 +35,9 @@
       "remappable": true,
       "disableable": true,
       "agentGuidance": "Prefer Contact for public-facing navigation tasks.",
-      "resolved": "/contact"
+      "resolved": "/contact",
+      "routeOrigin": "theme",
+      "entrypoint": "node_modules/@portfolio-engine/editorial-theme/dist/pages/contact.astro"
     },
     {
       "pattern": "/",
@@ -30,7 +47,21 @@
       "remappable": true,
       "disableable": false,
       "agentGuidance": "Prefer Home for public-facing navigation tasks.",
-      "resolved": "/"
+      "resolved": "/",
+      "routeOrigin": "theme",
+      "entrypoint": "node_modules/@portfolio-engine/editorial-theme/dist/pages/index.astro"
+    },
+    {
+      "pattern": "/resume",
+      "label": "Résumé",
+      "section": null,
+      "visibility": "public",
+      "remappable": true,
+      "disableable": true,
+      "agentGuidance": "Prefer Résumé for public-facing navigation tasks.",
+      "resolved": "/resume",
+      "routeOrigin": "theme",
+      "entrypoint": "node_modules/@portfolio-engine/editorial-theme/dist/pages/resume.astro"
     },
     {
       "pattern": "/work/[slug]",
@@ -40,7 +71,9 @@
       "remappable": false,
       "disableable": false,
       "agentGuidance": "Prefer Work detail for internal navigation tasks.",
-      "resolved": "/work/[slug]"
+      "resolved": "/work/[slug]",
+      "routeOrigin": "theme",
+      "entrypoint": "node_modules/@portfolio-engine/editorial-theme/dist/pages/work/[slug].astro"
     },
     {
       "pattern": "/work",
@@ -50,7 +83,9 @@
       "remappable": true,
       "disableable": true,
       "agentGuidance": "Prefer Work for public-facing navigation tasks.",
-      "resolved": "/work"
+      "resolved": "/work",
+      "routeOrigin": "theme",
+      "entrypoint": "node_modules/@portfolio-engine/editorial-theme/dist/pages/work.astro"
     },
     {
       "pattern": "/writing/[slug]",
@@ -60,7 +95,9 @@
       "remappable": false,
       "disableable": false,
       "agentGuidance": "Prefer Writing detail for internal navigation tasks.",
-      "resolved": "/writing/[slug]"
+      "resolved": "/writing/[slug]",
+      "routeOrigin": "theme",
+      "entrypoint": "node_modules/@portfolio-engine/editorial-theme/dist/pages/writing/[slug].astro"
     },
     {
       "pattern": "/writing",
@@ -70,7 +107,9 @@
       "remappable": true,
       "disableable": true,
       "agentGuidance": "Prefer Writing for public-facing navigation tasks.",
-      "resolved": "/writing"
+      "resolved": "/writing",
+      "routeOrigin": "theme",
+      "entrypoint": "node_modules/@portfolio-engine/editorial-theme/dist/pages/writing/index.astro"
     },
     {
       "pattern": "/ssr-registry-smoke",
@@ -80,7 +119,8 @@
       "visibility": "public",
       "remappable": false,
       "disableable": false,
-      "routeOrigin": "consumer-local"
+      "routeOrigin": "consumer-local",
+      "entrypoint": "src/pages-local/ssr-registry-smoke.astro"
     }
   ],
   "overrideSurfaces": [
@@ -91,7 +131,8 @@
         "bookingUrl",
         "pillars",
         "base",
-        "tagline"
+        "tagline",
+        "ctas"
       ],
       "defaultComponentPath": "src/components/sections/HeroSection.astro",
       "hostPage": "src/pages/index.astro",

--- a/examples/node-ssr-demo/astro.config.mjs
+++ b/examples/node-ssr-demo/astro.config.mjs
@@ -5,8 +5,8 @@ import { adminTools } from '@portfolio-engine/admin-tools';
 import {
   DEFAULT_OVERRIDE_SURFACES,
   DEFAULT_ROUTE_REGISTRY,
-  editorialTheme,
 } from '@portfolio-engine/editorial-theme';
+import { editorialTheme } from '@portfolio-engine/editorial-theme/integration';
 
 const routeRegistry = DEFAULT_ROUTE_REGISTRY.map((route) => ({
   ...route,

--- a/examples/node-ssr-demo/src/content.config.ts
+++ b/examples/node-ssr-demo/src/content.config.ts
@@ -1,44 +1,11 @@
 import { defineCollection } from 'astro:content';
 import { z } from 'zod';
 import { glob } from 'astro/loaders';
+import { ProfilePersonSchema, ProfileCvSchema } from '@portfolio-engine/schema';
 
 const profile = defineCollection({
   loader: glob({ pattern: '**/*.json', base: './src/content/profile' }),
-  schema: z.union([
-    // person entry
-    z.object({
-      name: z.string(),
-      bio: z.string(),
-      photo: z.string().optional(),
-      email: z.string().optional(),
-      linkedin: z.url().optional(),
-      instagram: z.url().optional(),
-    }),
-    // cv entry
-    z.object({
-      awards: z
-        .array(
-          z.object({
-            title: z.string(),
-            context: z.string().optional(),
-            description: z.string().optional(),
-            image: z.string().optional(),
-          }),
-        )
-        .optional(),
-      education: z
-        .array(
-          z.object({
-            degree: z.string(),
-            institution: z.string(),
-            location: z.string().optional(),
-            year: z.union([z.string(), z.number()]).optional(),
-            note: z.string().optional(),
-          }),
-        )
-        .optional(),
-    }),
-  ]),
+  schema: z.union([ProfilePersonSchema, ProfileCvSchema]),
 });
 
 const projects = defineCollection({

--- a/examples/node-ssr-demo/src/content/profile/person.json
+++ b/examples/node-ssr-demo/src/content/profile/person.json
@@ -1,5 +1,8 @@
 {
   "name": "Alex Morgan",
-  "bio": "Independent designer and technologist working at the intersection of clarity and craft. I help teams ship products that respect people's time and attention.",
+  "shortBio": "Independent designer and technologist at the intersection of clarity and craft.",
+  "longBio": [
+    "Independent designer and technologist working at the intersection of clarity and craft. I help teams ship products that respect people's time and attention."
+  ],
   "email": "alex@demo.example"
 }

--- a/examples/node-ssr-demo/src/overrides/Hero.astro
+++ b/examples/node-ssr-demo/src/overrides/Hero.astro
@@ -1,4 +1,7 @@
 ---
+import type { ProfilePerson } from '@portfolio-engine/editorial-theme';
+import { resolveHeroBio } from '@portfolio-engine/editorial-theme';
+
 /**
  * Demo override for the Hero surface.
  *
@@ -14,11 +17,7 @@ interface Pillar {
   image?: string;
 }
 
-interface Person {
-  name: string;
-  bio: string;
-  photo?: string;
-}
+type Person = Pick<ProfilePerson, 'name' | 'shortBio' | 'summary' | 'longBio' | 'photo'>;
 
 interface Props {
   person: Person;
@@ -29,6 +28,7 @@ interface Props {
 }
 
 const { person, tagline } = Astro.props;
+const heroLine = resolveHeroBio(person);
 ---
 
 <section
@@ -43,6 +43,6 @@ const { person, tagline } = Astro.props;
       {person.name}
       {tagline && <span class="block text-3xl font-normal text-[var(--stone-soft)]">{tagline}</span>}
     </h1>
-    <p class="text-lg leading-relaxed text-[var(--stone-soft)]">{person.bio}</p>
+    <p class="text-lg leading-relaxed text-[var(--stone-soft)]">{heroLine}</p>
   </div>
 </section>

--- a/package.json
+++ b/package.json
@@ -9,10 +9,11 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --check \"**/*.{md,json,yml,yaml,mjs}\" --ignore-path .prettierignore",
     "format:write": "prettier --write \"**/*.{md,json,yml,yaml,mjs}\" --ignore-path .prettierignore",
-    "build:audit-report-shells": "node portfolio_engine_v3_audit_pack/write-report-shells.mjs",
     "check": "pnpm --filter \"./packages/*\" run build && pnpm -r run check",
     "smoke:packed": "node scripts/smoke-packed-consumer.mjs",
-    "release": "changeset publish"
+    "release": "changeset publish",
+    "typecheck": "pnpm -r run check",
+    "test": "pnpm -r --if-present run test"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/packages/admin-tools/README.md
+++ b/packages/admin-tools/README.md
@@ -14,7 +14,7 @@ Optional Astro integration that injects a **private `/admin` dashboard** and **G
 // astro.config.mjs
 import { defineConfig } from 'astro/config';
 import vercel from '@astrojs/vercel';
-import { editorialTheme } from '@portfolio-engine/editorial-theme';
+import { editorialTheme } from '@portfolio-engine/editorial-theme/integration';
 import { adminTools } from '@portfolio-engine/admin-tools';
 
 export default defineConfig({

--- a/packages/admin-tools/src/client/admin-app.ts
+++ b/packages/admin-tools/src/client/admin-app.ts
@@ -5,7 +5,23 @@ import type { DesignTokenGroup } from '../lib/design-token-groups.js';
 const PERSON_PATH = 'src/content/profile/person.json';
 const SITE_PATH = 'src/config/site.json';
 
-const PERSON_FIELDS = ['name', 'email', 'linkedin', 'instagram', 'photo', 'bio'] as const;
+const PERSON_TEXT_FIELDS = ['name', 'email', 'linkedin', 'instagram', 'photo', 'shortBio', 'summary'] as const;
+
+function formatLongBioForForm(value: unknown): string {
+  if (!Array.isArray(value)) return '';
+  return value
+    .filter((p): p is string => typeof p === 'string' && p.trim().length > 0)
+    .map((p) => p.trim())
+    .join('\n\n');
+}
+
+function parseLongBioInput(raw: string): string[] | undefined {
+  const paras = raw
+    .split(/\n\s*\n/)
+    .map((p) => p.replace(/\n/g, ' ').trim())
+    .filter(Boolean);
+  return paras.length > 0 ? paras : undefined;
+}
 
 type FieldDef = {
   name: string;
@@ -703,7 +719,7 @@ function initSettingsEditor(
     formEl.hidden = false;
     try {
       const [personRaw, siteRaw] = await Promise.all([api.getText(PERSON_PATH), api.getText(SITE_PATH)]);
-      const person = JSON.parse(personRaw.content) as Record<string, string>;
+      const person = JSON.parse(personRaw.content) as Record<string, unknown>;
       const site = JSON.parse(siteRaw.content) as Record<string, unknown>;
       formEl.dataset.personJson = JSON.stringify(person);
       formEl.dataset.siteJson = JSON.stringify(site);
@@ -712,7 +728,14 @@ function initSettingsEditor(
           ? (site.contact as Record<string, string>)
           : { heading: '', body: '' };
       const flat: Record<string, string> = {
-        ...person,
+        name: String(person.name ?? ''),
+        email: String(person.email ?? ''),
+        linkedin: String(person.linkedin ?? ''),
+        instagram: String(person.instagram ?? ''),
+        photo: String(person.photo ?? ''),
+        shortBio: String(person.shortBio ?? ''),
+        summary: String(person.summary ?? ''),
+        longBio: formatLongBioForForm(person.longBio),
         title: String(site.title ?? ''),
         tagline: String(site.tagline ?? ''),
         description: String(site.description ?? ''),
@@ -738,10 +761,14 @@ function initSettingsEditor(
 
   formEl.addEventListener('submit', async (e) => {
     e.preventDefault();
-    const personData = JSON.parse(formEl.dataset.personJson ?? '{}') as Record<string, string>;
+    const personData = JSON.parse(formEl.dataset.personJson ?? '{}') as Record<string, unknown>;
     const siteData = JSON.parse(formEl.dataset.siteJson ?? '{}') as Record<string, unknown>;
     const fd = new FormData(formEl);
-    for (const k of PERSON_FIELDS) personData[k] = String(fd.get(k) ?? '');
+    for (const k of PERSON_TEXT_FIELDS) personData[k] = String(fd.get(k) ?? '');
+    const longBioParsed = parseLongBioInput(String(fd.get('longBio') ?? ''));
+    if (longBioParsed) personData.longBio = longBioParsed;
+    else delete personData.longBio;
+    delete personData.bio;
     siteData.title = String(fd.get('title') ?? '');
     siteData.tagline = String(fd.get('tagline') ?? '');
     siteData.description = String(fd.get('description') ?? '');

--- a/packages/admin-tools/src/routes/admin.astro
+++ b/packages/admin-tools/src/routes/admin.astro
@@ -4,7 +4,11 @@ export const prerender = false;
 
 import '@portfolio-engine/editorial-theme/styles/global.css';
 import ThemeTokenOverrides from '@portfolio-engine/editorial-theme/components/ThemeTokenOverrides.astro';
-import { editorialGoogleFontsStylesheetHref } from '@portfolio-engine/editorial-theme';
+import {
+  editorialGoogleFontsStylesheetHref,
+  resolveHeroBio,
+  type ProfilePerson,
+} from '@portfolio-engine/editorial-theme';
 import { getCollection } from 'astro:content';
 import { config } from '@portfolio-engine:config';
 import { routes } from '@portfolio-engine:routes';
@@ -82,13 +86,7 @@ const projects = await tryCollection('projects');
 const testimonials = await tryCollection('testimonials');
 const profile = await tryCollection('profile');
 
-const personEntry = profile.find((e) => 'name' in e.data && 'bio' in e.data);
-const shortBio =
-  personEntry && 'bio' in personEntry.data && typeof personEntry.data.bio === 'string'
-    ? personEntry.data.bio.length > 120
-      ? personEntry.data.bio.slice(0, 120).trimEnd() + '…'
-      : personEntry.data.bio
-    : '';
+const personEntry = profile.find((e) => e.id === 'person');
 
 const writingSorted = [...writing].sort(
   (a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime(),
@@ -107,6 +105,15 @@ const contentApiUrl = sitePathUrl(Astro.request, 'api/content');
 
 const personOnDisk = await readJsonSafe('src/content/profile/person.json');
 const siteOnDisk = await readJsonSafe('src/config/site.json');
+
+function heroLineFromPersonRecord(raw: Record<string, unknown> | null): string {
+  if (!raw || typeof raw.name !== 'string') return '';
+  return resolveHeroBio(raw as ProfilePerson);
+}
+
+const settingsHeroLine =
+  heroLineFromPersonRecord(personOnDisk) ||
+  (personEntry ? resolveHeroBio(personEntry.data as ProfilePerson) : '');
 const settingsAvailable =
   personOnDisk !== null &&
   siteOnDisk !== null &&
@@ -277,7 +284,7 @@ const googleFontsHref = editorialGoogleFontsStylesheetHref(config.theme);
                       <div class="adm-settings-copy">
                         <p class="adm-settings-name">{String(personOnDisk?.['name'] ?? '')}</p>
                         <p class="adm-settings-tagline">{config.site.tagline}</p>
-                        <p class="adm-settings-bio">{shortBio || String(personOnDisk?.['bio'] ?? '')}</p>
+                        <p class="adm-settings-bio">{settingsHeroLine}</p>
                       </div>
                     </div>
                   </div>
@@ -312,7 +319,16 @@ const googleFontsHref = editorialGoogleFontsStylesheetHref(config.theme);
                         >Photo path<input class="adm-input" name="photo" type="text" placeholder="/media/portrait.jpg" /></label
                       >
                       <label class="adm-label adm-label--full"
-                        >Bio<textarea class="adm-input adm-textarea" name="bio" rows="4"></textarea></label
+                        >Short bio (hero)<input class="adm-input" name="shortBio" type="text" /></label
+                      >
+                      <label class="adm-label adm-label--full"
+                        >Summary<textarea class="adm-input adm-textarea" name="summary" rows="3"></textarea></label
+                      >
+                      <label class="adm-label adm-label--full"
+                        >Long bio (paragraphs; blank line between)<textarea
+                          class="adm-input adm-textarea"
+                          name="longBio"
+                          rows="6"></textarea></label
                       >
                     </div>
                     <p class="adm-form-group-label">Site</p>

--- a/packages/admin-tools/src/routes/admin.astro
+++ b/packages/admin-tools/src/routes/admin.astro
@@ -576,7 +576,8 @@ const googleFontsHref = editorialGoogleFontsStylesheetHref(config.theme);
 
     <div id="adm-toast" class="adm-toast" role="status" aria-live="polite"></div>
 
-    <style>
+    <!-- Client JS (token swatches, drawer fields, etc.) injects nodes without Astro's scoped data attributes; default scoped CSS would not match. -->
+    <style is:global>
       .adm-wrap {
         max-width: 52rem;
         margin: 0 auto;

--- a/packages/editorial-theme/README.md
+++ b/packages/editorial-theme/README.md
@@ -10,7 +10,7 @@ theme provides — all from one call in your `astro.config.mjs`.
 ```js
 // astro.config.mjs
 import { defineConfig } from 'astro/config';
-import { editorialTheme } from '@portfolio-engine/editorial-theme';
+import { editorialTheme } from '@portfolio-engine/editorial-theme/integration';
 
 export default defineConfig({
   integrations: [

--- a/packages/editorial-theme/README.md
+++ b/packages/editorial-theme/README.md
@@ -115,11 +115,12 @@ expect them):
 | `writing`      | `content` | title, date, description?, image?, draft?, tags?                                                       |
 | `testimonials` | `data`    | quote, author, role, featured?                                                                         |
 
-For the `profile` collection, prefer `shortBio`/`summary`/`longBio` over
-dumping everything into `bio`. The `bio` field is still accepted but deprecated:
-it is split on blank lines into paragraphs when present. A hero that receives a
-wall of bio text will look unpolished — use `shortBio` (one liner) for the hero
-and `longBio` (array of paragraphs) for about/resume.
+For the `profile` collection, biography copy uses only `shortBio` (hero/meta
+one-liner), optional `summary` (cards and second hero fallback), and `longBio`
+(array of paragraphs for about/resume). `ProfilePersonSchema` rejects the old
+`bio` key (`.strict()`). The TypeScript `ProfilePerson` type still includes a
+`@deprecated` `bio?` field so tooling flags any code that references it — it is
+never read by the theme.
 
 See [`examples/demo-site/src/content.config.ts`](../../examples/demo-site/src/content.config.ts)
 for a working reference.
@@ -135,12 +136,12 @@ it. Both are configured by passing an `overrides` option to
 Replace one of the four named section blocks with your own Astro
 component:
 
-| Surface                | Page | Replaces                               | Props received                                   |
-| ---------------------- | ---- | -------------------------------------- | ------------------------------------------------ |
-| `Hero`                 | `/`  | The home-page hero (name, bio, CTAs)   | `{ person, bookingUrl, pillars, base, tagline }` |
-| `FeaturedWriting`      | `/`  | The "Recent Writing" block on the home | `{ posts, base }`                                |
-| `TestimonialSection`   | `/`  | The testimonials block on the home     | `{ testimonials }`                               |
-| `CollaborationSection` | `/`  | The collaboration CTA at the bottom    | `{ base, ctaBody }`                              |
+| Surface                | Page | Replaces                                                  | Props received                                   |
+| ---------------------- | ---- | --------------------------------------------------------- | ------------------------------------------------ |
+| `Hero`                 | `/`  | The home-page hero (name, shortBio/summary/longBio, CTAs) | `{ person, bookingUrl, pillars, base, tagline }` |
+| `FeaturedWriting`      | `/`  | The "Recent Writing" block on the home                    | `{ posts, base }`                                |
+| `TestimonialSection`   | `/`  | The testimonials block on the home                        | `{ testimonials }`                               |
+| `CollaborationSection` | `/`  | The collaboration CTA at the bottom                       | `{ base, ctaBody }`                              |
 
 ```js
 editorialTheme({

--- a/packages/editorial-theme/package.json
+++ b/packages/editorial-theme/package.json
@@ -12,6 +12,10 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./integration": {
+      "types": "./dist/integration-public.d.ts",
+      "import": "./dist/integration-public.js"
+    },
     "./layouts/Layout.astro": "./dist/layouts/Layout.astro",
     "./styles/global.css": "./dist/styles/global.css",
     "./styles/design-tokens.css": "./dist/styles/design-tokens.css",

--- a/packages/editorial-theme/src/components/sections/HeroSection.astro
+++ b/packages/editorial-theme/src/components/sections/HeroSection.astro
@@ -14,7 +14,6 @@ interface Pillar {
 
 interface Person {
   name: string;
-  bio?: string;
   shortBio?: string;
   summary?: string;
   longBio?: string[];

--- a/packages/editorial-theme/src/index.ts
+++ b/packages/editorial-theme/src/index.ts
@@ -7,7 +7,7 @@ export {
   EDITORIAL_GOOGLE_FONTS_STYLESHEET_HREF,
 } from './lib/google-fonts.js';
 export {
-  splitBioParagraphs,
+  resolveLongBioParagraphs,
   resolveHeroBio,
   type ProfilePerson,
 } from './lib/profile-person.js';

--- a/packages/editorial-theme/src/index.ts
+++ b/packages/editorial-theme/src/index.ts
@@ -12,8 +12,6 @@ export {
   type ProfilePerson,
 } from './lib/profile-person.js';
 
-export { editorialTheme } from './integration.js';
-export type { EditorialThemeOptions } from './integration.js';
 export { DEFAULT_OVERRIDE_SURFACES, DEFAULT_ROUTE_REGISTRY } from './registry.js';
 
 /** Default relative path for consumer registry JSON — same default used by engine-core. */

--- a/packages/editorial-theme/src/integration-public.ts
+++ b/packages/editorial-theme/src/integration-public.ts
@@ -1,0 +1,6 @@
+/**
+ * Astro config entry only — imports Tailwind PostCSS and must not be bundled with theme runtime
+ * (`resolveHeroBio`, components, etc.). Use `import { editorialTheme } from '@portfolio-engine/editorial-theme/integration'`.
+ */
+export { editorialTheme } from './integration.js';
+export type { EditorialThemeOptions } from './integration.js';

--- a/packages/editorial-theme/src/integration.ts
+++ b/packages/editorial-theme/src/integration.ts
@@ -30,7 +30,7 @@ const TAILWIND_SSR_EXTERNAL = [
  * Returns an array of integrations: Tailwind CSS (PostCSS, via Vite `css.postcss`) + engine-core.
  * Astro accepts arrays in its integrations list and flattens them, so consumers
  * can use this exactly like a single integration:
- *   integrations: [editorialTheme({ ... })]
+ *   integrations: [editorialTheme({ ... })]  // import from `@portfolio-engine/editorial-theme/integration`
  *
  * Consumer-local routes: optional `src/registry/portfolio-engine.registry.json` +
  * `src/pages-local/*.astro` — see `docs/downstream/custom-page-via-registry.md`.
@@ -43,8 +43,8 @@ export function editorialTheme(options: EditorialThemeOptions): AstroIntegration
         updateConfig({
           vite: {
             /**
-             * PostCSS pipeline keeps Tailwind off Rollup's SSR JS graph. The Vite plugin pulls
-             * `@tailwindcss/oxide` `.node` binaries into the server bundle and breaks Astro builds.
+             * PostCSS runs outside Rollup. Import `editorialTheme` from `@portfolio-engine/editorial-theme/integration`
+             * only (not the package root) so Tailwind/Oxide never enter the SSR JS graph.
              */
             css: {
               postcss: {

--- a/packages/editorial-theme/src/lib/load-profile-person.ts
+++ b/packages/editorial-theme/src/lib/load-profile-person.ts
@@ -2,7 +2,7 @@ import { getEntry } from 'astro:content';
 import type { ProfilePerson } from './profile-person.js';
 
 export type { ProfilePerson } from './profile-person.js';
-export { splitBioParagraphs, resolveHeroBio } from './profile-person.js';
+export { resolveHeroBio, resolveLongBioParagraphs } from './profile-person.js';
 
 export async function loadProfilePerson(): Promise<ProfilePerson> {
   const personEntry = await getEntry('profile', 'person');

--- a/packages/editorial-theme/src/lib/profile-person.ts
+++ b/packages/editorial-theme/src/lib/profile-person.ts
@@ -1,13 +1,11 @@
 /** Mirrors `profile/person` in the consumer content schema (union collection narrows poorly in types). */
 export type ProfilePerson = {
   name: string;
-  /** @deprecated Prefer `shortBio` for hero, `longBio` for about/resume. If only `bio` is provided, it is split on blank lines into paragraphs. */
-  bio?: string;
-  /** Short one-liner shown in the hero and meta descriptions (preferred over `bio`). */
+  /** Short one-liner shown in the hero and meta descriptions. */
   shortBio?: string;
   /** One or two sentence summary used in cards, meta, and hero fallback. */
   summary?: string;
-  /** Full biography rendered as paragraphs on the about/profile page. */
+  /** Full biography rendered as paragraphs on the about/profile and resume pages. */
   longBio?: string[];
   /** Structured values shown as cards on the about page. */
   values?: Array<{ title: string; body: string }>;
@@ -21,26 +19,13 @@ export type ProfilePerson = {
   instagram?: string;
 };
 
-/**
- * Split a legacy single `bio` string into paragraphs by blank lines.
- * Returns an empty array when the input is empty/undefined.
- */
-export function splitBioParagraphs(bio: string | undefined): string[] {
-  if (!bio?.trim()) return [];
-  return bio
-    .split(/\n\s*\n/)
-    .map((p) => p.replace(/\n/g, ' ').trim())
-    .filter(Boolean);
+export function resolveLongBioParagraphs(person: ProfilePerson): string[] {
+  return person.longBio?.filter((p) => Boolean(p?.trim())).map((p) => p.trim()) ?? [];
 }
 
-/**
- * Returns the best short description for use in the hero / meta contexts.
- * Prefers `shortBio` > `summary` > first paragraph of `longBio` > first paragraph of `bio`.
- */
 export function resolveHeroBio(person: ProfilePerson): string {
   if (person.shortBio) return person.shortBio;
   if (person.summary) return person.summary;
-  if (person.longBio && person.longBio.length > 0) return person.longBio[0];
-  const paras = splitBioParagraphs(person.bio);
-  return paras[0] ?? '';
+  const paragraphs = resolveLongBioParagraphs(person);
+  return paragraphs[0] ?? '';
 }

--- a/packages/editorial-theme/src/lib/profile-person.ts
+++ b/packages/editorial-theme/src/lib/profile-person.ts
@@ -1,6 +1,11 @@
 /** Mirrors `profile/person` in the consumer content schema (union collection narrows poorly in types). */
 export type ProfilePerson = {
   name: string;
+  /**
+   * @deprecated Not read by the theme. Content must use `shortBio`, `summary`, and `longBio`
+   * (`ProfilePersonSchema` rejects this key). Remove `bio` from JSON and migrate copy into those fields.
+   */
+  bio?: string;
   /** Short one-liner shown in the hero and meta descriptions. */
   shortBio?: string;
   /** One or two sentence summary used in cards, meta, and hero fallback. */
@@ -19,10 +24,14 @@ export type ProfilePerson = {
   instagram?: string;
 };
 
+/** Normalized paragraphs from `longBio` only (blank entries dropped). */
 export function resolveLongBioParagraphs(person: ProfilePerson): string[] {
   return person.longBio?.filter((p) => Boolean(p?.trim())).map((p) => p.trim()) ?? [];
 }
 
+/**
+ * Short line for hero/meta: `shortBio`, then `summary`, then first `longBio` paragraph.
+ */
 export function resolveHeroBio(person: ProfilePerson): string {
   if (person.shortBio) return person.shortBio;
   if (person.summary) return person.summary;

--- a/packages/editorial-theme/src/pages/about.astro
+++ b/packages/editorial-theme/src/pages/about.astro
@@ -5,7 +5,7 @@ import SectionIntro from '../components/SectionIntro.astro';
 import ImageOrFallback from '../components/ImageOrFallback.astro';
 import { getEntry } from 'astro:content';
 import { getBase, resolveAssetUrl } from '../lib/utils';
-import { loadProfilePerson, splitBioParagraphs } from '../lib/load-profile-person';
+import { loadProfilePerson, resolveLongBioParagraphs } from '../lib/load-profile-person';
 
 const base = getBase();
 const person = await loadProfilePerson();
@@ -39,9 +39,9 @@ type CvProfileData = {
 
 const cv = (cvEntry?.data ?? {}) as CvProfileData;
 
-// Resolve bio paragraphs — prefer longBio array, fall back to splitting legacy bio string.
+// Resolve bio paragraphs — use longBio content when present.
 const bioParagraphs: string[] =
-  person.longBio && person.longBio.length > 0 ? person.longBio : splitBioParagraphs(person.bio);
+  resolveLongBioParagraphs(person);
 
 const metaDescriptionRaw =
   person.shortBio?.trim() ||

--- a/packages/editorial-theme/src/pages/index.astro
+++ b/packages/editorial-theme/src/pages/index.astro
@@ -11,7 +11,7 @@ import { getCollection } from 'astro:content';
 import type { ResolvedConfig } from '@portfolio-engine/engine-core';
 import { config } from '@portfolio-engine:config';
 import { getBase, resolveAssetUrl, sortByDateDesc } from '../lib/utils';
-import { loadProfilePerson } from '../lib/load-profile-person';
+import { loadProfilePerson, resolveHeroBio } from '../lib/load-profile-person';
 
 type Pillar = NonNullable<ResolvedConfig['features']['pillars']>[number];
 
@@ -42,7 +42,7 @@ const featuredTestimonials = config.features.testimonials
 
 <Layout
   title={`${person.name} — ${config.site.tagline}`}
-  description={person.bio}
+  description={resolveHeroBio(person)}
 >
   {
     bookingUrl && (

--- a/packages/editorial-theme/src/pages/resume.astro
+++ b/packages/editorial-theme/src/pages/resume.astro
@@ -3,7 +3,7 @@ import Layout from '../layouts/Layout.astro';
 import Reveal from '../components/Reveal.astro';
 import SectionIntro from '../components/SectionIntro.astro';
 import { getEntry } from 'astro:content';
-import { loadProfilePerson, splitBioParagraphs } from '../lib/load-profile-person';
+import { loadProfilePerson, resolveLongBioParagraphs } from '../lib/load-profile-person';
 
 const person = await loadProfilePerson();
 
@@ -47,13 +47,13 @@ type CvProfileData = {
 
 const cv = (cvEntry?.data ?? {}) as CvProfileData;
 
-/** Prefer longBio paragraphs, then a single summary paragraph, then legacy bio split. */
+/** Prefer longBio paragraphs, then a single summary paragraph. */
 const summaryParagraphs: string[] =
   person.longBio && person.longBio.length > 0
     ? person.longBio
     : person.summary?.trim()
       ? [person.summary.trim()]
-      : splitBioParagraphs(person.bio);
+      : resolveLongBioParagraphs(person);
 
 const metaDescriptionRaw =
   person.summary?.trim() ||

--- a/packages/editorial-theme/tsup.config.ts
+++ b/packages/editorial-theme/tsup.config.ts
@@ -12,7 +12,7 @@ function copyAssets() {
 }
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/integration-public.ts'],
   format: ['esm'],
   dts: true,
   clean: true,

--- a/packages/engine-core/README.md
+++ b/packages/engine-core/README.md
@@ -8,7 +8,7 @@ Consumers call `editorialTheme()` only. Engine-core is mounted internally by the
 
 ```js
 // astro.config.mjs — what the consumer writes
-import { editorialTheme } from '@portfolio-engine/editorial-theme';
+import { editorialTheme } from '@portfolio-engine/editorial-theme/integration';
 export default defineConfig({
   integrations: [
     editorialTheme({

--- a/packages/schema/CHANGELOG.md
+++ b/packages/schema/CHANGELOG.md
@@ -1,9 +1,5 @@
 # @portfolio-engine/schema
 
-## Unreleased
-
-- **Breaking:** `ProfilePersonSchema` no longer allows `bio`. Use `shortBio`, `summary`, and `longBio` instead. The schema is now `.strict()` so unknown keys (including `bio`) fail validation.
-
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/schema/CHANGELOG.md
+++ b/packages/schema/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @portfolio-engine/schema
 
+## Unreleased
+
+- **Breaking:** `ProfilePersonSchema` no longer allows `bio`. Use `shortBio`, `summary`, and `longBio` instead. The schema is now `.strict()` so unknown keys (including `bio`) fail validation.
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/schema/src/profile.ts
+++ b/packages/schema/src/profile.ts
@@ -10,26 +10,30 @@ const WorkingPrincipleSchema = z.object({
   body: z.string(),
 });
 
-export const ProfilePersonSchema = z.object({
-  name: z.string(),
-  roleLine: z.string().optional(),
-  /** Short one-liner for hero and meta. Preferred over `bio`. */
-  shortBio: z.string().optional(),
-  /** One or two sentence summary for cards, meta, and hero fallback. */
-  summary: z.string().optional(),
-  /** @deprecated Prefer `shortBio`/`summary`/`longBio`. Split on blank lines into paragraphs when used. */
-  bio: z.string().optional(),
-  /** Full biography paragraphs for about and resume pages. */
-  longBio: z.array(z.string()).optional(),
-  values: z.array(ValueCardSchema).optional(),
-  workingPrinciples: z.array(WorkingPrincipleSchema).optional(),
-  credentials: z.array(z.string()).optional(),
-  email: z.string().optional(),
-  linkedin: z.url().optional(),
-  github: z.url().optional(),
-  instagram: z.url().optional(),
-  photo: z.string().optional(),
-});
+/**
+ * Canonical `profile/person` shape. Biography copy uses only `shortBio`, `summary`, and `longBio`.
+ * The old `bio` string is not accepted here — use `longBio` (paragraph array) instead.
+ */
+export const ProfilePersonSchema = z
+  .object({
+    name: z.string(),
+    roleLine: z.string().optional(),
+    /** Short one-liner for hero and meta. */
+    shortBio: z.string().optional(),
+    /** One or two sentence summary for cards, meta, and hero fallback. */
+    summary: z.string().optional(),
+    /** Full biography paragraphs for about and resume pages. */
+    longBio: z.array(z.string()).optional(),
+    values: z.array(ValueCardSchema).optional(),
+    workingPrinciples: z.array(WorkingPrincipleSchema).optional(),
+    credentials: z.array(z.string()).optional(),
+    email: z.string().optional(),
+    linkedin: z.url().optional(),
+    github: z.url().optional(),
+    instagram: z.url().optional(),
+    photo: z.string().optional(),
+  })
+  .strict();
 
 export const ProfileExperienceSchema = z.object({
   organization: z.string(),


### PR DESCRIPTION
### Motivation

- Unify disparate profile bio fields and remove legacy string-splitting behavior to make editorial data handling consistent.  
- Remove a broken root npm script reference that pointed to a nonexistent path.  
- Improve contributor discoverability by adding conventional root-level `typecheck` and `test` scripts and document the audit findings.

### Description

- Add a repository audit document at `docs/repo-audit-2026-05-06.md` summarizing checks and fixes.  
- Remove the invalid `build:audit-report-shells` script from `package.json` and add root scripts `typecheck: "pnpm -r run check"` and `test: "pnpm -r --if-present run test"`.  
- Replace the legacy `bio`-splitting helper with `resolveLongBioParagraphs` and update exports/imports in `packages/editorial-theme/src/*`.  
- Update the `ProfilePerson` type to prefer `shortBio`, `summary`, and `longBio[]` (removing the deprecated `bio` fallback) and adapt `resolveHeroBio` and page components (`about.astro`, `index.astro`, `resume.astro`) to use the new model.

### Testing

- Ran `pnpm lint` across the workspace and the linter succeeded.  
- Ran the workspace build/check flow via `pnpm check` and the checks succeeded in the current environment.  
- Note that automated checks ran in an environment using Node 22 while the repo `engines` require Node `>=24 <25`, so CI may behave differently depending on the runner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faaad240f48320894934bd37c8e020)