### PR TITLE
feat(workflow-kit): add rendered interaction verification templates

### DIFF
--- a/.changeset/editorial-theme-ambient-bg-pointer-events.md
+++ b/.changeset/editorial-theme-ambient-bg-pointer-events.md
@@ -1,0 +1,22 @@
+---
+'@portfolio-engine/editorial-theme': patch
+---
+
+Prevent the decorative ambient background from intercepting pointer interactions.
+
+`AmbientBackground.astro` is `aria-hidden` and visually behind the page (`-z-10`), but
+lacked explicit `pointer-events: none`. This allowed the layer to intercept clicks and text
+selection in rendered sites, causing CTAs and cards to fail in real browser interaction even
+when their `href` values were correct.
+
+This was the root cause of the downstream click failures reported in `jordan-site` PR #60:
+static rendered-link checks passed because hrefs existed, but actual browser clicks were
+blocked until pointer events were disabled on `.ambient-bg`.
+
+#### Agent migration
+
+- **Packages:** `@portfolio-engine/editorial-theme`
+- **Consumer paths:** no consumer action required — this is fixed upstream
+- **Actions:**
+  - If a downstream site added a local CSS workaround like `.ambient-bg { pointer-events: none }`,
+    that workaround is now redundant and can be removed after upgrading.

--- a/.changeset/workflow-kit-rendered-interactions.md
+++ b/.changeset/workflow-kit-rendered-interactions.md
@@ -16,7 +16,7 @@ Downstream agents should compare and update:
 - `scripts/check-rendered-links.mjs` — hardened: supports single-quoted hrefs, normalizes leading slashes, documents static-only scope
 - `scripts/check-content-boundaries.mjs` — hardened: fixed brittle CSS regex, added heuristic-limitation header comment
 - `.github/pull_request_template.md` — add interaction verification section distinguishing static vs browser checks
-- `.claude/CLAUDE.md` — add rendered-link and interaction check steps to local validation
+- `CLAUDE.md` — add rendered-link and interaction check steps to local validation
 - `.github/copilot-instructions.md` — same additions
 - `.cursor/rules/downstream-agent-rules.md` — add interaction verification requirements
 

--- a/.changeset/workflow-kit-rendered-interactions.md
+++ b/.changeset/workflow-kit-rendered-interactions.md
@@ -1,0 +1,36 @@
+---
+'@portfolio-engine/workflow-kit': minor
+---
+
+Add rendered interaction verification templates and prompts for downstream sites.
+
+This complements static rendered-link checks with browser-level smoke testing for CTAs, cards, navigation, and PDF/external links. The docs now distinguish static href validation from Playwright/browser interaction verification and update downstream PR checklist guidance.
+
+#### Agent update note
+
+Workflow-kit templates changed.
+
+Downstream agents should compare and update:
+
+- `.github/workflows/ci.yml` — add static rendered-link check step; optionally enable rendered interaction smoke
+- `scripts/check-rendered-links.mjs` — hardened: supports single-quoted hrefs, normalizes leading slashes, documents static-only scope
+- `scripts/check-content-boundaries.mjs` — hardened: fixed brittle CSS regex, added heuristic-limitation header comment
+- `.github/pull_request_template.md` — add interaction verification section distinguishing static vs browser checks
+- `.claude/CLAUDE.md` — add rendered-link and interaction check steps to local validation
+- `.github/copilot-instructions.md` — same additions
+- `.cursor/rules/downstream-agent-rules.md` — add interaction verification requirements
+
+New templates to copy (optional but recommended):
+
+- `scripts/check-rendered-interactions.mjs` — Playwright browser interaction smoke runner
+- `scripts/rendered-interactions.config.mjs` — copy from `rendered-interactions.config.example.mjs` and edit
+- prompts/`rendered-interaction-review.prompt.md` — browser interaction review prompt
+
+Setup for interaction smoke (if adopting):
+
+```bash
+pnpm add -D @playwright/test
+pnpm exec playwright install --with-deps chromium
+```
+
+Do not blindly overwrite downstream customizations. Copy new checks intentionally.

--- a/docs/packages/workflow-kit.md
+++ b/docs/packages/workflow-kit.md
@@ -60,6 +60,13 @@ if any of the above issues are present. This gap was exposed by downstream PR #6
 `jordan-site`:
 <https://github.com/rainonej/jordan-site/pull/60>
 
+**Concrete case study:** All hrefs were correct and static link checks passed, but browser
+clicks failed. The root cause was the decorative `.ambient-bg` layer from
+`@portfolio-engine/editorial-theme`: `aria-hidden` and behind the page (`-z-10`), but without
+`pointer-events: none`, so it still intercepted clicks and text selection. This bug is fixed
+upstream as of this release. The downstream lesson: decorative fixed background layers must
+explicitly disable pointer events regardless of `z-index` or `aria-hidden`.
+
 Use `check-rendered-interactions` when a change affects:
 
 - CTAs, buttons, or primary links

--- a/docs/packages/workflow-kit.md
+++ b/docs/packages/workflow-kit.md
@@ -11,22 +11,25 @@ usage instructions and the full template listing.
 **Boundary-check scripts** (`templates/scripts/`) — copy into your downstream `scripts/` directory
 and wire them into CI:
 
-| Script                         | What it catches                                                                  |
-| ------------------------------ | -------------------------------------------------------------------------------- |
-| `check-content-boundaries.mjs` | Content leaked into route/template/component files                               |
-| `check-schema-strictness.mjs`  | `.passthrough()`, type casts (errors); null fallbacks, many optionals (warnings) |
-| `check-rendered-links.mjs`     | Stale internal links, placeholder content                                        |
-| `check-unused.mjs`             | Unused files/exports (Knip wrapper)                                              |
-| `check-tooling-version.mjs`    | Drift from upstream templates                                                    |
+| Script                                     | What it catches                                                                  |
+| ------------------------------------------ | -------------------------------------------------------------------------------- |
+| `check-content-boundaries.mjs`             | Content leaked into route/template/component files                               |
+| `check-schema-strictness.mjs`              | `.passthrough()`, type casts (errors); null fallbacks, many optionals (warnings) |
+| `check-rendered-links.mjs`                 | Stale internal links, placeholder content (static hrefs only)                    |
+| `check-rendered-interactions.mjs`          | Browser-level CTA/card/nav click verification (Playwright)                       |
+| `rendered-interactions.config.example.mjs` | Example config for `check-rendered-interactions`                                 |
+| `check-unused.mjs`                         | Unused files/exports (Knip wrapper)                                              |
+| `check-tooling-version.mjs`                | Drift from upstream templates                                                    |
 
 **AI prompts** (`templates/prompts/`) — copy-paste into Claude Code, Cursor, or a PR review workflow:
 
