### PR TITLE
docs: changelog agent migration notes + downstream agent upgrade instructions

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -1,0 +1,40 @@
+# Changesets (portfolio-engine)
+
+This directory holds **pending** release notes. When `dev` is merged into `main`, CI runs `changeset version`, which **consumes** these files, bumps package versions, and merges the prose into each package’s `CHANGELOG.md`.
+
+## Authoring
+
+1. After your change lands on **`dev`**, run `pnpm changeset` (or `pnpm exec changeset add`) and follow the prompts.
+2. Pick the correct semver bump for each affected `@portfolio-engine/*` package.
+3. In the **summary body**, write a short human-facing description, then add consumer-facing migration text when needed (see below).
+
+**Promotion flow:** feature branches → `dev` → `main`. Releases apply on **`main`** only. See [`docs/workflows/release-workflow.md`](../docs/workflows/release-workflow.md).
+
+## Agent migration block (required when consumers are affected)
+
+If your change touches **content shape**, **config keys**, **public imports**, **CSS variables**, **registry/manifest contracts**, or anything else a consumer repo must update, add a `#### Agent migration` section to the changeset body with a **checklist** (packages, consumer paths, imperative actions). Omit this section only when there is **no** consumer migration surface (internal refactors, tests, CI-only changes).
+
+Full rules, multi-version reading order for agents, and a worked example: **[`docs/workflows/changelog-agent-migration.md`](../docs/workflows/changelog-agent-migration.md)**.
+
+## Minimal template
+
+Copy and edit (frontmatter package names and bump types must match your change):
+
+```markdown
+---
+'@portfolio-engine/schema': patch
+'@portfolio-engine/editorial-theme': patch
+---
+
+Short summary of what changed and why (human readers).
+
+#### Agent migration
+
+- **Packages:** …
+- **Consumer paths:** … (e.g. `src/content/...`, `src/config/...`)
+- **Actions:**
+  - …
+- **Supersedes:** … (optional; if this release overrides earlier migration advice)
+```
+
+Only `README.md` in this folder is ignored by the Release workflow’s “pending changesets” scan; all other `*.md` files here are treated as pending changesets.

--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -4,7 +4,7 @@ This directory holds **pending** release notes. When `dev` is merged into `main`
 
 ## Authoring
 
-1. After your change lands on **`dev`**, run `pnpm changeset` (or `pnpm exec changeset add`) and follow the prompts.
+1. Run `pnpm changeset` (or `pnpm exec changeset add`) **in the same PR as your code change** (preferred) so the changeset merges to **`dev`** with the feature. If you truly cannot, land a follow-up on **`dev`** before **`dev` → `main`** promotion—releases need pending `.changeset/*.md` on the `dev` tip you promote (see ship checklist in [`docs/workflows/release-workflow.md`](../docs/workflows/release-workflow.md)).
 2. Pick the correct semver bump for each affected `@portfolio-engine/*` package.
 3. In the **summary body**, write a short human-facing description, then add consumer-facing migration text when needed (see below).
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -65,7 +65,7 @@ A downstream-originated feature should explain:
 
 ## Releases
 
-The maintainer controls releases. Release candidates should document package versions, migration notes, breaking changes, downstream impact, and changeset entries where applicable.
+The maintainer controls releases. Release candidates should document package versions, migration notes, breaking changes, downstream impact, and changeset entries where applicable. Published changelogs should include **agent-oriented migration notes** (`#### Agent migration` in changeset bodies) when consumers must update content, config, or imports; see [`docs/workflows/changelog-agent-migration.md`](docs/workflows/changelog-agent-migration.md).
 
 ## Security
 

--- a/docs/downstream/agent-tooling.md
+++ b/docs/downstream/agent-tooling.md
@@ -13,6 +13,10 @@ Use the smallest tool that answers the question:
 | Lighthouse CI                   | Optional performance, accessibility, SEO, and best-practice regression checks                                       | Replacing manual design review                             |
 | Vale                            | Optional prose and tone linting                                                                                     | Deciding factual content                                   |
 
+## Upstream contract changes
+
+When `@portfolio-engine/*` versions change, do **not** guess new content fields, config keys, or import paths from memory. Read each package’s **`CHANGELOG.md`** for the version range you are crossing (see **[`upgrade-path.md`](upgrade-path.md)** — especially the **AI / coding agents** subsection), apply **`#### Agent migration`** notes, then confirm with **`pnpm check`** and **`pnpm build`**.
+
 ## Recommended install: Claude Code
 
 Run from the consumer-site repo root.

