### PR TITLE
docs: discoverability quick fixes — READMEs, file comments, unlock detail screens

### DIFF
--- a/.changeset/unlock-detail-screens.md
+++ b/.changeset/unlock-detail-screens.md
@@ -1,0 +1,5 @@
+---
+"@portfolio-engine/editorial-theme": patch
+---
+
+Unlock `/work/[slug]` and `/writing/[slug]` in the default registry (`remappable: true, disableable: true`) so downstream sites can fully replace the individual work and writing item screens.

--- a/.changeset/unlock-detail-screens.md
+++ b/.changeset/unlock-detail-screens.md
@@ -1,5 +1,5 @@
 ---
-"@portfolio-engine/editorial-theme": patch
+'@portfolio-engine/editorial-theme': patch
 ---
 
 Unlock `/work/[slug]` and `/writing/[slug]` in the default registry (`remappable: true, disableable: true`) so downstream sites can fully replace the individual work and writing item screens.

--- a/README.md
+++ b/README.md
@@ -44,19 +44,19 @@ The three **required** packages are published to npm — your repo installs them
 
 ## Where to change things
 
-| Goal | Change this |
-|---|---|
-| Change colors or fonts | `src/config/theme.json` in the downstream site |
-| Change site-wide CSS | A `.css` file in `src/overrides/` in the downstream site |
-| Change the shared outer frame (nav, footer, head) | `packages/editorial-theme/src/layouts/Layout.astro` |
-| Change the home screen | `packages/editorial-theme/src/pages/index.astro` |
-| Change the default work list screen | `packages/editorial-theme/src/pages/work.astro` |
-| Change the default individual work screen | `packages/editorial-theme/src/pages/work/[slug].astro` |
-| Change the default writing list screen | `packages/editorial-theme/src/pages/writing/index.astro` |
-| Change the default individual writing screen | `packages/editorial-theme/src/pages/writing/[slug].astro` |
+| Goal                                              | Change this                                                     |
+| ------------------------------------------------- | --------------------------------------------------------------- |
+| Change colors or fonts                            | `src/config/theme.json` in the downstream site                  |
+| Change site-wide CSS                              | A `.css` file in `src/overrides/` in the downstream site        |
+| Change the shared outer frame (nav, footer, head) | `packages/editorial-theme/src/layouts/Layout.astro`             |
+| Change the home screen                            | `packages/editorial-theme/src/pages/index.astro`                |
+| Change the default work list screen               | `packages/editorial-theme/src/pages/work.astro`                 |
+| Change the default individual work screen         | `packages/editorial-theme/src/pages/work/[slug].astro`          |
+| Change the default writing list screen            | `packages/editorial-theme/src/pages/writing/index.astro`        |
+| Change the default individual writing screen      | `packages/editorial-theme/src/pages/writing/[slug].astro`       |
 | Replace Hero, Footer, or another override surface | `src/overrides/` in the downstream site + the consumer registry |
-| Add a custom downstream screen | The downstream site's `src/pages-local/` and consumer registry |
-| Change what screens are listed in navigation | `src/config/navigation.json` in the downstream site |
+| Add a custom downstream screen                    | The downstream site's `src/pages-local/` and consumer registry  |
+| Change what screens are listed in navigation      | `src/config/navigation.json` in the downstream site             |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,24 @@ The three **required** packages are published to npm — your repo installs them
 
 ---
 