-| Prompt                              | Purpose                                                    |
-| ----------------------------------- | ---------------------------------------------------------- |
-| `architecture-review.prompt.md`     | Check changed files for content/schema/template separation |
-| `downstream-upgrade.prompt.md`      | Apply a new Portfolio Engine release                       |
-| `content-boundary-review.prompt.md` | Detailed boundary check for a PR                           |
-| `visual-review.prompt.md`           | Visual design review (avoids content authoring)            |
+| Prompt                                  | Purpose                                                    |
+| --------------------------------------- | ---------------------------------------------------------- |
+| `architecture-review.prompt.md`         | Check changed files for content/schema/template separation |
+| `downstream-upgrade.prompt.md`          | Apply a new Portfolio Engine release                       |
+| `content-boundary-review.prompt.md`     | Detailed boundary check for a PR                           |
+| `visual-review.prompt.md`               | Visual design review (avoids content authoring)            |
+| `rendered-interaction-review.prompt.md` | Browser interaction review: CTAs, cards, nav, overlays     |
 
 **GitHub Actions template** (`templates/github/ci.yml`) — starter CI with type check,
 content boundary check, and build.
@@ -36,6 +39,35 @@ recommended extensions (Astro, MDX, YAML, ESLint, Prettier, Tailwind).
 
 **Cursor/MCP setup** (`templates/cursor/`) — architecture boundary rules and downstream
 agent rules for AI-assisted development.
+
+## Static rendered links vs browser interactions
+
+`check-rendered-links` verifies that `href` values in built HTML resolve to files in `dist/`.
+It does not verify that a user can click the element in a browser.
+
+`check-rendered-interactions` verifies that interactive elements — CTAs, cards, navigation —
+are actually clickable using Playwright's actionability checks. This catches classes of issues
+that static link checks cannot detect:
+
+- An overlay or `position: fixed` element covering a CTA
+- `pointer-events: none` on a link wrapper
+- A `z-index` layer in front of the clickable area
+- Nested anchors (`<a>` inside `<a>`) that produce undefined click behavior
+- The Vercel preview toolbar intercepting interaction in preview URLs
+
+A downstream refactor can pass static link checks while still breaking real click behavior
+if any of the above issues are present. This gap was exposed by downstream PR #60 in
+`jordan-site`:
+<https://github.com/rainonej/jordan-site/pull/60>
+
+Use `check-rendered-interactions` when a change affects:
+
+- CTAs, buttons, or primary links
+- Cards (project, research, writing)
+- Navigation (header, footer, mobile menu)
+- Overlays, hover layers, or layout wrappers
+- Links inside complex components
+- Vercel preview behavior
 
 ## Changeset policy for workflow-kit
 

--- a/packages/editorial-theme/src/components/AmbientBackground.astro
+++ b/packages/editorial-theme/src/components/AmbientBackground.astro
@@ -1,4 +1,5 @@
-<div aria-hidden="true" class="ambient-bg fixed inset-0 -z-10 overflow-hidden">
-  <div class="ambient-blob ambient-blob-amber"></div>
-  <div class="ambient-blob ambient-blob-stone"></div>
+{/* Decorative background only; must never intercept clicks or text selection. */}
+<div aria-hidden="true" class="ambient-bg pointer-events-none fixed inset-0 -z-10 overflow-hidden">
+  <div class="ambient-blob ambient-blob-amber pointer-events-none"></div>
+  <div class="ambient-blob ambient-blob-stone pointer-events-none"></div>
 </div>

--- a/packages/workflow-kit/README.md
+++ b/packages/workflow-kit/README.md
@@ -199,6 +199,13 @@ an overlay, nested anchor, z-index layer, or preview toolbar intercepts interact
 was exposed by downstream PR #60 in `jordan-site`:
 <https://github.com/rainonej/jordan-site/pull/60>
 
+**Concrete case study:** In that PR, all hrefs were correct and static link checks passed.
+But `.ambient-bg` — the decorative background component from `editorial-theme` — was
+`aria-hidden` and visually behind the page (`-z-10`), yet still intercepted clicks and text
+selection because it lacked `pointer-events: none`. Adding `pointer-events: none` to the
+ambient background layer restored all interactions. This bug is now fixed upstream in
+`@portfolio-engine/editorial-theme`.
+
 Use `check-rendered-interactions` (or equivalent Playwright tests) when a change affects:
 
 - CTAs, buttons, or primary links

--- a/packages/workflow-kit/README.md
+++ b/packages/workflow-kit/README.md
@@ -27,21 +27,24 @@ templates/
       downstream-agent-rules.md       Rules for AI agents making changes to downstream sites
 
   prompts/
-    architecture-review.prompt.md     Review changed files for content/schema/template separation
-    downstream-upgrade.prompt.md      How to apply a new Portfolio Engine release
-    content-boundary-review.prompt.md Detailed content boundary check for a PR
-    visual-review.prompt.md           Visual design review (avoids content authoring)
+    architecture-review.prompt.md          Review changed files for content/schema/template separation
+    downstream-upgrade.prompt.md           How to apply a new Portfolio Engine release
+    content-boundary-review.prompt.md      Detailed content boundary check for a PR
+    visual-review.prompt.md                Visual design review (avoids content authoring)
+    rendered-interaction-review.prompt.md  Browser interaction review: CTAs, cards, nav, overlays
 
   husky/
     pre-commit                      Git pre-commit hook — runs lint-staged (auto-fix before commit)
     lint-staged.config.mjs          lint-staged config (eslint --fix + prettier --write on staged files)
 
   scripts/
