### PR TITLE
fix(release): publish from latest main and enforce npm alignment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,6 +148,18 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
 
+      - name: Sync checkout to latest origin/main tip
+        run: |
+          set -euo pipefail
+          git fetch origin main --tags
+          checkout_head="$(git rev-parse HEAD)"
+          main_head="$(git rev-parse origin/main)"
+          if [ "$checkout_head" != "$main_head" ]; then
+            echo "::notice::Publish job checkout head ($checkout_head) is behind origin/main ($main_head); resetting to origin/main."
+            git reset --hard "$main_head"
+          fi
+          echo "Publishing from $(git rev-parse HEAD)."
+
       - uses: pnpm/action-setup@v4
         with:
           version: 10
@@ -188,6 +200,30 @@ jobs:
         run: pnpm release
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Verify npm registry matches main package versions
+        run: |
+          set -euo pipefail
+          mismatches=()
+          for pkg in schema engine-core editorial-theme admin-tools; do
+            local_ver="$(node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('packages/${pkg}/package.json','utf8'));process.stdout.write(p.version)")"
+            if ! remote_ver="$(npm view "@portfolio-engine/${pkg}" version 2>/dev/null)"; then
+              mismatches+=("@portfolio-engine/${pkg}: main=${local_ver}, npm=<lookup failed>")
+              continue
+            fi
+            if [ "$local_ver" != "$remote_ver" ]; then
+              mismatches+=("@portfolio-engine/${pkg}: main=${local_ver}, npm=${remote_ver}")
+            fi
+          done
+          if [ "${#mismatches[@]}" -gt 0 ]; then
+            echo "::error::Release verification failed: npm is not aligned with versions on main."
+            echo "::error::Mismatched packages:"
+            printf '::error:: - %s\n' "${mismatches[@]}"
+            echo "::error::This usually means publish ran from the wrong commit or npm rejected publish for one or more packages."
+            echo "::error::Re-run Release after checking the Publish to npm job logs and branch tip."
+            exit 1
+          fi
+          echo "npm registry versions match package versions on main."
 
       # When every package is already on npm, `changeset publish` no-ops and does not create tags.
       # Still run `changeset tag` so Git Graph / tooling match registry versions.

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,7 +3,7 @@
   "tasks": [
     {
       "label": "Promote dev → main",
-      "detail": "dev→main PR, CI, merge, then workflow_dispatch Release so npm publish runs (gh CLI + auth)",
+      "detail": "dev→main PR, CI, merge, workflow_dispatch Release, then verifies npm versions match origin/main (fails with diagnostics on mismatch)",
       "type": "shell",
       "options": {
         "cwd": "${workspaceFolder}",

--- a/scripts/promote-dev-to-main.ps1
+++ b/scripts/promote-dev-to-main.ps1
@@ -9,6 +9,55 @@ function Ensure-Gh {
 
 Ensure-Gh
 
+function Verify-MainPublishedVersions {
+  param(
+    [string]$RunUrl
+  )
+
+  Write-Host ''
+  Write-Host 'Verifying npm registry matches origin/main package versions...'
+  git fetch origin main --tags | Out-Null
+
+  $packages = @(
+    @{ Name = '@portfolio-engine/schema'; Path = 'packages/schema/package.json' },
+    @{ Name = '@portfolio-engine/engine-core'; Path = 'packages/engine-core/package.json' },
+    @{ Name = '@portfolio-engine/editorial-theme'; Path = 'packages/editorial-theme/package.json' },
+    @{ Name = '@portfolio-engine/admin-tools'; Path = 'packages/admin-tools/package.json' }
+  )
+
+  $mismatches = @()
+  foreach ($pkg in $packages) {
+    $mainVersion = (git show "origin/main:$($pkg.Path)").Trim() | ConvertFrom-Json | Select-Object -ExpandProperty version
+    $npmVersion = ''
+    try {
+      $npmVersion = (npm view $pkg.Name version 2>$null).Trim()
+    } catch {
+      $npmVersion = '<lookup failed>'
+    }
+    if ([string]::IsNullOrWhiteSpace($npmVersion)) { $npmVersion = '<lookup failed>' }
+    if ($mainVersion -ne $npmVersion) {
+      $mismatches += "$($pkg.Name): main=$mainVersion, npm=$npmVersion"
+    }
+  }
+
+  if ($mismatches.Count -gt 0) {
+    Write-Host ''
+    Write-Error @"
+Release finished but npm does not match origin/main versions.
+Mismatched packages:
+ - $($mismatches -join "`n - ")
+
+Release run: $RunUrl
+
+This indicates publish did not apply the latest version commit (or npm publish failed/no-op unexpectedly).
+Inspect the Release run logs (Publish to npm job) before retrying.
+"@
+    exit 1
+  }
+
+  Write-Host 'Registry verification passed: npm versions match origin/main.'
+}
+
 # gh -q filter: build in a variable so PowerShell does not parse ".[0]" as member access.
 $prNumberQuery = '.[0].number'
 
@@ -74,10 +123,12 @@ for ($k = 0; $k -lt 120; $k++) {
 }
 
 if ($null -eq $runId) {
-  Write-Warning 'Could not resolve the workflow_dispatch Release run. Check Actions -> Release on main.'
-  exit 0
+  Write-Error 'Could not resolve the workflow_dispatch Release run. Check Actions -> Release on main and verify workflow_dispatch was accepted.'
+  exit 1
 }
 
 gh run watch $runId --exit-status
 Write-Host "Release run $runId completed."
 Write-Host 'Tip: git fetch origin main --tags  (then refresh Git Graph)'
+$runUrl = "https://github.com/$((gh repo view --json nameWithOwner -q .nameWithOwner).Trim())/actions/runs/$runId"
+Verify-MainPublishedVersions -RunUrl $runUrl

--- a/scripts/promote-dev-to-main.sh
+++ b/scripts/promote-dev-to-main.sh
@@ -6,6 +6,49 @@ if ! command -v gh >/dev/null 2>&1; then
   exit 1
 fi
 
+verify_main_published_versions() {
+  local run_url="$1"
+  local mismatches=()
+  local main_ver npm_ver pkg name
+
+  echo ''
+  echo 'Verifying npm registry matches origin/main package versions...'
+  git fetch origin main --tags >/dev/null
+
+  for pkg in schema engine-core editorial-theme admin-tools; do
+    name="@portfolio-engine/${pkg}"
+    main_ver="$(
+      git show "origin/main:packages/${pkg}/package.json" |
+        node -e 'const fs=require("fs");const s=fs.readFileSync(0,"utf8");process.stdout.write(JSON.parse(s).version)'
+    )"
+    if ! npm_ver="$(npm view "${name}" version 2>/dev/null)"; then
+      npm_ver="<lookup failed>"
+    fi
+    [[ -n "$npm_ver" ]] || npm_ver="<lookup failed>"
+    if [[ "$main_ver" != "$npm_ver" ]]; then
+      mismatches+=("${name}: main=${main_ver}, npm=${npm_ver}")
+    fi
+  done
+
+  if ((${#mismatches[@]} > 0)); then
+    {
+      echo 'Release finished but npm does not match origin/main versions.'
+      echo 'Mismatched packages:'
+      for row in "${mismatches[@]}"; do
+        echo " - ${row}"
+      done
+      echo ''
+      echo "Release run: ${run_url}"
+      echo ''
+      echo 'This indicates publish did not apply the latest version commit (or npm publish failed/no-op unexpectedly).'
+      echo 'Inspect the Release run logs (Publish to npm job) before retrying.'
+    } >&2
+    exit 1
+  fi
+
+  echo 'Registry verification passed: npm versions match origin/main.'
+}
+
 git fetch origin dev main
 
 dev="$(git rev-parse origin/dev)"
@@ -63,10 +106,12 @@ for _ in $(seq 1 120); do
 done
 
 if [[ -z "$run_id" ]]; then
-  echo 'Warning: could not resolve the workflow_dispatch Release run. Check Actions → Release on main.' >&2
-  exit 0
+  echo 'Could not resolve the workflow_dispatch Release run. Check Actions → Release on main and verify workflow_dispatch was accepted.' >&2
+  exit 1
 fi
 
 gh run watch "$run_id" --exit-status
 echo "Release run ${run_id} completed."
 echo 'Tip: git fetch origin main --tags  (then refresh Git Graph)'
+repo="$(gh repo view --json nameWithOwner -q .nameWithOwner | tr -d '[:space:]')"
+verify_main_published_versions "https://github.com/${repo}/actions/runs/${run_id}"


### PR DESCRIPTION
## Summary
Hardens release automation so publish always runs from the latest main tip and fails with actionable diagnostics when npm and main versions diverge.

## Changes
- In .github/workflows/release.yml publish job:
  - fetch/reset to latest origin/main before install/build/publish
  - add post-publish verification: compare packages/*/package.json versions vs 
pm view for schema/engine-core/editorial-theme/admin-tools
  - fail with detailed mismatch list when drift remains
- In scripts/promote-dev-to-main.ps1 and .sh:
  - fail if workflow_dispatch run cannot be resolved
  - after Release run completes, verify npm vs origin/main package versions and fail with detailed diagnostics + run URL on mismatch
- Update .vscode/tasks.json task detail to reflect version verification behavior.

## Why this prevents recurrence
The previous failure mode occurred when publish executed from a stale checkout SHA instead of the version-bump commit. The workflow now forcibly syncs to latest origin/main before pnpm release, then verifies npm registry state against main as a hard gate.

## Validation
- ash -n scripts/promote-dev-to-main.sh
- release logic validated by codepath inspection against the observed stale-checkout incident logs

Made with [Cursor](https://cursor.com)