+## Where to change things
+
+| Goal | Change this |
+|---|---|
+| Change colors or fonts | `src/config/theme.json` in the downstream site |
+| Change site-wide CSS | A `.css` file in `src/overrides/` in the downstream site |
+| Change the shared outer frame (nav, footer, head) | `packages/editorial-theme/src/layouts/Layout.astro` |
+| Change the home screen | `packages/editorial-theme/src/pages/index.astro` |
+| Change the default work list screen | `packages/editorial-theme/src/pages/work.astro` |
+| Change the default individual work screen | `packages/editorial-theme/src/pages/work/[slug].astro` |
+| Change the default writing list screen | `packages/editorial-theme/src/pages/writing/index.astro` |
+| Change the default individual writing screen | `packages/editorial-theme/src/pages/writing/[slug].astro` |
+| Replace Hero, Footer, or another override surface | `src/overrides/` in the downstream site + the consumer registry |
+| Add a custom downstream screen | The downstream site's `src/pages-local/` and consumer registry |
+| Change what screens are listed in navigation | `src/config/navigation.json` in the downstream site |
+
+---
+
 ## Updating the theme
 
 ```bash

--- a/examples/node-ssr-demo/.portfolio-engine/manifest.json
+++ b/examples/node-ssr-demo/.portfolio-engine/manifest.json
@@ -1,8 +1,8 @@
 {
-  "generatedAt": "2026-05-06T05:11:04.391Z",
+  "generatedAt": "2026-05-12T16:47:17.147Z",
   "rootDir": ".",
   "portfolioEngine": {
-    "engineCoreVersion": "0.3.0",
+    "engineCoreVersion": "0.3.1",
     "editorialThemeVersion": "unknown"
   },
   "consumerRegistry": {
@@ -68,8 +68,8 @@
       "label": "Work detail",
       "section": null,
       "visibility": "hidden",
-      "remappable": false,
-      "disableable": false,
+      "remappable": true,
+      "disableable": true,
       "agentGuidance": "Prefer Work detail for internal navigation tasks.",
       "resolved": "/work/[slug]",
       "routeOrigin": "theme",
@@ -92,8 +92,8 @@
       "label": "Writing detail",
       "section": null,
       "visibility": "hidden",
-      "remappable": false,
-      "disableable": false,
+      "remappable": true,
+      "disableable": true,
       "agentGuidance": "Prefer Writing detail for internal navigation tasks.",
       "resolved": "/writing/[slug]",
       "routeOrigin": "theme",

--- a/packages/admin-tools/src/README.md
+++ b/packages/admin-tools/src/README.md
@@ -1,0 +1,23 @@
+# What this folder controls
+
+This folder contains the admin interface — a password-protected area at `/admin` where a site owner can view and edit their site's content.
+
+This package is optional. A site works without it.
+
+## What each file/folder does
+
+| File / folder         | What it handles                                                       |
+|-----------------------|-----------------------------------------------------------------------|
+| `integration.ts`      | Astro integration entry point — adds the `/admin` route and API       |
+| `index.ts`            | Public exports for this package                                       |
+| `routes/admin.astro`  | The admin UI screen at `/admin`                                       |
+| `routes/api/`         | API endpoints for reading and writing content files                   |
+| `routes/api/auth/`    | GitHub OAuth authentication (login, callback, logout, session check)  |
+| `server/`             | Server-side helpers: session management and file paths                |
+| `client/`             | Browser-side helpers: content API calls and YAML frontmatter parsing  |
+| `components/`         | Astro components used inside the admin UI                             |
+| `lib/`                | Shared utilities (design token groups, etc.)                          |
+
+## Authentication
+
+The admin area uses GitHub OAuth. Any GitHub account in the configured allowed list can log in. The `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, and `SESSION_SECRET` environment variables must be set.

--- a/packages/admin-tools/src/README.md
+++ b/packages/admin-tools/src/README.md
@@ -6,17 +6,17 @@ This package is optional. A site works without it.
 
 ## What each file/folder does
 
-| File / folder         | What it handles                                                       |
-|-----------------------|-----------------------------------------------------------------------|
-| `integration.ts`      | Astro integration entry point — adds the `/admin` route and API       |
-| `index.ts`            | Public exports for this package                                       |
-| `routes/admin.astro`  | The admin UI screen at `/admin`                                       |
-| `routes/api/`         | API endpoints for reading and writing content files                   |
-| `routes/api/auth/`    | GitHub OAuth authentication (login, callback, logout, session check)  |
-| `server/`             | Server-side helpers: session management and file paths                |
-| `client/`             | Browser-side helpers: content API calls and YAML frontmatter parsing  |
-| `components/`         | Astro components used inside the admin UI                             |
-| `lib/`                | Shared utilities (design token groups, etc.)                          |
+| File / folder        | What it handles                                                      |
+| -------------------- | -------------------------------------------------------------------- |
+| `integration.ts`     | Astro integration entry point — adds the `/admin` route and API      |
+| `index.ts`           | Public exports for this package                                      |
+| `routes/admin.astro` | The admin UI screen at `/admin`                                      |
+| `routes/api/`        | API endpoints for reading and writing content files                  |
+| `routes/api/auth/`   | GitHub OAuth authentication (login, callback, logout, session check) |
+| `server/`            | Server-side helpers: session management and file paths               |
+| `client/`            | Browser-side helpers: content API calls and YAML frontmatter parsing |
+| `components/`        | Astro components used inside the admin UI                            |
+| `lib/`               | Shared utilities (design token groups, etc.)                         |
 
 ## Authentication
 

--- a/packages/editorial-theme/src/README.md
+++ b/packages/editorial-theme/src/README.md
@@ -2,12 +2,12 @@
 
 This folder contains the source code for the editorial theme — the default look, screens, and behavior that every site built on portfolio-engine gets out of the box.
 
