### PR TITLE
chore(ci): non-interactive check + agent PR policy

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,6 +9,12 @@ This monorepo ships **`@portfolio-engine/*`** packages and a reference app under
 - **Automatic Copilot code review** is enabled via **repository rulesets** for PRs into **`dev`** and **`epic/**`\*\* (GitHub Settings → Rules → Rulesets). That behavior is not defined in workflow YAML.
 - After a review, **apply** inline suggestions or comment **`@copilot`** on the PR if you want the coding agent to push commits. There is no supported fully hands-off “review then auto-commit everything” mode.
 
+## Agent PR workflow
+
+- Do not merge directly from an agent session.
+- Open PRs against **`dev`** unless a human explicitly requests a different base branch.
+- After opening a PR, request review from **`copilot-pull-request-reviewer`** (or trigger `@copilot review`) before merge.
+
 ## Quality bar
 
 - Run **`pnpm lint`**, **`pnpm check`**, and **`pnpm --filter demo-site run build`** (or full **`pnpm build`**) before considering work done.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,8 @@ jobs:
           fi
 
       - name: Typecheck + astro check (pnpm check)
+        env:
+          CI: true
         run: pnpm check
 
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Typecheck + astro check (pnpm check)
         env:
-          CI: true
+          CI: "true"
         run: pnpm check
 
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Typecheck + astro check (pnpm check)
         env:
-          CI: "true"
+          CI: 'true'
         run: pnpm check
 
   build:


### PR DESCRIPTION
## Summary
- Set `CI=true` for the `pnpm check` step in CI so Astro checks run in non-interactive mode.
- Add explicit repo instruction that agent changes go through PRs to `dev` and request Copilot review before merge.

## Verification
- `pnpm check --filter ./packages/*`