-    check-content-boundaries.mjs    Fail when content leaks into route/template/component files
-    check-rendered-links.mjs        Fail on stale internal links or placeholder content
-    check-schema-strictness.mjs     Fail on .passthrough(), type casts; warn on null fallbacks
-    check-unused.mjs                Knip wrapper for unused files, exports, and dependencies
-    check-tooling-version.mjs       Warn when upstream templates may have changed
+    check-content-boundaries.mjs             Fail when content leaks into route/template/component files
+    check-rendered-links.mjs                 Fail on stale internal links or placeholder content (static only)
+    check-rendered-interactions.mjs          Browser interaction smoke-test (Playwright — see below)
+    rendered-interactions.config.example.mjs Example config for check-rendered-interactions
+    check-schema-strictness.mjs              Fail on .passthrough(), type casts; warn on null fallbacks
+    check-unused.mjs                         Knip wrapper for unused files, exports, and dependencies
+    check-tooling-version.mjs                Warn when upstream templates may have changed
 ```
 
 ## How to use
@@ -185,6 +188,51 @@ import {
 
 Compose these into site-specific schemas in your downstream `src/content.config.ts`.
 Do not use `.passthrough()` on first-class content schemas.
+
+## Static rendered links vs browser interactions
+
+`check-rendered-links` verifies that `href` values in built HTML point to generated files in
+`dist/`. It does not verify that a user can click the element in a browser.
+
+A downstream refactor can pass static link checks while still breaking real click behavior if
+an overlay, nested anchor, z-index layer, or preview toolbar intercepts interaction. This gap
+was exposed by downstream PR #60 in `jordan-site`:
+<https://github.com/rainonej/jordan-site/pull/60>
+
+Use `check-rendered-interactions` (or equivalent Playwright tests) when a change affects:
+
+- CTAs, buttons, or primary links
+- Cards (project, research, writing)
+- Header or footer navigation
+- Overlays, hover layers, or layout wrappers
+- Links inside complex components
+- Vercel preview behavior
+
+### Setting up Playwright for interaction checks
+
+Copy the interaction smoke template from workflow-kit:
+
+```bash
+cp node_modules/@portfolio-engine/workflow-kit/templates/scripts/check-rendered-interactions.mjs scripts/
+cp node_modules/@portfolio-engine/workflow-kit/templates/scripts/rendered-interactions.config.example.mjs scripts/rendered-interactions.config.mjs
+```
+
+Install Playwright:
+
+```bash
+pnpm add -D @playwright/test
+pnpm exec playwright install --with-deps chromium
+```
+
+Edit `scripts/rendered-interactions.config.mjs` to match your site's routes and interactions,
+then run:
+
+```bash
+SITE_URL=https://your-preview.vercel.app node scripts/check-rendered-interactions.mjs
+```
+
+Add `check:rendered-interactions` to your `package.json` scripts and run it after deploying
+Vercel preview builds for changes that touch CTAs, cards, or navigation.
 
 ## Changeset policy
 

--- a/packages/workflow-kit/src/index.ts
+++ b/packages/workflow-kit/src/index.ts
@@ -38,10 +38,13 @@ export const TEMPLATE_PATHS = {
     downstreamUpgrade: 'templates/prompts/downstream-upgrade.prompt.md',
     contentBoundaryReview: 'templates/prompts/content-boundary-review.prompt.md',
     visualReview: 'templates/prompts/visual-review.prompt.md',
+    renderedInteractionReview: 'templates/prompts/rendered-interaction-review.prompt.md',
   },
   scripts: {
     checkContentBoundaries: 'templates/scripts/check-content-boundaries.mjs',
     checkRenderedLinks: 'templates/scripts/check-rendered-links.mjs',
+    checkRenderedInteractions: 'templates/scripts/check-rendered-interactions.mjs',
+    renderedInteractionsConfigExample: 'templates/scripts/rendered-interactions.config.example.mjs',
     checkSchemaStrictness: 'templates/scripts/check-schema-strictness.mjs',
     checkUnused: 'templates/scripts/check-unused.mjs',
     checkToolingVersion: 'templates/scripts/check-tooling-version.mjs',

--- a/packages/workflow-kit/templates/agent/CLAUDE.md
+++ b/packages/workflow-kit/templates/agent/CLAUDE.md
@@ -108,6 +108,32 @@ node scripts/check-content-boundaries.mjs
 node scripts/check-schema-strictness.mjs
 ```
 
+After build, run the static rendered-link check:
+
+```bash
+node scripts/check-rendered-links.mjs
+```
+
+This check validates that internal hrefs resolve to files in `dist/`. It does **not** prove
+that elements are visible, clickable, or free of overlay/z-index/nested-anchor issues.
+
+For changes that affect CTAs, cards, navigation, overlays, or layout wrappers, also run
+browser interaction verification:
+
+```bash
+SITE_URL=https://your-preview.vercel.app node scripts/check-rendered-interactions.mjs
+```
+
+If `scripts/check-rendered-interactions.mjs` is not present, follow the setup instructions
+in `node_modules/@portfolio-engine/workflow-kit/README.md`.
+
+When reporting work done in a PR, distinguish:
+
+- **Static rendered HTML verified** — output of `check-rendered-links` or equivalent
+- **Browser interaction verified** — Playwright output, Vercel preview URL, or manual steps
+
+Do not claim browser interactions were verified unless you actually clicked or ran Playwright.
+
 ## Visual QA
 
 After layout/style changes, inspect the site in a browser.

--- a/packages/workflow-kit/templates/agent/copilot-instructions.md
+++ b/packages/workflow-kit/templates/agent/copilot-instructions.md
@@ -54,7 +54,23 @@ If boundary-check scripts are present:
 ```bash
 node scripts/check-content-boundaries.mjs
 node scripts/check-schema-strictness.mjs
+node scripts/check-rendered-links.mjs
 ```
+
+`check-rendered-links` validates static hrefs. It does **not** prove elements are clickable.
+
+For changes that touch CTAs, cards, navigation, overlays, or layout wrappers, also run:
+
+```bash
+SITE_URL=https://your-preview.vercel.app node scripts/check-rendered-interactions.mjs
+```
+
+In the PR body, distinguish:
+
+- **Static rendered HTML verified** — `check-rendered-links` output or equivalent
+- **Browser interaction verified** — Playwright output, Vercel preview URL, or manual steps
+
+Do not claim browser interactions were verified unless you actually clicked or ran Playwright.
 
 ## Tooling rules
 

--- a/packages/workflow-kit/templates/cursor/rules/downstream-agent-rules.md
+++ b/packages/workflow-kit/templates/cursor/rules/downstream-agent-rules.md
@@ -49,3 +49,7 @@ do not blindly overwrite local customizations.
 - Use `as SomeType` casts on `entry.data` from content collections.
 - Claim browser interactions were verified unless you actually clicked elements or ran Playwright.
 - Mistake `check-rendered-links` (static href check) for proof that elements are clickable.
+- Assume a decorative layer is non-interactive just because it is `aria-hidden` or has a
+  negative `z-index`. Decorative background layers need explicit `pointer-events: none` to
+  avoid intercepting clicks and text selection. Search for `ambient-bg`, `fixed`, or `inset-0`
+  layers and verify they have `pointer-events-none`.

--- a/packages/workflow-kit/templates/cursor/rules/downstream-agent-rules.md
+++ b/packages/workflow-kit/templates/cursor/rules/downstream-agent-rules.md
@@ -21,6 +21,14 @@ Before editing `src/pages-local/`, `src/overrides/`, or package-level components
 - Authored content belongs in `src/content/`, not in Astro files.
 - Run `node scripts/check-content-boundaries.mjs` after your change.
 
+If the change touches CTAs, cards, navigation, overlays, or layout wrappers:
+
+- Run `node scripts/check-rendered-links.mjs` after build (validates static hrefs).
+- Also run browser interaction verification — static link checks cannot catch overlay,
+  pointer-events, z-index, or nested-anchor issues that break real clicks.
+- Use `node scripts/check-rendered-interactions.mjs` with a Vercel preview URL, or
+  use Playwright MCP / browser DevTools to verify CTAs and cards are actually clickable.
+
 ## Schema changes
 
 - Use primitives from `@portfolio-engine/schema` (MetricSchema, EvidenceItemSchema, etc.).
@@ -39,3 +47,5 @@ do not blindly overwrite local customizations.
 - Add content to route files or templates.
 - Invent new schema fields without updating all content files.
 - Use `as SomeType` casts on `entry.data` from content collections.
+- Claim browser interactions were verified unless you actually clicked elements or ran Playwright.
+- Mistake `check-rendered-links` (static href check) for proof that elements are clickable.

--- a/packages/workflow-kit/templates/github/ci.yml
+++ b/packages/workflow-kit/templates/github/ci.yml
@@ -81,3 +81,29 @@ jobs:
 
       - name: Build
         run: pnpm build