-| Subfolder    | What it controls                                                        |
-|--------------|-------------------------------------------------------------------------|
-| `pages/`     | The visitor-facing screens (what a visitor sees at each web address)    |
-| `components/`| Reusable visual pieces used across multiple screens                     |
-| `layouts/`   | The shared outer frame that wraps every screen (nav, footer, head)      |
-| `styles/`    | Colors, spacing, fonts, and global visual rules                         |
-| `lib/`       | Shared helper functions used by pages and components                    |
+| Subfolder     | What it controls                                                     |
+| ------------- | -------------------------------------------------------------------- |
+| `pages/`      | The visitor-facing screens (what a visitor sees at each web address) |
+| `components/` | Reusable visual pieces used across multiple screens                  |
+| `layouts/`    | The shared outer frame that wraps every screen (nav, footer, head)   |
+| `styles/`     | Colors, spacing, fonts, and global visual rules                      |
+| `lib/`        | Shared helper functions used by pages and components                 |
 
 The theme is consumed as an npm package. Downstream sites do not edit this folder directly — they install the package and override specific pieces through the registry system.

--- a/packages/editorial-theme/src/README.md
+++ b/packages/editorial-theme/src/README.md
@@ -1,0 +1,13 @@
+# What this folder controls
+
+This folder contains the source code for the editorial theme — the default look, screens, and behavior that every site built on portfolio-engine gets out of the box.
+
+| Subfolder    | What it controls                                                        |
+|--------------|-------------------------------------------------------------------------|
+| `pages/`     | The visitor-facing screens (what a visitor sees at each web address)    |
+| `components/`| Reusable visual pieces used across multiple screens                     |
+| `layouts/`   | The shared outer frame that wraps every screen (nav, footer, head)      |
+| `styles/`    | Colors, spacing, fonts, and global visual rules                         |
+| `lib/`       | Shared helper functions used by pages and components                    |
+
+The theme is consumed as an npm package. Downstream sites do not edit this folder directly — they install the package and override specific pieces through the registry system.

--- a/packages/editorial-theme/src/components/README.md
+++ b/packages/editorial-theme/src/components/README.md
@@ -1,0 +1,20 @@
+# What this folder controls
+
+This folder contains reusable visual pieces used across multiple screens.
+
+A "component" is a self-contained piece of the screen — a navigation bar, a card, a section — that can appear in many places without being rewritten each time.
+
+## Key components
+
+| File / folder             | What it displays                                              |
+|---------------------------|---------------------------------------------------------------|
+| `Nav.astro`               | The top navigation bar shown on every screen                  |
+| `Footer.astro`            | The footer shown at the bottom of every screen                |
+| `sections/HeroSection.astro` | The large intro section on the home screen                |
+| `sections/FeaturedWritingSection.astro` | The writing preview section on the home screen |
+| `sections/TestimonialSection.astro`     | The testimonials section on the home screen    |
+| `sections/CollaborationSection.astro`   | The call-to-action section on the home screen  |
+| `ImageOrFallback.astro`   | Displays an image, or a letter placeholder if no image exists |
+| `WritingList.astro`       | A list of writing cards                                       |
+
+Some of these components (`Hero`, `FeaturedWriting`, `TestimonialSection`, `CollaborationSection`, `Footer`) can be replaced by a downstream site through the override surface system. See `../registry.ts`.

--- a/packages/editorial-theme/src/components/README.md
+++ b/packages/editorial-theme/src/components/README.md
@@ -6,15 +6,15 @@ A "component" is a self-contained piece of the screen — a navigation bar, a ca
 
 ## Key components
 
-| File / folder             | What it displays                                              |
-|---------------------------|---------------------------------------------------------------|
-| `Nav.astro`               | The top navigation bar shown on every screen                  |
-| `Footer.astro`            | The footer shown at the bottom of every screen                |
-| `sections/HeroSection.astro` | The large intro section on the home screen                |
-| `sections/FeaturedWritingSection.astro` | The writing preview section on the home screen |
-| `sections/TestimonialSection.astro`     | The testimonials section on the home screen    |
-| `sections/CollaborationSection.astro`   | The call-to-action section on the home screen  |
-| `ImageOrFallback.astro`   | Displays an image, or a letter placeholder if no image exists |
-| `WritingList.astro`       | A list of writing cards                                       |
+| File / folder                           | What it displays                                              |
+| --------------------------------------- | ------------------------------------------------------------- |
+| `Nav.astro`                             | The top navigation bar shown on every screen                  |
+| `Footer.astro`                          | The footer shown at the bottom of every screen                |
+| `sections/HeroSection.astro`            | The large intro section on the home screen                    |
+| `sections/FeaturedWritingSection.astro` | The writing preview section on the home screen                |
+| `sections/TestimonialSection.astro`     | The testimonials section on the home screen                   |
+| `sections/CollaborationSection.astro`   | The call-to-action section on the home screen                 |
+| `ImageOrFallback.astro`                 | Displays an image, or a letter placeholder if no image exists |
+| `WritingList.astro`                     | A list of writing cards                                       |
 
 Some of these components (`Hero`, `FeaturedWriting`, `TestimonialSection`, `CollaborationSection`, `Footer`) can be replaced by a downstream site through the override surface system. See `../registry.ts`.