--- a/docs/downstream/consumption.md
+++ b/docs/downstream/consumption.md
@@ -80,7 +80,7 @@ export default defineConfig({
 });
 ```
 
-**Upgrade:** bump the version in `package.json` and run `pnpm install`. Pin to a specific minor to control when you pick up changes.
+**Upgrade:** bump the version in `package.json` and run `pnpm install`. Pin to a specific minor to control when you pick up changes. For changelogs, breaking changes, and **AI/agent** upgrade steps, see **[`upgrade-path.md`](upgrade-path.md)**.
 
 ## Vercel (standalone consumer repo)
 

--- a/docs/downstream/templates/agent/CLAUDE.md
+++ b/docs/downstream/templates/agent/CLAUDE.md
@@ -22,6 +22,16 @@ Do not modify upstream package code from this repo unless explicitly asked.
 
 Prefer consumer-site configuration, content, context, or override changes first.
 
+## Package upgrades (`@portfolio-engine/*`)
+
+When `package.json` or the lockfile changes versions for **`@portfolio-engine/*`**, or when the user asks to upgrade engine packages:
+
+1. Follow **`docs/downstream/upgrade-path.md`** in this repo (if missing, use the same path in the upstream [portfolio-engine](https://github.com/rainonej/portfolio-engine) repo).
+2. For each touched package, read **`CHANGELOG.md`** for the full semver window (previous version → new version), **oldest to newest**. Prefer **`#### Agent migration`** sections for actionable steps; merge them into one checklist. If two releases disagree, **follow the newer release**.
+3. Changelogs are available under `node_modules/@portfolio-engine/<pkg>/CHANGELOG.md` after install, or on GitHub under `packages/<pkg>/CHANGELOG.md`.
+
+Then run `pnpm install` (if needed), `pnpm check`, and `pnpm build`.
+
 ## Required reading before content/design work
 
 Before writing copy or changing design direction, read:

--- a/docs/downstream/templates/agent/CLAUDE.md
+++ b/docs/downstream/templates/agent/CLAUDE.md
@@ -28,7 +28,7 @@ When `package.json` or the lockfile changes versions for **`@portfolio-engine/*`
 
 1. Follow **`docs/downstream/upgrade-path.md`** in this repo (if missing, use the same path in the upstream [portfolio-engine](https://github.com/rainonej/portfolio-engine) repo).
 2. For each touched package, read **`CHANGELOG.md`** for the full semver window (previous version → new version), **oldest to newest**. Prefer **`#### Agent migration`** sections for actionable steps; merge them into one checklist. If two releases disagree, **follow the newer release**.
-3. Changelogs are available under `node_modules/@portfolio-engine/<pkg>/CHANGELOG.md` after install, or on GitHub under `packages/<pkg>/CHANGELOG.md`.
+3. Read changelogs from `node_modules/@portfolio-engine/<pkg>/CHANGELOG.md` when present; otherwise use GitHub `rainonej/portfolio-engine` → `packages/<pkg>/CHANGELOG.md`.
 
 Then run `pnpm install` (if needed), `pnpm check`, and `pnpm build`.
 

--- a/docs/downstream/templates/agent/copilot-instructions.md
+++ b/docs/downstream/templates/agent/copilot-instructions.md
@@ -22,7 +22,7 @@ When **`@portfolio-engine/*`** versions change in `package.json` / the lockfile,
 
 1. Read **`docs/downstream/upgrade-path.md`** (or the upstream [portfolio-engine](https://github.com/rainonej/portfolio-engine) copy).
 2. For each engine package, read its **`CHANGELOG.md`** from the previous version through the new one, **in semver order**. Use **`#### Agent migration`** blocks as the primary task list; merge across versions into one plan. If instructions conflict, **the newer release wins**.
-3. Sources: `node_modules/@portfolio-engine/<pkg>/CHANGELOG.md` after install, or GitHub `packages/<pkg>/CHANGELOG.md`.
+3. Sources: `node_modules/@portfolio-engine/<pkg>/CHANGELOG.md` when shipped; otherwise GitHub `rainonej/portfolio-engine` at `packages/<pkg>/CHANGELOG.md`.
 
 Then run `pnpm check` and `pnpm build`.
 

--- a/docs/downstream/templates/agent/copilot-instructions.md
+++ b/docs/downstream/templates/agent/copilot-instructions.md
@@ -16,6 +16,16 @@ Prefer changes in:
 
 Do not patch upstream package behavior in this consumer repo unless explicitly asked.
 
+## Package upgrades (`@portfolio-engine/*`)
+
+When **`@portfolio-engine/*`** versions change in `package.json` / the lockfile, or when upgrading those dependencies:
+
+1. Read **`docs/downstream/upgrade-path.md`** (or the upstream [portfolio-engine](https://github.com/rainonej/portfolio-engine) copy).
+2. For each engine package, read its **`CHANGELOG.md`** from the previous version through the new one, **in semver order**. Use **`#### Agent migration`** blocks as the primary task list; merge across versions into one plan. If instructions conflict, **the newer release wins**.
+3. Sources: `node_modules/@portfolio-engine/<pkg>/CHANGELOG.md` after install, or GitHub `packages/<pkg>/CHANGELOG.md`.
+
+Then run `pnpm check` and `pnpm build`.
+
 ## Quality bar
 
 Before considering work complete, run:

--- a/docs/downstream/upgrade-path.md
+++ b/docs/downstream/upgrade-path.md
@@ -57,7 +57,7 @@ Or use the VS Code / script flows in [One-click upgrade](#one-click-upgrade-vs-c
 
 When `@portfolio-engine/*` versions change (or the user asks to upgrade engine packages), agents should **not** infer new APIs from memory.
 
-1. For **each** `@portfolio-engine/*` package in the consumer `package.json`, read that package’s **`CHANGELOG.md`** for every release **after** the version the site previously used **through** the version being installed, in **ascending semver order** (oldest first). After `pnpm install`, use `node_modules/@portfolio-engine/<pkg>/CHANGELOG.md`, or read the same file on GitHub from [`rainonej/portfolio-engine`](https://github.com/rainonej/portfolio-engine) (paths under `packages/<pkg>/CHANGELOG.md`).
+1. For **each** `@portfolio-engine/*` package in the consumer `package.json`, read that package’s **`CHANGELOG.md`** for every release **after** the version the site previously used **through** the version being installed, in **ascending semver order** (oldest first). After `pnpm install`, you can read `node_modules/@portfolio-engine/<pkg>/CHANGELOG.md` if the package ships it; **if that file is missing**, use the canonical copy on GitHub: [`rainonej/portfolio-engine`](https://github.com/rainonej/portfolio-engine) at `packages/<pkg>/CHANGELOG.md` (replace `<pkg>` with `schema`, `engine-core`, `editorial-theme`, or `admin-tools`).
 2. Merge all **`#### Agent migration`** sections from that version window into **one** checklist before editing consumer files. If instructions conflict between releases, **follow the newer release**. Prefer explicit “Supersedes” lines in the changelog when present.
 3. Apply migration steps, then run `pnpm check` and `pnpm build`.
 

--- a/docs/downstream/upgrade-path.md
+++ b/docs/downstream/upgrade-path.md
@@ -53,6 +53,18 @@ Or use the VS Code / script flows in [One-click upgrade](#one-click-upgrade-vs-c
 4. Run `pnpm check` and `pnpm build` to catch type errors early.
 5. Test the site locally.
 
+### AI / coding agents
+
+When `@portfolio-engine/*` versions change (or the user asks to upgrade engine packages), agents should **not** infer new APIs from memory.
+
+1. For **each** `@portfolio-engine/*` package in the consumer `package.json`, read that package’s **`CHANGELOG.md`** for every release **after** the version the site previously used **through** the version being installed, in **ascending semver order** (oldest first). After `pnpm install`, use `node_modules/@portfolio-engine/<pkg>/CHANGELOG.md`, or read the same file on GitHub from [`rainonej/portfolio-engine`](https://github.com/rainonej/portfolio-engine) (paths under `packages/<pkg>/CHANGELOG.md`).
+2. Merge all **`#### Agent migration`** sections from that version window into **one** checklist before editing consumer files. If instructions conflict between releases, **follow the newer release**. Prefer explicit “Supersedes” lines in the changelog when present.
+3. Apply migration steps, then run `pnpm check` and `pnpm build`.
+
+Maintainers document the shape of **Agent migration** notes in the upstream repo: [`docs/workflows/changelog-agent-migration.md`](../workflows/changelog-agent-migration.md). Consumer repos that only vendor `docs/downstream/` can open that link on GitHub.
+
+**Template refresh:** If this site was set up before upstream added the **Package upgrades** instructions to [`templates/agent/`](templates/agent/) (`CLAUDE.md`, `copilot-instructions.md`), merge that new section from the upstream portfolio-engine repo into your root `CLAUDE.md` and `.github/copilot-instructions.md` if you rely on agents for bumps. The setup seed scripts (`07-seed-agent-tooling.*`) only create those files when they are missing.
+
 ## Patch tracking
 
 When `agreni-site` needs a fix that isn't yet in a portfolio-engine release:

--- a/docs/workflows/changelog-agent-migration.md
+++ b/docs/workflows/changelog-agent-migration.md
@@ -1,0 +1,72 @@
+# Changelog: Agent migration notes
+
+Consumer repos and coding agents need **task-shaped** instructions when `@portfolio-engine/*` releases change content shape, config keys, imports, CSS variables, or integration entrypoints. This document defines how maintainers add those notes so they flow from **Changesets** into each package **`CHANGELOG.md`**.
+
+## When to write Agent migration notes
+
+Add an **Agent migration** block whenever a changeset can affect **consumer** repos:
+
+- Content collection fields, Zod schemas mirrored in `src/content/`, or frontmatter keys
+- `src/config/*.json` keys or `theme.json` / `site.json` shape
+- Public import paths (e.g. integration moved out of package root)
+- CSS variables, design tokens, or override surfaces agents might edit
+- Registry or manifest contracts
+
+**Skip** the block for internal-only changes (refactors, tests, CI) with **no** consumer-visible contract change.
+
+## Where it appears
+
+Write the block in the **body** of the same `.changeset/<name>.md` file as the summary. After `pnpm exec changeset version`, that text is merged into the relevant package(s) `CHANGELOG.md` under the new version.
+
+### Format (required for consistency)
+
+1. A short **human-facing** summary (what shipped and why).
+2. A markdown heading **`#### Agent migration`** (level 4) so authors and agents can grep for it.
+3. Under that heading, use **bullet checklists**, not prose paragraphs:
+   - **Packages:** list affected `@portfolio-engine/*` packages.
+   - **Consumer paths:** glob-style or concrete paths in a typical consumer repo (e.g. `src/content/profile/**/*.md`, `src/config/theme.json`), not only paths inside `packages/`.
+   - **Actions:** imperative steps (remove field `bio`; add `shortBio`, `summary`, `longBio`; map old text to new fields with a one-line rule).
+   - **Supersedes (optional):** if this release overrides earlier migration advice, add one line: `Supersedes: <short description of obsolete guidance>` so multi-version readers keep the latest intent only.
+
+Do not rely on vague bullets like “update profile schema” without paths and field names.
+
+## Multi-version upgrades (humans and agents)
+
+When jumping several versions (e.g. `0.4.x` → `0.5.y`):
+
+1. For **each** `@portfolio-engine/*` dependency you bump, open that package’s `CHANGELOG.md` (from `node_modules/@portfolio-engine/<pkg>/CHANGELOG.md` after install, or from the [upstream repo](https://github.com/rainonej/portfolio-engine)).
+2. Collect every **version section** with a semver **strictly greater** than the version you had **through** the version you installed, in **ascending semver order** (oldest release notes first).
+3. Build **one** merged checklist from all **Agent migration** blocks in that window.
+4. If two blocks conflict, **the newer release wins**—drop or amend steps that older blocks implied. Use explicit **Supersedes** lines when you know a later release reverses earlier guidance.
+
+This avoids “do X in vN, undo X in vN+1” double work when the agent merges instructions before editing files.
+
+## Worked example (schema 0.5.0–style)
+
+The following is **illustrative** text in the preferred shape (profile field split and integration import). Adapt to each real changeset.
+
+```markdown
+Refine profile copy fields and strict validation for person content.
+
+#### Agent migration
+
+- **Packages:** `@portfolio-engine/schema`, `@portfolio-engine/editorial-theme` (and `@portfolio-engine/admin-tools` if the site uses admin UI for the same model).
+- **Consumer paths:** `src/content/profile/**/*.{md,mdx}` (or your collection path for person/profile entries); any local Zod or TypeScript mirroring `ProfilePerson`.
+- **Actions:**
+  - Remove frontmatter/content field **`bio`** wherever present.
+  - Add **`shortBio`** (short lead), **`summary`** (one-line or card summary), and **`longBio`** (longer body). Split the old `bio` text across these three using judgment: put the essence in `shortBio`/`summary`, detail in `longBio`.
+  - Ensure content validates against the published `ProfilePerson` schema (run `pnpm check` / `pnpm build`).
+- **Imports:** In `astro.config.*`, import the Astro integration from `@portfolio-engine/editorial-theme/integration` (not the package root). Do not import `editorialTheme` from `@portfolio-engine/editorial-theme` root in SSR bundles.
+- **CSS (if custom styles):** Legacy variables `--ink`, `--paper`, `--copper`, etc. are removed in the same release family; use semantic `--color-*` tokens per the editorial-theme changelog for that version.
+```
+
+## Downstream visibility
+
+Consumer maintainers and agents should follow **[`docs/downstream/upgrade-path.md`](../downstream/upgrade-path.md)** (AI / coding agents subsection). That doc links here so agents know **what** these blocks mean.
+
+Sites that were seeded with older agent templates may need to **merge** the **Package upgrades** section from upstream [`docs/downstream/templates/agent/`](../downstream/templates/agent/) into root `CLAUDE.md` and `.github/copilot-instructions.md` if they rely on agents for bumps; the seed scripts only create those files when missing.
+
+## Future work (optional)
+
+- **Custom Changesets changelog package** — normalize or inject headings if authors routinely miss `#### Agent migration`.
+- **Machine-readable migration manifests** (YAML/JSON per version) plus a small CLI to squash operations deterministically — only if prose-first workflows prove insufficient.