+
+      - name: Static rendered-link check
+        run: node scripts/check-rendered-links.mjs
+
+      # Rendered interaction smoke — only runs if the downstream repo has opted in by
+      # copying check-rendered-interactions.mjs to scripts/. This check uses Playwright
+      # to verify that CTAs, cards, and navigation are actually clickable in a browser.
+      # Static link checks (above) cannot catch overlay, pointer-events, or z-index issues.
+      #
+      # To enable: copy the template, install Playwright, and add check:rendered-interactions
+      # to your package.json scripts.
+      #   pnpm add -D @playwright/test
+      #   pnpm exec playwright install --with-deps chromium
+      #
+      # Then uncomment the step below and set SITE_URL in your repository secrets or
+      # pass a local server URL.
+      #
+      # - name: Rendered interaction smoke
+      #   run: |
+      #     if [ -f scripts/check-rendered-interactions.mjs ]; then
+      #       pnpm check:rendered-interactions
+      #     else
+      #       echo "No rendered interaction smoke configured; skipping."
+      #     fi
+      #   env:
+      #     SITE_URL: ${{ secrets.VERCEL_PREVIEW_URL }}

--- a/packages/workflow-kit/templates/github/pull_request_template.md
+++ b/packages/workflow-kit/templates/github/pull_request_template.md
@@ -8,9 +8,30 @@
 - [ ] No site-specific copy was added to `src/pages-local/**/*.astro`
 - [ ] No fallback strings (`?? ''`, `?? null`) were added for fields that belong in a schema
 - [ ] Schema changes use `.strict()` — no `.passthrough()` for first-class content
-- [ ] Internal links resolve (run `node scripts/check-rendered-links.mjs` after build)
+- [ ] `pnpm check:rendered-links` passed after build (static href validation)
 - [ ] `pnpm check` passes
 - [ ] `pnpm build` passes
+
+## Interaction verification
+
+<!-- Static link checks verify hrefs exist. They do NOT verify that elements are clickable. -->
+<!-- Complete this section whenever the change affects CTAs, cards, navigation, overlays, or layout wrappers. -->
+
+- [ ] Browser interaction smoke was performed for changed CTAs / cards / navigation
+- [ ] Vercel preview was checked, or PR explains why only local preview was available
+- [ ] PR body lists the routes and interactions verified
+
+**Static rendered HTML verified** (check-rendered-links output or equivalent):
+
+```
+<!-- paste output or note "N/A – no interactive changes" -->
+```
+
+**Browser interaction verified** (Playwright output, Vercel preview URL, or manual steps):
+
+```
+<!-- paste output, preview URL, or describe what was clicked and what happened -->
+```
 
 ## Portfolio Engine version
 

--- a/packages/workflow-kit/templates/github/pull_request_template.md
+++ b/packages/workflow-kit/templates/github/pull_request_template.md
@@ -8,7 +8,7 @@
 - [ ] No site-specific copy was added to `src/pages-local/**/*.astro`
 - [ ] No fallback strings (`?? ''`, `?? null`) were added for fields that belong in a schema
 - [ ] Schema changes use `.strict()` — no `.passthrough()` for first-class content
-- [ ] `pnpm check:rendered-links` passed after build (static href validation)
+- [ ] `node scripts/check-rendered-links.mjs` passed after build (static href validation)
 - [ ] `pnpm check` passes
 - [ ] `pnpm build` passes
 

--- a/packages/workflow-kit/templates/prompts/rendered-interaction-review.prompt.md
+++ b/packages/workflow-kit/templates/prompts/rendered-interaction-review.prompt.md
@@ -1,0 +1,126 @@
+# Rendered Interaction Review
+
+Use this prompt when you need to verify that a site's interactive elements work correctly
+in a real browser — not just that their hrefs exist in the static build.
+
+This prompt is different from `visual-review.prompt.md`, which focuses on visual design
+quality. This prompt focuses on whether users can actually click CTAs, cards, and navigation.
+
+---
+
+## Scope
+
+Review rendered browser behavior for:
+
+- **CTAs** — primary and secondary call-to-action buttons and links
+- **Card clicks** — project cards, research cards, writing cards
+- **Navigation** — header nav links, mobile menu, anchor links
+- **Download / open links** — resume PDF, external document links
+- **External links** — expected `target` and `rel` attributes
+- **Empty sections** — no section visible with a heading but no content
+- **Placeholder content** — no TODO, "Your Name Here", or Lorem ipsum visible
+- **Desktop and mobile** — repeat checks at a wide viewport and a narrow viewport
+
+Do **not** change content or design. Only diagnose interaction behavior.
+
+---
+
+## What to check
+
+For each of the following, report PASS or FAIL with route, element, expected behavior,
+actual behavior, suspected cause, and file pointer.
+
+### Homepage CTAs
+
+- Does the primary CTA (e.g. "View Work") navigate to the correct route?
+- Does the secondary CTA (e.g. "Download Resume") open the correct file or route?
+- Are the CTA elements actually clickable, or does something intercept the click?
+
+### Cards
+
+- Do project/research/writing cards navigate to their detail pages when clicked?
+- Is the clickable area the full card, or only part of it?
+- Are there nested anchors (`<a>` inside `<a>`) that could confuse click handling?
+
+### Header navigation
+
+- Does each nav link navigate to the correct route?
+- Do nav links work on mobile (if a hamburger menu is present, does it open and close)?
+
+### Related links
+
+- Do "Related" or "See also" links on detail pages work?
+- Are external links opening in a new tab with `rel="noopener noreferrer"`?
+
+### Resume / PDF links
+
+- Does the resume link open the PDF or route correctly?
+- If it opens in a new tab, is `target="_blank"` and `rel` set correctly?
+
+### Mailto / external links
+
+- Do mailto links open the email client?
+- Do external links have the expected `target` and `rel`.
+
+### Overlay / interception checks
+
+- Is there any `position: fixed`, `position: absolute`, or `inset-0` element that
+  sits above interactive elements and intercepts clicks?
+- Are `pointer-events: none` or `z-index` values hiding or blocking interactive areas?
+- Does the Vercel Toolbar or any preview banner intercept CTA clicks?
+
+### Nested anchor check
+
+- Search for `<a` elements inside other `<a` elements. The HTML content model forbids
+  nested interactive content — nested anchors produce undefined behavior in browsers.
+
+### Empty section check
+
+- Verify no section heading is visible with no body content beneath it.
+- Verify no route renders a completely blank page.
+
+---
+
+## Diagnostic steps
+
+When an interaction fails or is suspect, use the following to diagnose:
+
+1. **Playwright role-based locator** — locate the element with `getByRole('link', { name: /view work/i })`.
+   If the locator resolves but `.click()` throws, the element is obscured.
+
+2. **`document.elementFromPoint(x, y)`** — use the browser console to find what element
+   is at the pixel coordinates where the CTA appears. If it is not the `<a>` element,
+   something is covering it.
+
+3. **Inspect `pointer-events`, `z-index`, `position`** — in DevTools, check the computed
+   styles of the CTA and its ancestors for `pointer-events: none`, high `z-index` siblings,
+   or `position: absolute / fixed` overlays.
+
+4. **Search for overlay patterns in source** — grep or search the component tree for:
+   - `absolute`, `fixed`, `inset-0`, `z-`, `pointer-events`
+   - `<a` inside another `<a`
+
+---
+
+## References
+
+- Playwright actionability checks: <https://playwright.dev/docs/actionability>
+- Playwright locators (role-based): <https://playwright.dev/docs/locators>
+- MDN anchor element content model: <https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a>
+- Vercel Toolbar docs: <https://vercel.com/docs/vercel-toolbar>
+
+---
+
+## Output format
+
+Provide a PASS/FAIL table with one row per interaction checked:
+
+| Route | Element clicked       | Expected behavior                   | Actual behavior     | Suspected cause                                        | File pointer                   |
+| ----- | --------------------- | ----------------------------------- | ------------------- | ------------------------------------------------------ | ------------------------------ |
+| `/`   | "View Work" CTA       | Navigate to `/product-achievements` | Navigated correctly | —                                                      | —                              |
+| `/`   | "Download Resume" CTA | Open `/resume.pdf`                  | Click intercepted   | Overlay `div.hero-overlay` has `z-index: 10` above CTA | `src/components/Hero.astro:42` |
+
+After the table, list any additional findings (nested anchors, empty sections,
+placeholder content) as a bulleted list.
+
+Do not suggest content changes. Only report interaction issues and their suspected causes.