--- a/packages/editorial-theme/src/layouts/Layout.astro
+++ b/packages/editorial-theme/src/layouts/Layout.astro
@@ -1,4 +1,10 @@
 ---
+/**
+ * This file controls the shared outer frame that wraps every visitor-facing screen.
+ *
+ * It includes the navigation bar, footer, global styles, and SEO metadata.
+ * Every page on the site passes through this layout.
+ */
 import Nav from '../components/Nav.astro';
 import AmbientBackground from '../components/AmbientBackground.astro';
 import Footer from '../components/Footer.astro';

--- a/packages/editorial-theme/src/layouts/README.md
+++ b/packages/editorial-theme/src/layouts/README.md
@@ -1,0 +1,16 @@
+# What this folder controls
+
+This folder contains the shared outer frame that wraps every visitor-facing screen.
+
+| File           | What it controls                                                         |
+|----------------|--------------------------------------------------------------------------|
+| `Layout.astro` | The HTML shell: head metadata, nav, footer, global styles, and the slot where page content goes |
+
+Every page on the site is wrapped in `Layout.astro`. It handles:
+- SEO metadata (title, description, Open Graph, Twitter Card)
+- Google Fonts loading
+- Navigation bar and footer
+- Global CSS and theme token overrides
+- The inline JavaScript for scroll-reveal animations
+
+To change the shared outer frame for a downstream site, edit `Layout.astro` here (if contributing to the theme) or replace the `Footer` override surface from a downstream site.

--- a/packages/editorial-theme/src/layouts/README.md
+++ b/packages/editorial-theme/src/layouts/README.md
@@ -2,11 +2,12 @@
 
 This folder contains the shared outer frame that wraps every visitor-facing screen.
 
-| File           | What it controls                                                         |
-|----------------|--------------------------------------------------------------------------|
+| File           | What it controls                                                                                |
+| -------------- | ----------------------------------------------------------------------------------------------- |
 | `Layout.astro` | The HTML shell: head metadata, nav, footer, global styles, and the slot where page content goes |
 
 Every page on the site is wrapped in `Layout.astro`. It handles:
+
 - SEO metadata (title, description, Open Graph, Twitter Card)
 - Google Fonts loading
 - Navigation bar and footer

--- a/packages/editorial-theme/src/pages/README.md
+++ b/packages/editorial-theme/src/pages/README.md
@@ -5,19 +5,20 @@ This folder contains the default visitor-facing screens that come with the theme
 Each `.astro` file describes what a visitor sees at a particular web address.
 
 Some filenames come from Astro and cannot be made more descriptive:
+
 - `index.astro` means "the main screen for this folder."
 - `[slug].astro` means "one screen for each content item."
 
 ## Screens in this folder
 
-| File               | Web address        | What it shows                                     |
-|--------------------|--------------------|---------------------------------------------------|
-| `index.astro`      | `/`                | The home screen (hero, featured work, writing)    |
-| `about.astro`      | `/about`           | The about screen                                  |
-| `work.astro`       | `/work`            | The list of all work items                        |
-| `writing/`         | `/writing`         | The list of all writing items (subfolder)         |
-| `contact.astro`    | `/contact`         | The contact screen                                |
-| `resume.astro`     | `/resume`          | The résumé screen                                 |
+| File            | Web address | What it shows                                  |
+| --------------- | ----------- | ---------------------------------------------- |
+| `index.astro`   | `/`         | The home screen (hero, featured work, writing) |
+| `about.astro`   | `/about`    | The about screen                               |
+| `work.astro`    | `/work`     | The list of all work items                     |
+| `writing/`      | `/writing`  | The list of all writing items (subfolder)      |
+| `contact.astro` | `/contact`  | The contact screen                             |
+| `resume.astro`  | `/resume`   | The résumé screen                              |
 
 ## Subfolders
 

