### PR TITLE
fix(demo-site): post-merge follow-ups from #130 Copilot review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,11 @@ web_modules/
 .next
 out
 
+# Vercel
+# Build Output API tree lifted into repo-root by scripts/lift-vercel-output.mjs,
+# and the Vercel CLI's local project metadata. Never commit either.
+.vercel/
+
 # Nuxt.js build / generate output
 .nuxt
 dist

--- a/examples/demo-site/src/content/projects/iframe-embeds.md
+++ b/examples/demo-site/src/content/projects/iframe-embeds.md
@@ -46,6 +46,6 @@ const demoSrc =
 
 A note on `sandbox`: the iframe sandbox is _restrictive by default_. `allow-scripts` enables JS inside the embedded document (needed for the interactive diagram). Leave `allow-same-origin` _off_ for same-origin demos — adding it back alongside `allow-scripts` effectively defeats the sandbox, since the embedded page can then reach into the parent's storage and DOM. For a fully passive embed (e.g. a static SVG diagram with no JS), you can omit `sandbox` entirely.
 
-For Markdown posts that can't import a helper, write the path relative to the rendered page (e.g. `src="../../assets/demos/architecture/"` from `/writing/<slug>/`); same-origin path validation still applies.
+For Markdown posts that can't import a helper, write the path relative to the rendered page (e.g. `src="../../assets/demos/architecture/"` from `/writing/<slug>/`) — this is a recommended _convention_ to stay same-origin and `BASE_URL`-portable, but it's not enforced: a raw `<iframe>` in Markdown bypasses the theme component entirely, so none of the build-time validation listed above runs on it. Anything Markdown can express, the browser will render. Prefer the `<IframeEmbed>` component (via MDX) whenever you need the validation guarantees; reserve raw iframes for embeds whose `src` you have full control over.
 
 This site embeds the self-contained interactive diagram on the [architecture page](/architecture) and inside the [four-layer architecture writing post](/writing/four-layer-architecture).

--- a/examples/demo-site/src/overrides/Hero.astro
+++ b/examples/demo-site/src/overrides/Hero.astro
@@ -47,12 +47,14 @@ const photoSrc = person.photo
   ? (resolveAssetUrl(person.photo, base) ?? person.photo)
   : null;
 