--- a/packages/workflow-kit/templates/prompts/rendered-interaction-review.prompt.md
+++ b/packages/workflow-kit/templates/prompts/rendered-interaction-review.prompt.md
@@ -68,6 +68,15 @@ actual behavior, suspected cause, and file pointer.
   sits above interactive elements and intercepts clicks?
 - Are `pointer-events: none` or `z-index` values hiding or blocking interactive areas?
 - Does the Vercel Toolbar or any preview banner intercept CTA clicks?
+- **Decorative background layers** — ambient gradient/blob backgrounds are a known
+  source of click interception. A layer can be `aria-hidden` and visually behind the
+  page (`-z-10`) yet still block clicks and text selection if it lacks `pointer-events:
+none`. In `jordan-site` PR #60, `.ambient-bg` was the root cause: static
+  rendered-link checks passed because hrefs were correct, but clicks failed in all
+  browsers until `pointer-events: none` was applied to the layer. Search specifically:
+  ```bash
+  rg -n "ambient-bg|fixed|inset-0|pointer-events" src packages
+  ```
 
 ### Nested anchor check
 
@@ -99,6 +108,11 @@ When an interaction fails or is suspect, use the following to diagnose:
 4. **Search for overlay patterns in source** — grep or search the component tree for:
    - `absolute`, `fixed`, `inset-0`, `z-`, `pointer-events`
    - `<a` inside another `<a`
+   - `ambient-bg`, `ambient-blob`, or any decorative gradient layer
+
+5. **Verify text selection** — if text cannot be selected on the page, a fixed overlay
+   likely intercepts all pointer events, not just clicks. This is the same class of bug
+   as click interception.
 
 ---
 

--- a/packages/workflow-kit/templates/scripts/check-content-boundaries.mjs
+++ b/packages/workflow-kit/templates/scripts/check-content-boundaries.mjs
@@ -10,6 +10,11 @@
  * NOTE: getCollection/getEntry in route files is intentional for the thin-host
  * pattern (route loads data, passes to template). This script does NOT flag it.
  *
+ * IMPORTANT: This is a heuristic guardrail, not a proof that all labels live in YAML.
+ * Short strings, generic UI labels, and some fallback labels may remain unless a
+ * downstream repo adopts stricter local policy. False negatives are expected for
+ * strings under 40 characters and for strings that look like CSS utility classes.
+ *
  * Copy this script to scripts/check-content-boundaries.mjs in your downstream repo.
  */
 
@@ -72,7 +77,7 @@ function looksLikeAuthoredCopy(str) {
     if (cssLike / tokens.length >= 0.65) return false;
   }
   // Single-token CSS expression (e.g. bg-[color-mix(in_srgb,var(--…)_15%,…)])