--- a/packages/editorial-theme/src/pages/README.md
+++ b/packages/editorial-theme/src/pages/README.md
@@ -1,0 +1,27 @@
+# What this folder controls
+
+This folder contains the default visitor-facing screens that come with the theme.
+
+Each `.astro` file describes what a visitor sees at a particular web address.
+
+Some filenames come from Astro and cannot be made more descriptive:
+- `index.astro` means "the main screen for this folder."
+- `[slug].astro` means "one screen for each content item."
+
+## Screens in this folder
+
+| File               | Web address        | What it shows                                     |
+|--------------------|--------------------|---------------------------------------------------|
+| `index.astro`      | `/`                | The home screen (hero, featured work, writing)    |
+| `about.astro`      | `/about`           | The about screen                                  |
+| `work.astro`       | `/work`            | The list of all work items                        |
+| `writing/`         | `/writing`         | The list of all writing items (subfolder)         |
+| `contact.astro`    | `/contact`         | The contact screen                                |
+| `resume.astro`     | `/resume`          | The résumé screen                                 |
+
+## Subfolders
+
+- `work/` — contains `[slug].astro`, the individual work item screen at `/work/[slug]`
+- `writing/` — contains `index.astro` (writing list) and `[slug].astro` (individual writing screen)
+
+A downstream site can replace any of these screens through the registry. See `../registry.ts`.

--- a/packages/editorial-theme/src/pages/work.astro
+++ b/packages/editorial-theme/src/pages/work.astro
@@ -1,4 +1,10 @@
 ---
+/**
+ * This file controls the default work list screen.
+ *
+ * It shows all items from the work content folder as a grid of cards.
+ * Each card links to the individual work item screen (/work/[slug]).
+ */
 import Layout from '../layouts/Layout.astro';
 import { getCollection } from 'astro:content';
 import ImageOrFallback from '../components/ImageOrFallback.astro';

--- a/packages/editorial-theme/src/pages/work/README.md
+++ b/packages/editorial-theme/src/pages/work/README.md
@@ -1,0 +1,13 @@
+# What this folder controls
+
+This folder contains the individual work item screen.
+
+| File          | Web address      | What it shows                                         |
+|---------------|------------------|-------------------------------------------------------|
+| `[slug].astro`| `/work/[slug]`   | One screen for each item in the `content/projects/` folder |
+
+`[slug]` is an Astro convention — it means the file generates one screen per content item, using the item's filename as the web address.
+
+For example, an item at `content/projects/acme-redesign.md` produces a screen at `/work/acme-redesign`.
+
+A downstream site can fully replace this screen by setting `remappable: true` in the registry (which is already the case).

--- a/packages/editorial-theme/src/pages/work/README.md
+++ b/packages/editorial-theme/src/pages/work/README.md
@@ -2,9 +2,9 @@
 
 This folder contains the individual work item screen.
 
-| File          | Web address      | What it shows                                         |
-|---------------|------------------|-------------------------------------------------------|
-| `[slug].astro`| `/work/[slug]`   | One screen for each item in the `content/projects/` folder |
+| File           | Web address    | What it shows                                              |
+| -------------- | -------------- | ---------------------------------------------------------- |
+| `[slug].astro` | `/work/[slug]` | One screen for each item in the `content/projects/` folder |
 
 `[slug]` is an Astro convention — it means the file generates one screen per content item, using the item's filename as the web address.
 

--- a/packages/editorial-theme/src/pages/work/[slug].astro
+++ b/packages/editorial-theme/src/pages/work/[slug].astro
@@ -1,4 +1,10 @@
 ---
+/**
+ * This file controls the default individual work item screen.
+ *
+ * It creates one visitor-facing screen for each item in the work content folder.
+ * It decides where the title, image, tags, description, and body text appear.
+ */
 import Layout from '../../layouts/Layout.astro';
 import type { CollectionEntry } from 'astro:content';
 import { getCollection, render } from 'astro:content';

--- a/packages/editorial-theme/src/pages/writing/README.md
+++ b/packages/editorial-theme/src/pages/writing/README.md
@@ -2,10 +2,10 @@
 
 This folder contains the writing list screen and the individual writing item screen.
 
-| File           | Web address         | What it shows                                          |
-|----------------|---------------------|--------------------------------------------------------|
-| `index.astro`  | `/writing`          | The list of all writing items (excludes drafts)        |
-| `[slug].astro` | `/writing/[slug]`   | One screen for each item in the `content/writing/` folder |
+| File           | Web address       | What it shows                                             |
+| -------------- | ----------------- | --------------------------------------------------------- |
+| `index.astro`  | `/writing`        | The list of all writing items (excludes drafts)           |
+| `[slug].astro` | `/writing/[slug]` | One screen for each item in the `content/writing/` folder |
 
 `[slug]` is an Astro convention — it means the file generates one screen per content item, using the item's filename as the web address.
 

--- a/packages/editorial-theme/src/pages/writing/README.md
+++ b/packages/editorial-theme/src/pages/writing/README.md
@@ -1,0 +1,14 @@
+# What this folder controls
+
+This folder contains the writing list screen and the individual writing item screen.
+
+| File           | Web address         | What it shows                                          |
+|----------------|---------------------|--------------------------------------------------------|
+| `index.astro`  | `/writing`          | The list of all writing items (excludes drafts)        |
+| `[slug].astro` | `/writing/[slug]`   | One screen for each item in the `content/writing/` folder |
+
+`[slug]` is an Astro convention — it means the file generates one screen per content item, using the item's filename as the web address.
+
+For example, an item at `content/writing/my-post.md` produces a screen at `/writing/my-post`.
+
+A downstream site can fully replace either of these screens through the registry. See `../../registry.ts`.