-// Only attach the popup script if the configured booking URL parses as a
-// safe absolute https:// URL. The schema validates bookingUrl as a generic
-// URL, which would let a misconfigured site.json sneak `javascript:` or
-// other unexpected schemes into `window.location.href` /
-// `Calendly.initPopupWidget`. When the URL fails the check we still render
-// the CTA — it just falls through to plain link behavior, no JS hook.
+// Only treat the configured booking URL as usable if it parses as a safe
+// absolute https:// URL. The schema validates bookingUrl as a generic URL,
+// which would let a misconfigured site.json sneak `javascript:` or other
+// unexpected schemes into `window.location.href` /
+// `Calendly.initPopupWidget`. When the URL fails the check, the popup
+// script is not attached AND any CTA whose href matches the unsafe
+// bookingUrl is dropped from `sanitizedCtas` below — we never let an
+// unvalidated bookingUrl reach a rendered <a href> or a JS call.
 const safeBookingUrl: string | null = (() => {
   if (!bookingUrl) return null;
   try {

--- a/examples/demo-site/src/overrides/Hero.astro
+++ b/examples/demo-site/src/overrides/Hero.astro
@@ -139,6 +139,7 @@ const linkCtas = [
 >
   <div
     class="absolute right-6 top-24 hidden rounded-full border border-[var(--color-border-default)] bg-[var(--color-surface-wash)] px-3 py-1 font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--color-accent-primary)] md:inline-block"
+    role="note"
     aria-label="This Hero is rendered by a consumer-supplied override"
   >
     demo: Hero override active

--- a/examples/demo-site/src/pages-local/architecture.astro
+++ b/examples/demo-site/src/pages-local/architecture.astro
@@ -11,9 +11,12 @@ import IframeEmbed from '@portfolio-engine/editorial-theme/components/IframeEmbe
 import { getBase, resolveAssetUrl } from '@portfolio-engine/editorial-theme';
 
 const base = getBase();
-const diagramSrc =
-  resolveAssetUrl('/assets/demos/architecture/', base) ??
-  '/assets/demos/architecture/';
+// resolveAssetUrl only returns null for null/empty input, so passing a
+// non-empty literal here is guaranteed to return a string.
+const diagramSrc = resolveAssetUrl(
+  '/assets/demos/architecture/',
+  base,
+) as string;
 ---
 
 <Layout

--- a/examples/demo-site/src/pages-local/features.astro
+++ b/examples/demo-site/src/pages-local/features.astro
@@ -129,6 +129,12 @@ const statusStyles: Record<FeatureRow['status'], string> = {
 
     <div class="overflow-hidden rounded-2xl border border-[var(--color-border-default)] bg-[var(--color-surface-page)]">
       <table class="w-full border-collapse text-left text-sm">
+        <caption class="sr-only">
+          Live capability matrix for portfolio-engine: each row lists a
+          feature, its current status (shipped, beta, or planned), and a
+          short description. Data is read at build time from the theme's
+          DEFAULT_ROUTE_REGISTRY and DEFAULT_OVERRIDE_SURFACES exports.
+        </caption>
         <thead>
           <tr class="border-b border-[var(--color-border-default)] bg-[var(--color-surface-wash)]">
             <th class="px-5 py-4 font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--color-accent-primary)]">


### PR DESCRIPTION
## Summary

Small follow-up to **#130** addressing 7 inline Copilot comments that landed _after_ #130 was merged. All changes are scoped to `examples/demo-site`, the root `.gitignore`, and a new `scripts/`-style note in the demo-site README — **no `@portfolio-engine/*` package source is touched**, so this requires no changeset.

| commit | scope | what it does |
|---|---|---|
| `0be6714` (= `c23f717` on the original branch) | demo-site | Adds `role="note"` to the Hero override badge so AT actually announces its `aria-label`; drops the unreachable `?? '/assets/demos/architecture/'` fallback in `architecture.astro` (the literal can never make `resolveAssetUrl` return null); rewords the closing paragraph of `iframe-embeds.md` so it no longer falsely claims build-time validation runs on raw `<iframe>` in Markdown. |
| `792c996` (= `ee201f3`) | repo + demo-site | Adds `.vercel/` to the root `.gitignore` — now needed because #130's `vercel.json` writes the Build Output API tree to `<repo-root>/.vercel/output/`, and `vercel link` / `vercel pull` also drop project metadata at `<repo>/.vercel/`. Also adds an `sr-only` `<caption>` to the feature-matrix `<table>` in `features.astro` so screen readers navigating by table get an announced name. |
| `5c6c54b` (= `98295f5`) | demo-site | Corrects the now-stale block comment above `safeBookingUrl` in `overrides/Hero.astro` to describe the actual two-layer guarantee (popup script gate + `sanitizedCtas` filter), instead of the old "falls through to plain link" wording, which had been true in an earlier iteration but contradicted the current behavior. |

### Why a follow-up PR, not part of #130

#130 was merged at `14:51Z` once Copilot signed off on the round of comments through `e4ec5d3` (the pure-Node `lift-vercel-output.mjs` commit). Copilot then continued its review loop on the merged commit for another ~25 minutes, flagging the items above. They're all legitimate a11y + docs accuracy fixes worth keeping; nothing here changes shipped behavior or any public API.

## Test plan

- [x] All three commits cherry-pick cleanly onto `origin/dev` post-merge (no conflicts).
- [x] No `packages/` paths touched → `Changeset guard (dev)` will not fire.
- [ ] CI green on `feat/demo-site-meta-showcase-followups` (build, check, lint, smoke-packed).
- [ ] Vercel preview renders the demo-site with the corrected Hero badge, feature-matrix caption, and architecture page.
- [ ] Copilot review pass (already opt-in via PR reviewer request).