-  if (tokens.length === 1 && /^[\w/[\]:!.()\-,%#_]+$/.test(str)) return false;
+  if (tokens.length === 1 && /^[\w/[\]:!.()\\,%#_-]+$/.test(str)) return false;
   return true;
 }
 

--- a/packages/workflow-kit/templates/scripts/check-rendered-interactions.mjs
+++ b/packages/workflow-kit/templates/scripts/check-rendered-interactions.mjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+/**
+ * Browser interaction smoke-test for downstream Portfolio Engine sites.
+ *
+ * This is browser interaction verification.
+ * It complements, but does not replace, check-rendered-links.
+ *
+ * check-rendered-links verifies that href values in built HTML point to generated
+ * files. This script verifies that users can actually click CTAs, cards, and
+ * navigation in a real browser — catching issues like invisible overlays, nested
+ * anchors, z-index conflicts, and Vercel toolbar interception that static checks
+ * cannot detect.
+ *
+ * Requirements:
+ *   pnpm add -D @playwright/test
+ *   pnpm exec playwright install --with-deps chromium
+ *
+ * Usage:
+ *   node scripts/check-rendered-interactions.mjs
+ *   SITE_URL=https://my-preview.vercel.app node scripts/check-rendered-interactions.mjs
+ *
+ * Copy this script to scripts/check-rendered-interactions.mjs in your downstream repo.
+ * Copy rendered-interactions.config.example.mjs to scripts/rendered-interactions.config.mjs
+ * and edit it to match your site's routes and interactions.
+ */
+
+import { chromium } from '@playwright/test';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const ROOT = process.cwd();
+const configPath = join(ROOT, 'scripts', 'rendered-interactions.config.mjs');
+
+if (!existsSync(configPath)) {
+  console.error(
+    'check-rendered-interactions: config not found.\n' +
+      '  Copy rendered-interactions.config.example.mjs to\n' +
+      '  scripts/rendered-interactions.config.mjs and edit it for your site.',
+  );
+  process.exit(1);
+}
+
+const { default: config } = await import(pathToFileURL(configPath).href);
+
+const { baseUrl, routes = [], viewports = [], clickChecks = [] } = config;
+
+if (!baseUrl) {
+  console.error('check-rendered-interactions: config must export a baseUrl.');
+  process.exit(1);
+}
+
+const errors = [];
+const passes = [];
+
+const browser = await chromium.launch();
+
+for (const viewport of viewports.length > 0
+  ? viewports
+  : [{ name: 'default', width: 1280, height: 800 }]) {
+  const context = await browser.newContext({
+    viewport: { width: viewport.width, height: viewport.height },
+  });
+  const page = await context.newPage();
+
+  // Route reachability checks — assert h1 is visible on each route.
+  for (const route of routes) {
+    const url = baseUrl.replace(/\/$/, '') + route;
+    try {
+      await page.goto(url, { waitUntil: 'networkidle' });
+      const h1 = page.locator('h1').first();
+      const visible = await h1.isVisible().catch(() => false);
+      if (visible) {
+        passes.push({ viewport: viewport.name, route, check: 'h1 visible', result: 'PASS' });
+      } else {
+        errors.push({
+          viewport: viewport.name,
+          route,
+          check: 'h1 visible',
+          result: 'FAIL',
+          detail: 'No visible <h1> found on page.',
+        });
+      }
+    } catch (err) {
+      errors.push({
+        viewport: viewport.name,
+        route,
+        check: 'page load',
+        result: 'FAIL',
+        detail: String(err.message),
+      });
+    }
+  }
+
+  // Click interaction checks.
+  for (const check of clickChecks) {
+    const { from, role, name, expectedUrl, allowNewPage = false, note } = check;
+    const url = baseUrl.replace(/\/$/, '') + from;
+    try {
+      await page.goto(url, { waitUntil: 'networkidle' });
+
+      const locator = page.getByRole(role, { name });
+      const isVisible = await locator
+        .first()
+        .isVisible()
+        .catch(() => false);
+
+      if (!isVisible) {
+        errors.push({
+          viewport: viewport.name,
+          route: from,
+          check: `${role}[name=${name}] clickable`,
+          result: 'FAIL',
+          detail: `Element not visible. Check for overlay, z-index, or pointer-events issues.${note ? ' Note: ' + note : ''}`,
+        });
+        continue;
+      }
+
+      // Playwright actionability check: click() will throw if the element is
+      // obscured, disabled, or not stable — this catches overlay interception.
+      if (allowNewPage) {
+        const [newPage] = await Promise.all([
+          context.waitForEvent('page'),
+          locator.first().click(),
+        ]);
+        await newPage.waitForLoadState('networkidle');
+        const finalUrl = newPage.url();
+        if (expectedUrl && !expectedUrl.test(finalUrl)) {
+          errors.push({
+            viewport: viewport.name,
+            route: from,
+            check: `${role}[name=${name}] → ${String(expectedUrl)}`,
+            result: 'FAIL',
+            detail: `Opened new page at ${finalUrl}, expected ${String(expectedUrl)}.${note ? ' Note: ' + note : ''}`,
+          });
+        } else {
+          passes.push({
+            viewport: viewport.name,
+            route: from,
+            check: `${role}[name=${name}] → ${String(expectedUrl)}`,
+            result: 'PASS',
+          });
+        }
+        await newPage.close();
+      } else {
+        await locator.first().click();
+        await page.waitForLoadState('networkidle');
+        const finalUrl = page.url();
+        if (expectedUrl && !expectedUrl.test(finalUrl)) {
+          errors.push({
+            viewport: viewport.name,
+            route: from,
+            check: `${role}[name=${name}] → ${String(expectedUrl)}`,
+            result: 'FAIL',
+            detail: `Navigated to ${finalUrl}, expected ${String(expectedUrl)}.${note ? ' Note: ' + note : ''}`,
+          });
+        } else {
+          passes.push({
+            viewport: viewport.name,
+            route: from,
+            check: `${role}[name=${name}] → ${String(expectedUrl)}`,
+            result: 'PASS',
+          });
+        }
+      }
+    } catch (err) {
+      errors.push({
+        viewport: viewport.name,
+        route: from,
+        check: `${role}[name=${name}] clickable`,
+        result: 'FAIL',
+        detail: `${err.message}${note ? ' Note: ' + note : ''}`,
+      });
+    }
+  }
+
+  await context.close();
+}
+
+await browser.close();
+
+// Report results.
+const allResults = [...passes, ...errors];
+
+console.log('\ncheck-rendered-interactions results:\n');
+console.log(['Viewport', 'Route', 'Check', 'Result', 'Detail'].map((h) => h.padEnd(18)).join('  '));
+console.log('-'.repeat(100));
+
+for (const r of allResults) {
+  console.log(
+    [r.viewport, r.route, r.check, r.result, r.detail ?? '']
+      .map((v) => String(v).padEnd(18))
+      .join('  '),
+  );
+}
+
+if (errors.length > 0) {
+  console.error(`\ncheck-rendered-interactions: ${errors.length} failure(s). See table above.`);
+  process.exit(1);
+}
+
+console.log(`\ncheck-rendered-interactions: all ${passes.length} check(s) passed.`);

--- a/packages/workflow-kit/templates/scripts/check-rendered-interactions.mjs
+++ b/packages/workflow-kit/templates/scripts/check-rendered-interactions.mjs
@@ -72,7 +72,7 @@ for (const viewport of viewports.length > 0
   for (const route of routes) {
     const url = baseUrl.replace(/\/$/, '') + route;
     try {
-      await page.goto(url, { waitUntil: 'networkidle' });
+      await page.goto(url, { waitUntil: 'load' });
       const h1 = page.locator('h1').first();
       const visible = await h1.isVisible().catch(() => false);
       if (visible) {
@@ -102,7 +102,7 @@ for (const viewport of viewports.length > 0
     const { from, role, name, expectedUrl, allowNewPage = false, note } = check;
     const url = baseUrl.replace(/\/$/, '') + from;
     try {
-      await page.goto(url, { waitUntil: 'networkidle' });
+      await page.goto(url, { waitUntil: 'load' });
 
       const locator = page.getByRole(role, { name });
       const isVisible = await locator
@@ -123,50 +123,47 @@ for (const viewport of viewports.length > 0
 
       // Playwright actionability check: click() will throw if the element is
       // obscured, disabled, or not stable — this catches overlay interception.
+      let finalUrl;
       if (allowNewPage) {
-        const [newPage] = await Promise.all([
-          context.waitForEvent('page'),
-          locator.first().click(),
-        ]);
-        await newPage.waitForLoadState('networkidle');
-        const finalUrl = newPage.url();
-        if (expectedUrl && !expectedUrl.test(finalUrl)) {
-          errors.push({
-            viewport: viewport.name,
-            route: from,
-            check: `${role}[name=${name}] → ${String(expectedUrl)}`,
-            result: 'FAIL',
-            detail: `Opened new page at ${finalUrl}, expected ${String(expectedUrl)}.${note ? ' Note: ' + note : ''}`,
-          });
+        // allowNewPage: true means the click may open a new tab/popup OR navigate the
+        // current tab (e.g. inline PDF, same-origin redirect). Register the new-tab
+        // listener before clicking to avoid race conditions.
+        const newTabPromise = context.waitForEvent('page', { timeout: 2000 }).catch(() => null);
+        await locator.first().click();
+        const newTab = await newTabPromise;
+        if (newTab) {
+          // New tab or popup opened.
+          await newTab.waitForLoadState('load').catch(() => {});
+          finalUrl = newTab.url();
+          await newTab.close();
         } else {
-          passes.push({
-            viewport: viewport.name,
-            route: from,
-            check: `${role}[name=${name}] → ${String(expectedUrl)}`,
-            result: 'PASS',
-          });
+          // Same-tab navigation. Note: if the link triggers a file download, the
+          // current URL may not change — verify download links by href attribute
+          // rather than relying on this click check.
+          await page.waitForLoadState('load').catch(() => {});
+          finalUrl = page.url();
         }
-        await newPage.close();
       } else {
         await locator.first().click();
-        await page.waitForLoadState('networkidle');
-        const finalUrl = page.url();
-        if (expectedUrl && !expectedUrl.test(finalUrl)) {
-          errors.push({
-            viewport: viewport.name,
-            route: from,
-            check: `${role}[name=${name}] → ${String(expectedUrl)}`,
-            result: 'FAIL',
-            detail: `Navigated to ${finalUrl}, expected ${String(expectedUrl)}.${note ? ' Note: ' + note : ''}`,
-          });
-        } else {
-          passes.push({
-            viewport: viewport.name,
-            route: from,
-            check: `${role}[name=${name}] → ${String(expectedUrl)}`,
-            result: 'PASS',
-          });
-        }
+        await page.waitForLoadState('load').catch(() => {});
+        finalUrl = page.url();
+      }
+
+      if (expectedUrl && !expectedUrl.test(finalUrl)) {
+        errors.push({
+          viewport: viewport.name,
+          route: from,
+          check: `${role}[name=${name}] → ${String(expectedUrl)}`,
+          result: 'FAIL',
+          detail: `Navigated to ${finalUrl}, expected ${String(expectedUrl)}.${note ? ' Note: ' + note : ''}`,
+        });
+      } else {
+        passes.push({
+          viewport: viewport.name,
+          route: from,
+          check: `${role}[name=${name}] → ${String(expectedUrl)}`,
+          result: 'PASS',
+        });
       }
     } catch (err) {
       // On click failure, try to report what element is actually at the click point.

--- a/packages/workflow-kit/templates/scripts/check-rendered-interactions.mjs
+++ b/packages/workflow-kit/templates/scripts/check-rendered-interactions.mjs
@@ -11,6 +11,11 @@
  * anchors, z-index conflicts, and Vercel toolbar interception that static checks
  * cannot detect.
  *
+ * Known failure class: decorative background layers (e.g. ambient-bg, gradient blobs)
+ * can intercept clicks and text selection even when aria-hidden and behind the page
+ * (z-index: -1 or lower), if they lack pointer-events: none. If clicks fail but hrefs
+ * are correct, inspect fixed/absolute background layers first.
+ *
  * Requirements:
  *   pnpm add -D @playwright/test
  *   pnpm exec playwright install --with-deps chromium
@@ -164,12 +169,46 @@ for (const viewport of viewports.length > 0
         }
       }
     } catch (err) {
+      // On click failure, try to report what element is actually at the click point.
+      // This catches the ambient-background / overlay interception pattern, where a
+      // decorative layer sits above the interactive element and blocks the click.
+      let interceptInfo = '';
+      try {
+        const locator = page.getByRole(role, { name });
+        const box = await locator
+          .first()
+          .boundingBox()
+          .catch(() => null);
+        if (box) {
+          const hit = await page.evaluate(
+            ({ x, y }) => {
+              // Runs in browser context — document and getComputedStyle are browser globals.
+              const el = document.elementFromPoint(x, y); // eslint-disable-line no-undef
+              if (!el) return null;
+              const s = getComputedStyle(el); // eslint-disable-line no-undef
+              return {
+                tag: el.tagName,
+                className: el.getAttribute('class')?.slice(0, 80),
+                pointerEvents: s.pointerEvents,
+                position: s.position,
+                zIndex: s.zIndex,
+              };
+            },
+            { x: box.x + box.width / 2, y: box.y + box.height / 2 },
+          );
+          if (hit) {
+            interceptInfo = ` Intercepted by: <${hit.tag} class="${hit.className}" style="pointer-events:${hit.pointerEvents};position:${hit.position};z-index:${hit.zIndex}">`;
+          }
+        }
+      } catch {
+        // diagnostic failure is non-fatal
+      }
       errors.push({
         viewport: viewport.name,
         route: from,
         check: `${role}[name=${name}] clickable`,
         result: 'FAIL',
-        detail: `${err.message}${note ? ' Note: ' + note : ''}`,
+        detail: `${err.message}${interceptInfo}${note ? ' Note: ' + note : ''}`,
       });
     }
   }

--- a/packages/workflow-kit/templates/scripts/check-rendered-links.mjs
+++ b/packages/workflow-kit/templates/scripts/check-rendered-links.mjs
@@ -9,6 +9,11 @@
  * - No placeholder strings appear in public HTML
  * - No stale /work/ or /writing/ links if those routes were renamed
  *
+ * IMPORTANT: This script verifies static rendered hrefs.
+ * It does not prove the element is visible, clickable, unobscured, or reachable
+ * through browser interaction. For that, use the rendered interaction smoke template
+ * (scripts/check-rendered-interactions.mjs) with Playwright.
+ *
  * Copy this script to scripts/check-rendered-links.mjs in your downstream repo.
  * Edit RENAMED_ROUTES and PLACEHOLDER_STRINGS to match your site.
  *
@@ -29,6 +34,9 @@ const WARN_ONLY = process.argv.includes('--warn-only');
 // Routes that were renamed in this downstream site.
 // Format: ['/old-route', '/new-route']
 // If you renamed /work to /projects, add ['/work', '/projects'].
+// Downstream repos MUST customize this list to match their own route history.
+// Example: if you previously used /work and renamed it to /product-achievements,
+// add ['/work', '/product-achievements'].
 const RENAMED_ROUTES = [
   // ['/work', '/projects'],
 ];
@@ -80,15 +88,17 @@ for (const htmlFile of htmlFiles) {
     }
   }
 
-  // Check internal hrefs resolve
-  const hrefMatches = src.matchAll(/href="(\/[^"#?]+)"/g);
+  // Check internal hrefs resolve. Matches both single- and double-quoted hrefs.
+  const hrefMatches = src.matchAll(/href=(["'])(\/[^"'#?]+)\1/g);
   for (const m of hrefMatches) {
-    const href = m[1];
-    const candidate1 = join(DIST, href, 'index.html');
-    const candidate2 = join(DIST, href.replace(/\/$/, '') + '.html');
-    const candidate3 = join(DIST, href);
+    const href = m[2];
+    // Normalize leading slash before joining with DIST to avoid double-slash paths.
+    const hrefRel = href.replace(/^\/+/, '');
+    const candidate1 = join(DIST, hrefRel, 'index.html');
+    const candidate2 = join(DIST, hrefRel.replace(/\/$/, '') + '.html');
+    const candidate3 = join(DIST, hrefRel);
     if (!existsSync(candidate1) && !existsSync(candidate2) && !existsSync(candidate3)) {
-      const msg = `  ${rel}  [dead-link]  href="${href}" does not resolve in dist/`;
+      const msg = `  ${rel}  [dead-link]  href="${href}" does not resolve in ${DIST}`;
       if (WARN_ONLY) warnings.push(msg);
       else errors.push(msg);
     }

--- a/packages/workflow-kit/templates/scripts/rendered-interactions.config.example.mjs
+++ b/packages/workflow-kit/templates/scripts/rendered-interactions.config.example.mjs
@@ -6,8 +6,12 @@
  *
  * The checks below are based on the failure mode exposed by jordan-site PR #60,
  * where static rendered-link checks passed but homepage CTAs, resume links, and
- * research cards were not reliably clickable in a real browser due to overlay,
- * z-index, or nested-anchor issues.
+ * research cards were not reliably clickable in a real browser.
+ *
+ * Root cause: the decorative .ambient-bg layer from @portfolio-engine/editorial-theme
+ * was aria-hidden and visually behind the page (-z-10), but lacked pointer-events:none.
+ * It intercepted all clicks and text selection. This is now fixed upstream, but if you
+ * see clicks fail while hrefs are correct, check decorative fixed/background layers first.
  *
  * See check-rendered-interactions.mjs for the runner.
  */

--- a/packages/workflow-kit/templates/scripts/rendered-interactions.config.example.mjs
+++ b/packages/workflow-kit/templates/scripts/rendered-interactions.config.example.mjs
@@ -1,0 +1,66 @@
+/**
+ * Example rendered interaction config for downstream Portfolio Engine sites.
+ *
+ * Copy this file to scripts/rendered-interactions.config.mjs in your downstream
+ * repo and edit it to match your site's routes, viewports, and interactions.
+ *
+ * The checks below are based on the failure mode exposed by jordan-site PR #60,
+ * where static rendered-link checks passed but homepage CTAs, resume links, and
+ * research cards were not reliably clickable in a real browser due to overlay,
+ * z-index, or nested-anchor issues.
+ *
+ * See check-rendered-interactions.mjs for the runner.
+ */
+
+export default {
+  // Base URL for the deployed or local preview to test.
+  // Override with SITE_URL env var for Vercel previews.
+  baseUrl: process.env.SITE_URL ?? 'http://localhost:4321',
+
+  // Routes to visit. The runner asserts that a visible <h1> exists on each.
+  routes: ['/', '/product-achievements', '/research', '/resume', '/contact'],
+
+  // Viewports to test across. The runner repeats all checks on each viewport.
+  viewports: [
+    { name: 'desktop', width: 1440, height: 1000 },
+    { name: 'mobile', width: 390, height: 844 },
+  ],
+
+  // Click interaction checks.
+  // Each entry navigates to `from`, locates the element by role + name, clicks it,
+  // and asserts the resulting URL matches `expectedUrl`.
+  //
+  // Playwright's click() is actionability-checked: if the element is obscured by an
+  // overlay, has pointer-events:none, or is inside a nested anchor, it will throw —
+  // which is exactly the class of issues that static rendered-link checks miss.
+  clickChecks: [
+    // Homepage primary CTA — navigates to the work/projects/achievements page.
+    // Adjust the name pattern and expectedUrl to match your site's copy.
+    {
+      from: '/',
+      role: 'link',
+      name: /view work/i,
+      expectedUrl: /\/work|\/projects|\/product-achievements/,
+    },
+
+    // Homepage resume/download link — may open in a new tab.
+    // Set allowNewPage: true when the link opens a PDF or external page.
+    {
+      from: '/',
+      role: 'link',
+      name: /resume/i,
+      expectedUrl: /\/resume(\.pdf)?/,
+      allowNewPage: true,
+    },
+
+    // Research card — verify a real card click navigates to a detail page.
+    // Replace the name pattern with a specific article title from your content.
+    {
+      from: '/research',
+      role: 'link',
+      name: /.+/,
+      expectedUrl: /\/research\/.+/,
+      note: 'Replace with a specific article title in downstream repos.',
+    },
+  ],
+};


### PR DESCRIPTION
## Summary

Adds workflow-kit support for rendered browser interaction verification and fixes the upstream ambient background bug exposed by downstream `jordan-site` PR #60.

Downstream example:
- https://github.com/rainonej/jordan-site/pull/60

## Root cause from downstream

`jordan-site` PR #60 passed static rendered-link checks: hrefs existed and pointed to valid routes. But real browser clicks failed in all environments — plain Vercel preview, Vercel Toolbar hidden, incognito window.

The root cause was `AmbientBackground.astro` from `@portfolio-engine/editorial-theme`. It was `aria-hidden` and visually behind the page (`-z-10`), but lacked `pointer-events: none`. The decorative layer intercepted clicks and text selection on every page. Adding `pointer-events: none` to `.ambient-bg` restored all interactions.

Key lesson: a decorative background can have correct HTML/ARIA semantics and still block clicks unless pointer events are explicitly disabled. Static rendered-link checks cannot catch this — the hrefs were correct the entire time.

## What changed

**Bug fix — `@portfolio-engine/editorial-theme`:**
- `AmbientBackground.astro` — add `pointer-events-none` to the ambient background and its child blobs so the decorative layer can never intercept clicks or text selection

**Hardened — `@portfolio-engine/workflow-kit`:**
- `check-rendered-links.mjs` — support single- and double-quoted hrefs; normalize leading slashes before joining against dist; add header comment distinguishing static href checks from browser interaction
- `check-content-boundaries.mjs` — fix broken single-token CSS regex (unescaped `]` was closing char class early); add header comment documenting heuristic limitations

**New templates — `@portfolio-engine/workflow-kit`:**
- `check-rendered-interactions.mjs` — Playwright browser smoke runner: visits routes, checks `<h1>` visibility, runs actionability-checked click tests; on failure runs `elementFromPoint` diagnostic to identify the intercepting element
- `rendered-interactions.config.example.mjs` — example config covering CTA/resume/card checks in desktop + mobile viewports
- `rendered-interaction-review.prompt.md` — browser interaction review prompt focused on clickability, overlays, nested anchors, text selection, and the ambient-bg failure class

**Updated downstream templates:**
- Workflow-kit README and `docs/packages/workflow-kit.md` — add "Static rendered links vs browser interactions" section with the concrete ambient-bg case study
- `pull_request_template.md` — add interaction verification section distinguishing static HTML from browser clicks
- `CLAUDE.md` + `copilot-instructions.md` — add rendered-link check + browser interaction check steps; require PR body to distinguish static vs browser verification
- `downstream-agent-rules.md` — add rule against treating aria-hidden/negative-z-index decorative layers as non-interactive without `pointer-events: none`
- `ci.yml` — add static rendered-link check step; add commented optional Playwright smoke step

**Changesets:**
- `@portfolio-engine/editorial-theme`: patch (ambient bg pointer-events fix)
- `@portfolio-engine/workflow-kit`: minor (new templates/scripts/prompts)

## Verification

Commands run:

```bash
pnpm format
pnpm lint
pnpm --filter @portfolio-engine/workflow-kit build
pnpm --filter @portfolio-engine/editorial-theme build
```

All passed.

## Notes for reviewers

Please review:
- Whether `pointer-events-none` on `AmbientBackground.astro` is the right fix vs a CSS-only approach
- Whether the new interaction templates are generic enough for downstream sites (no jordan-site-specific content hardcoded)
- Whether the static-vs-browser distinction is clear enough for AI agents reading the docs/checklists
- Whether the `elementFromPoint` diagnostic in `check-rendered-interactions.mjs` is useful
- Whether the agent migration note in the editorial-theme changeset correctly identifies the only consumer action needed (removing redundant local CSS workarounds)