--- a/packages/editorial-theme/src/pages/writing/[slug].astro
+++ b/packages/editorial-theme/src/pages/writing/[slug].astro
@@ -1,4 +1,10 @@
 ---
+/**
+ * This file controls the default individual writing item screen.
+ *
+ * It creates one visitor-facing screen for each item in the writing content folder.
+ * It decides where the title, image, date, tags, description, and body text appear.
+ */
 import Layout from '../../layouts/Layout.astro';
 import type { CollectionEntry } from 'astro:content';
 import { getCollection, render } from 'astro:content';

--- a/packages/editorial-theme/src/pages/writing/index.astro
+++ b/packages/editorial-theme/src/pages/writing/index.astro
@@ -1,4 +1,10 @@
 ---
+/**
+ * This file controls the default writing list screen.
+ *
+ * It shows all non-draft items from the writing content folder as a list of cards.
+ * Each card links to the individual writing item screen (/writing/[slug]).
+ */
 import Layout from '../../layouts/Layout.astro';
 import type { CollectionEntry } from 'astro:content';
 import { getCollection } from 'astro:content';

--- a/packages/editorial-theme/src/registry.ts
+++ b/packages/editorial-theme/src/registry.ts
@@ -1,12 +1,18 @@
+/**
+ * This file lists the default screens and replaceable parts that come with the theme.
+ *
+ * The first list says which visitor-facing screens the theme provides.
+ * The second list says which pieces a site owner is allowed to replace.
+ */
 import type { OverrideSurfaceEntry, RouteRegistryEntry } from '@portfolio-engine/schema';
 
 export const DEFAULT_ROUTE_REGISTRY: RouteRegistryEntry[] = [
   { pattern: '/', label: 'Home', section: null, visibility: 'public', remappable: true, disableable: false },
   { pattern: '/about', label: 'About', section: null, visibility: 'public', remappable: true, disableable: true },
   { pattern: '/work', label: 'Work', section: null, visibility: 'public', remappable: true, disableable: true },
-  { pattern: '/work/[slug]', label: 'Work detail', section: null, visibility: 'hidden', remappable: false, disableable: false },
+  { pattern: '/work/[slug]', label: 'Work detail', section: null, visibility: 'hidden', remappable: true, disableable: true },
   { pattern: '/writing', label: 'Writing', section: null, visibility: 'public', remappable: true, disableable: true },
-  { pattern: '/writing/[slug]', label: 'Writing detail', section: null, visibility: 'hidden', remappable: false, disableable: false },
+  { pattern: '/writing/[slug]', label: 'Writing detail', section: null, visibility: 'hidden', remappable: true, disableable: true },
   { pattern: '/contact', label: 'Contact', section: null, visibility: 'public', remappable: true, disableable: true },
   { pattern: '/resume', label: 'Résumé', section: null, visibility: 'public', remappable: true, disableable: true },
 ];

--- a/packages/editorial-theme/src/styles/README.md
+++ b/packages/editorial-theme/src/styles/README.md
@@ -1,0 +1,16 @@
+# What this folder controls
+
+This folder contains the global visual rules for the theme.
+
+| File                 | What it controls                                                        |
+|----------------------|-------------------------------------------------------------------------|
+| `global.css`         | Base styles applied to every screen: resets, body defaults, typography  |
+| `design-tokens.css`  | CSS custom properties (variables) for colors, spacing, and font weights |
+
+## Changing colors, fonts, or spacing
+
+A downstream site controls visual appearance through `config/theme.json` — not by editing these files directly.
+
+The values in `theme.json` are read by the engine and injected as CSS variables at build time, overriding the defaults in `design-tokens.css`.
+
+To add custom CSS that is not covered by the theme config, a downstream site places a `.css` file in its `src/overrides/` folder. Those files are injected globally by the layout.

--- a/packages/editorial-theme/src/styles/README.md
+++ b/packages/editorial-theme/src/styles/README.md
@@ -2,10 +2,10 @@
 
 This folder contains the global visual rules for the theme.
 
-| File                 | What it controls                                                        |
-|----------------------|-------------------------------------------------------------------------|
-| `global.css`         | Base styles applied to every screen: resets, body defaults, typography  |
-| `design-tokens.css`  | CSS custom properties (variables) for colors, spacing, and font weights |
+| File                | What it controls                                                        |
+| ------------------- | ----------------------------------------------------------------------- |
+| `global.css`        | Base styles applied to every screen: resets, body defaults, typography  |
+| `design-tokens.css` | CSS custom properties (variables) for colors, spacing, and font weights |
 
 ## Changing colors, fonts, or spacing
 

