### PR TITLE
Feat/update demo site

### DIFF
--- a/packages/admin-tools/src/routes/admin.astro
+++ b/packages/admin-tools/src/routes/admin.astro
@@ -103,6 +103,11 @@ const logoutUrl = sitePathUrl(Astro.request, 'api/auth/logout');
 const homeUrl = siteHomeUrl(Astro.request);
 const contentApiUrl = sitePathUrl(Astro.request, 'api/content');
 
+const workRoute = routes.find((r) => r.pattern === '/work');
+const writingRoute = routes.find((r) => r.pattern === '/writing');
+const workUrl = workRoute ? sitePathUrl(Astro.request, workRoute.resolved.replace(/^\//, '')) : null;
+const writingUrl = writingRoute ? sitePathUrl(Astro.request, writingRoute.resolved.replace(/^\//, '')) : null;
+
 const personOnDisk = await readJsonSafe('src/content/profile/person.json');
 const siteOnDisk = await readJsonSafe('src/config/site.json');
 
@@ -389,14 +394,28 @@ const bodyFamilyLabel =
           <p class="adm-section-lead">Edit entries in place. New items are saved to your content folders.</p>
 
           <div class="adm-stat-row">
-            <a class="adm-stat adm-stat--link" href="/product-achievements" target="_blank" rel="noopener noreferrer">
-              <span class="adm-stat-num">{projects.length}</span>
-              <span class="adm-stat-label">Projects</span>
-            </a>
-            <a class="adm-stat adm-stat--link" href="/research" target="_blank" rel="noopener noreferrer">
-              <span class="adm-stat-num">{writing.length}</span>
-              <span class="adm-stat-label">Writing</span>
-            </a>
+            {workUrl ? (
+              <a class="adm-stat adm-stat--link" href={workUrl} target="_blank" rel="noopener noreferrer">
+                <span class="adm-stat-num">{projects.length}</span>
+                <span class="adm-stat-label">Projects</span>
+              </a>
+            ) : (
+              <div class="adm-stat">
+                <span class="adm-stat-num">{projects.length}</span>
+                <span class="adm-stat-label">Projects</span>
+              </div>
+            )}
+            {writingUrl ? (
+              <a class="adm-stat adm-stat--link" href={writingUrl} target="_blank" rel="noopener noreferrer">
+                <span class="adm-stat-num">{writing.length}</span>
+                <span class="adm-stat-label">Writing</span>
+              </a>
+            ) : (
+              <div class="adm-stat">
+                <span class="adm-stat-num">{writing.length}</span>
+                <span class="adm-stat-label">Writing</span>
+              </div>
+            )}
             <div class="adm-stat">
               <span class="adm-stat-num">{testimonials.length}</span>
               <span class="adm-stat-label">Testimonials</span>

--- a/packages/admin-tools/src/routes/admin.astro
+++ b/packages/admin-tools/src/routes/admin.astro
@@ -389,14 +389,14 @@ const bodyFamilyLabel =
           <p class="adm-section-lead">Edit entries in place. New items are saved to your content folders.</p>
 
           <div class="adm-stat-row">
-            <div class="adm-stat">
+            <a class="adm-stat adm-stat--link" href="/product-achievements" target="_blank" rel="noopener noreferrer">
               <span class="adm-stat-num">{projects.length}</span>
               <span class="adm-stat-label">Projects</span>
-            </div>
-            <div class="adm-stat">
+            </a>
+            <a class="adm-stat adm-stat--link" href="/research" target="_blank" rel="noopener noreferrer">
               <span class="adm-stat-num">{writing.length}</span>
               <span class="adm-stat-label">Writing</span>
-            </div>
+            </a>
             <div class="adm-stat">
               <span class="adm-stat-num">{testimonials.length}</span>
               <span class="adm-stat-label">Testimonials</span>
@@ -885,6 +885,14 @@ const bodyFamilyLabel =
         border-radius: 999px;
         border: 1px solid var(--color-border-default);
         background: var(--color-surface-elevated);
+        text-decoration: none;
+        color: inherit;
+      }
+      .adm-stat--link:hover {
+        border-color: var(--color-accent-primary);
+      }
+      .adm-stat--link:hover .adm-stat-num {
+        color: var(--color-accent-primary);
       }
       .adm-stat-num {
         font-family: ui-serif, Georgia, serif;


### PR DESCRIPTION
## Summary

Makes the Projects and Writing stat counters in the admin dashboard clickable links that resolve to the consumer's actual content section URLs via the route registry.

**Note on original scope:** This PR was opened with broader demo-site content and positioning changes (vision/workflow/contribute pages, updated copy, nav rework, feature flag changes, testimonial cleanup). All of those changes have since been merged into `main` through normal dev→main releases. The only remaining diff is the admin stat card feature in `packages/admin-tools`.

## Change

`packages/admin-tools/src/routes/admin.astro` — Projects and Writing stat counters are now `<a>` links when the corresponding routes are active:

- Looks up `/work` and `/writing` by canonical `pattern` in the `routes` registry (already imported from `@portfolio-engine:routes`).
- Resolves the href via `sitePathUrl()` so Astro `base` subpath deployments are handled correctly.
- Degrades gracefully to a plain non-link `<div>` if either route is disabled or absent in the consumer's config.

## Reviewer comments addressed

- **Codex (P2)**, **Copilot** (original review), and a second **Copilot** inline comment all flagged the original hardcoded `/product-achievements` and `/research` paths causing 404s across all consumers. Fixed in commit `ef2dbfb` using registry-derived routes. Replies posted to all related inline comments.

## Test plan

- [x] `pnpm check` passes
- [ ] Verify Projects stat links to `/work` (or consumer-remapped equivalent) in the admin dashboard
- [ ] Verify Writing stat links to `/writing` (or consumer-remapped equivalent)
- [ ] Verify stat falls back to non-link div when route is disabled in consumer config

## Target layer

- [x] `packages/admin-tools`

## Downstream origin

- [x] Yes — `agreni-site` audit surfaced the broken links; fix belongs upstream since `admin-tools` is shared

## Layer check

- [x] no, upstream package change is required — shared admin UI must not hardcode consumer-specific paths

## Changeset

- [x] Not needed — admin UI behavior change with no public API surface change; consumers benefit automatically

## AI assistance

- [x] Yes — Claude Sonnet 4.6, output reviewed

## Private data and secrets check

- [x] I did not include secrets, credentials, tokens, or private keys.
- [x] I did not include private downstream content that should not be public.
- [x] I did not put private files in `public/`.
- [x] I did not hardcode consumer-specific logic into upstream packages.