--- a/docs/workflows/changelog-agent-migration.md
+++ b/docs/workflows/changelog-agent-migration.md
@@ -28,6 +28,8 @@ Write the block in the **body** of the same `.changeset/<name>.md` file as the s
    - **Actions:** imperative steps (remove field `bio`; add `shortBio`, `summary`, `longBio`; map old text to new fields with a one-line rule).
    - **Supersedes (optional):** if this release overrides earlier migration advice, add one line: `Supersedes: <short description of obsolete guidance>` so multi-version readers keep the latest intent only.
 
+You may add **extra** bold-labeled bullets when they help agents scan (e.g. **Imports:**, **CSS:**, **Config:**). Prefer folding generic file edits into **Actions**; use separate labels when the topic is a distinct domain (import paths vs. content fields).
+
 Do not rely on vague bullets like “update profile schema” without paths and field names.
 
 ## Multi-version upgrades (humans and agents)

--- a/docs/workflows/release-workflow.md
+++ b/docs/workflows/release-workflow.md
@@ -2,6 +2,10 @@
 
 portfolio-engine uses [Changesets](https://github.com/changesets/changesets) for versioning and npm publishing. Promotion stays **feature branches → `dev` → `main`** (squash merge is fine). Maintainers ship by merging **`dev` into `main`**; CI applies versions and publishes—there is no manual “Version packages” PR step.
 
+## Maintainer: consumer-facing changelog notes
+
+Any changeset that can affect consumer repos should include a `#### Agent migration` block in the changeset body (task-shaped checklist: packages, consumer paths, actions). That text is merged into package `CHANGELOG.md` files when versions are applied. See **[changelog-agent-migration.md](./changelog-agent-migration.md)** for the full convention, multi-version reading order, and a worked example.
+
 ## Ship checklist
 
 1. Confirm `.changeset/*.md` files are on **`dev`** before promotion (see **Squash merges and changesets** below).


### PR DESCRIPTION
## Summary
Documents a maintainer convention for \#### Agent migration\ blocks in Changesets (merged into package CHANGELOGs) and instructs consumer-repo agents to read changelogs across the semver window when upgrading \@portfolio-engine/*\.

## Changes
- New [\docs/workflows/changelog-agent-migration.md\](docs/workflows/changelog-agent-migration.md): when to write notes, format, multi-version merge rules, worked example, future work.
- [\docs/workflows/release-workflow.md\](docs/workflows/release-workflow.md): link for maintainers.
- [\GOVERNANCE.md\](GOVERNANCE.md): Releases bullet references agent-oriented changelog notes.
- New [\.changeset/README.md\](.changeset/README.md): author onboarding + minimal template.
- [\docs/downstream/upgrade-path.md\](docs/downstream/upgrade-path.md): **AI / coding agents** subsection + template refresh note.
- [\docs/downstream/consumption.md\](docs/downstream/consumption.md): points upgrades to upgrade-path.
- [\docs/downstream/templates/agent/CLAUDE.md\](docs/downstream/templates/agent/CLAUDE.md) and [\copilot-instructions.md\](docs/downstream/templates/agent/copilot-instructions.md): **Package upgrades** section.
- [\docs/downstream/agent-tooling.md\](docs/downstream/agent-tooling.md): **Upstream contract changes** paragraph.

## Testing
- \pnpm run check:docs-hygiene\
- Prettier on touched markdown files

Made with [Cursor](https://cursor.com)