--- a/packages/engine-core/src/README.md
+++ b/packages/engine-core/src/README.md
@@ -6,15 +6,15 @@ Downstream sites and theme authors do not import from this package directly. Eve
 
 ## What each file does
 
-| File                      | What it handles                                                         |
-|---------------------------|-------------------------------------------------------------------------|
-| `config-loader.ts`        | Reads and validates `config/*.json` files from the downstream site      |
-| `virtual-modules.ts`      | Makes config and overrides available to Astro pages as virtual imports  |
-| `integration.ts`          | The Astro integration entry point — wires config, routes, and overrides |
-| `route-discovery.ts`      | Finds theme pages at build time                                         |
-| `route-remap.ts`          | Applies route overrides from the downstream registry                    |
-| `consumer-local-routes.ts`| Reads the downstream site's custom screen registry                      |
-| `override-resolution.ts`  | Resolves which component (theme default or downstream override) to use  |
-| `manifest.ts`             | Builds the engine manifest used by admin tools                          |
-| `types.ts`                | Shared internal TypeScript types                                        |
-| `doctor.ts`               | Diagnostic checks run at dev-server startup                             |
+| File                       | What it handles                                                         |
+| -------------------------- | ----------------------------------------------------------------------- |
+| `config-loader.ts`         | Reads and validates `config/*.json` files from the downstream site      |
+| `virtual-modules.ts`       | Makes config and overrides available to Astro pages as virtual imports  |
+| `integration.ts`           | The Astro integration entry point — wires config, routes, and overrides |
+| `route-discovery.ts`       | Finds theme pages at build time                                         |
+| `route-remap.ts`           | Applies route overrides from the downstream registry                    |
+| `consumer-local-routes.ts` | Reads the downstream site's custom screen registry                      |
+| `override-resolution.ts`   | Resolves which component (theme default or downstream override) to use  |
+| `manifest.ts`              | Builds the engine manifest used by admin tools                          |
+| `types.ts`                 | Shared internal TypeScript types                                        |
+| `doctor.ts`                | Diagnostic checks run at dev-server startup                             |

--- a/packages/engine-core/src/README.md
+++ b/packages/engine-core/src/README.md
@@ -1,0 +1,20 @@
+# What this folder controls
+
+This folder contains the internal machinery that makes the theme work.
+
+Downstream sites and theme authors do not import from this package directly. Everything a consumer needs is re-exported through `@portfolio-engine/editorial-theme`.
+
+## What each file does
+
+| File                      | What it handles                                                         |
+|---------------------------|-------------------------------------------------------------------------|
+| `config-loader.ts`        | Reads and validates `config/*.json` files from the downstream site      |
+| `virtual-modules.ts`      | Makes config and overrides available to Astro pages as virtual imports  |
+| `integration.ts`          | The Astro integration entry point — wires config, routes, and overrides |
+| `route-discovery.ts`      | Finds theme pages at build time                                         |
+| `route-remap.ts`          | Applies route overrides from the downstream registry                    |
+| `consumer-local-routes.ts`| Reads the downstream site's custom screen registry                      |
+| `override-resolution.ts`  | Resolves which component (theme default or downstream override) to use  |
+| `manifest.ts`             | Builds the engine manifest used by admin tools                          |
+| `types.ts`                | Shared internal TypeScript types                                        |
+| `doctor.ts`               | Diagnostic checks run at dev-server startup                             |

--- a/packages/schema/src/README.md
+++ b/packages/schema/src/README.md
@@ -1,0 +1,16 @@
+# What this folder controls
+
+This folder contains the shared data shapes (schemas) used across all packages.
+
+Schemas define what fields are required or optional in each config file, content entry, or registry entry, and what values are allowed. They are written with [Zod](https://zod.dev) so errors are caught at startup, not at runtime.
+
+## What each file defines
+
+| File                  | What it describes                                                   |
+|-----------------------|---------------------------------------------------------------------|
+| `index.ts`            | Exports everything — start here if you are looking for a type       |
+| `registry.ts`         | Shape of the theme route registry and override surface entries      |
+| `consumer-registry.ts`| Shape of the downstream site's custom screen registry file          |
+| `profile.ts`          | Shape of the `content/profile/` data (person, CV, experience, etc.) |
+| `theme-config.ts`     | Shape of `config/theme.json` (colors, fonts)                        |
+| `design-resolve.ts`   | Helpers for resolving design token values from theme config         |

--- a/packages/schema/src/README.md
+++ b/packages/schema/src/README.md
@@ -6,11 +6,11 @@ Schemas define what fields are required or optional in each config file, content
 
 ## What each file defines
 
-| File                  | What it describes                                                   |
-|-----------------------|---------------------------------------------------------------------|
-| `index.ts`            | Exports everything — start here if you are looking for a type       |
-| `registry.ts`         | Shape of the theme route registry and override surface entries      |
-| `consumer-registry.ts`| Shape of the downstream site's custom screen registry file          |
-| `profile.ts`          | Shape of the `content/profile/` data (person, CV, experience, etc.) |
-| `theme-config.ts`     | Shape of `config/theme.json` (colors, fonts)                        |
-| `design-resolve.ts`   | Helpers for resolving design token values from theme config         |
+| File                   | What it describes                                                   |
+| ---------------------- | ------------------------------------------------------------------- |
+| `index.ts`             | Exports everything — start here if you are looking for a type       |
+| `registry.ts`          | Shape of the theme route registry and override surface entries      |
+| `consumer-registry.ts` | Shape of the downstream site's custom screen registry file          |
+| `profile.ts`           | Shape of the `content/profile/` data (person, CV, experience, etc.) |
+| `theme-config.ts`      | Shape of `config/theme.json` (colors, fonts)                        |
+| `design-resolve.ts`    | Helpers for resolving design token values from theme config         |

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 packages:
   - 'packages/*'
   - 'examples/*'
+allowBuilds:
+  esbuild: true
+  sharp: true


### PR DESCRIPTION
## What this does

This is the quick-fix pass for making the portfolio-engine codebase understandable to a site owner without touching the physical folder structure or renaming any Astro-reserved filenames.

### Changes

**10 plain-English README files added** — one per confusing source folder:
- `packages/editorial-theme/src/README.md`
- `packages/editorial-theme/src/pages/README.md`
- `packages/editorial-theme/src/pages/work/README.md`
- `packages/editorial-theme/src/pages/writing/README.md`
- `packages/editorial-theme/src/components/README.md`
- `packages/editorial-theme/src/layouts/README.md`
- `packages/editorial-theme/src/styles/README.md`
- `packages/engine-core/src/README.md`
- `packages/schema/src/README.md`
- `packages/admin-tools/src/README.md`

Each explains what the folder controls in plain product language (not framework terms), with a table of key files and what they do.

**Plain-English comment blocks added** to 6 files:
- `registry.ts` — explains it lists default screens and replaceable parts
- `layouts/Layout.astro` — explains it is the shared outer frame for every screen
- `pages/work.astro` — explains it is the default work list screen
- `pages/work/[slug].astro` — explains it is the individual work item screen
- `pages/writing/index.astro` — explains it is the default writing list screen
- `pages/writing/[slug].astro` — explains it is the individual writing item screen

**Registry unlock** — actual behavior change:
- `/work/[slug]`: `remappable: false, disableable: false` → `remappable: true, disableable: true`
- `/writing/[slug]`: `remappable: false, disableable: false` → `remappable: true, disableable: true`

Downstream sites can now fully replace the individual work and writing screens, matching what they could already do with the list screens.

**Root README** — added "Where to change things" quick-reference table mapping goals to files.

---

## Longer fix (not in this PR — tracking here)

The longer fix would change the mental model exposed to downstream users. Key ideas:

**1. Rename user-facing registry concepts from technical words to plain words**
- "route" → "screen address"
- "page" → "visitor-facing screen"
- "component" → "reusable visual piece"
- "override" → "replacement"
- "slug" → "content item name in the URL"

**2. Split the downstream consumer registry into two clear files**
- `src/registry/screens.json` — "What visitor-facing screens does this site add or replace?"
- `src/registry/replaceable-pieces.json` — "What reusable visual pieces does this site add or replace?"

Currently these are merged into one file (`portfolio-engine.registry.json`) with mixed concerns.

**3. Make upstream and downstream registries mirror each other**
Upstream (`registry.ts`) uses `RouteRegistryEntry` / `OverrideSurfaceEntry`. Downstream uses a single JSON file with mixed concepts. They should mirror the same plain-language model.

**4. Allow clearer downstream folder aliases**
- `src/visitor-screens/` as alias for `src/pages-local/`
- `src/visual-pieces/` as alias for `src/components/` (or a new downstream-level folder)

This would make a downstream repo readable without fighting Astro.

**5. Make admin tools use the same plain-language model**
Admin UI should say "Screens", "Reusable visual pieces", "Navigation" — not "localRoutes", "slug", "component override".

The goal of the longer fix: a site owner should be able to ask "Where do I change the list screen? Where do I change the individual item screen? Where do I change the reusable card?" and the repo should answer that immediately without the owner needing to know what a route registry is.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)