### PR TITLE
fix(workflow-kit): bug fixes and CI template improvements (#149)

### DIFF
--- a/.changeset/workflow-kit-issue-149-fixes.md
+++ b/.changeset/workflow-kit-issue-149-fixes.md
@@ -1,0 +1,28 @@
+---
+'@portfolio-engine/workflow-kit': patch
+---
+
+Fix `check-rendered-interactions.mjs` bugs and add CI template improvements.
+
+#### Bug fixes
+
+- **Route reachability:** replace `h1` visibility check with `<main>` presence. Visually-hidden `h1`s (`clip-path: inset(50%)`) return `false` from `isVisible()` even when the page rendered correctly; some templates emit no `h1` at all. Every template wraps content in `<main>`, making it the universal render signal.
+- **Safe error serialization:** both catch blocks now use `err instanceof Error ? err.message : String(err)` so non-Error throws (string rejects, `null`) produce accurate diagnostics instead of `"undefined"`.
+
+#### New template
+
+- **`rendered-interactions.yml`:** deployment_status-triggered GitHub Actions workflow that runs `pnpm check:rendered-interactions` against Vercel preview URLs automatically, with no polling or manual URL wiring.
+
+#### CI template improvements (`ci.yml`)
+
+- Add `check:tooling-version` as a blocking step in the `check` job so workflow-kit version drift is caught in CI rather than at runtime.
+- Add non-blocking `unused` job (`continue-on-error: true`) for knip dead-code auditing — visible signal without hard-blocking merges on false positives.
+- Add descriptive `name:` fields to all jobs (`Format & lint`, `Types, docs & schema`, `Build, smoke & links`) so GitHub Actions failure notices are unambiguous.
+
+#### Agent update note
+
+Workflow-kit templates changed. Downstream repos should re-copy:
+
+- `scripts/check-rendered-interactions.mjs` — pick up the `<main>` check and safe error serialization
+- `.github/workflows/rendered-interactions.yml` — new file; add to enable deployment-triggered interaction checks
+- `.github/workflows/ci.yml` — pick up tooling-version step, unused job, and job names

--- a/packages/workflow-kit/README.md
+++ b/packages/workflow-kit/README.md
@@ -12,6 +12,7 @@ templates/
 
   github/
     ci.yml                          GitHub Actions CI template
+    rendered-interactions.yml       Vercel deployment_status-triggered interaction checks
     pull_request_template.md        PR checklist for content/schema discipline
     issue_template.md               Issue template
 
@@ -217,11 +218,13 @@ Use `check-rendered-interactions` (or equivalent Playwright tests) when a change
 
 ### Setting up Playwright for interaction checks
 
-Copy the interaction smoke template from workflow-kit:
+Copy the interaction smoke template and the CI workflow from workflow-kit:
 
 ```bash
 cp node_modules/@portfolio-engine/workflow-kit/templates/scripts/check-rendered-interactions.mjs scripts/
 cp node_modules/@portfolio-engine/workflow-kit/templates/scripts/rendered-interactions.config.example.mjs scripts/rendered-interactions.config.mjs
+mkdir -p .github/workflows
+cp node_modules/@portfolio-engine/workflow-kit/templates/github/rendered-interactions.yml .github/workflows/
 ```
 
 Install Playwright:
@@ -238,8 +241,11 @@ then run:
 SITE_URL=https://your-preview.vercel.app node scripts/check-rendered-interactions.mjs
 ```
 
-Add `check:rendered-interactions` to your `package.json` scripts and run it after deploying
-Vercel preview builds for changes that touch CTAs, cards, or navigation.
+Add `check:rendered-interactions` to your `package.json` scripts.
+
+The `rendered-interactions.yml` workflow triggers on Vercel `deployment_status` events — it
+runs automatically when Vercel marks a deployment successful, with `SITE_URL` set from
+`github.event.deployment_status.environment_url`. No polling or manual URL wiring needed.
 
 ## Changeset policy
 
@@ -253,11 +259,15 @@ Workflow-kit templates changed.
 Downstream agents should compare and update:
 
 - `.github/workflows/ci.yml`
+- `.github/workflows/rendered-interactions.yml`
 - `.vscode/extensions.json`
 - `.vscode/settings.json`
 - `.cursor/rules/portfolio-engine-boundaries.md`
 - `scripts/check-content-boundaries.mjs`
+- `scripts/check-rendered-interactions.mjs`
+- `scripts/rendered-interactions.config.example.mjs`
 - `scripts/check-schema-strictness.mjs`
+- `scripts/check-tooling-version.mjs`
 
 Do not blindly overwrite downstream customizations. Copy the new checks intentionally.
 ```

--- a/packages/workflow-kit/templates/github/ci.yml
+++ b/packages/workflow-kit/templates/github/ci.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   lint:
+    name: Format & lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -35,6 +36,7 @@ jobs:
         run: pnpm format:check
 
   check:
+    name: Types, docs & schema
     runs-on: ubuntu-latest
     needs: lint
     steps:
@@ -61,7 +63,11 @@ jobs:
       - name: Schema strictness check
         run: node scripts/check-schema-strictness.mjs
 
+      - name: Tooling version check
+        run: pnpm check:tooling-version
+
   build:
+    name: Build, smoke & links
     runs-on: ubuntu-latest
     needs: check
     steps:
@@ -107,3 +113,26 @@ jobs:
       #     fi
       #   env:
       #     SITE_URL: ${{ secrets.VERCEL_PREVIEW_URL }}
+
+  unused:
+    name: Dead code audit
+    runs-on: ubuntu-latest
+    needs: lint
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Unused files and exports check
+        run: pnpm check:unused

--- a/packages/workflow-kit/templates/github/rendered-interactions.yml
+++ b/packages/workflow-kit/templates/github/rendered-interactions.yml
@@ -1,0 +1,42 @@
+# Portfolio Engine — downstream rendered-interactions workflow template
+# Copy this to .github/workflows/rendered-interactions.yml in your downstream repo.
+#
+# Triggers on deployment_status (fires when Vercel marks a deployment successful).
+# No polling or timed delay needed — the event carries the deployment URL directly.
+
+name: Rendered Interactions
+
+on:
+  deployment_status:
+
+jobs:
+  rendered-interactions:
+    name: Rendered interaction checks
+    runs-on: ubuntu-latest
+    if: >
+      github.event.deployment_status.state == 'success' &&
+      contains(github.event.deployment_status.environment_url, '.vercel.app')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.deployment.sha }}
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Rendered interaction checks
+        run: pnpm check:rendered-interactions
+        env:
+          SITE_URL: ${{ github.event.deployment_status.environment_url }}

--- a/packages/workflow-kit/templates/github/rendered-interactions.yml
+++ b/packages/workflow-kit/templates/github/rendered-interactions.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version-file: .nvmrc
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies

--- a/packages/workflow-kit/templates/scripts/check-rendered-interactions.mjs
+++ b/packages/workflow-kit/templates/scripts/check-rendered-interactions.mjs
@@ -68,22 +68,25 @@ for (const viewport of viewports.length > 0
   });
   const page = await context.newPage();
 
-  // Route reachability checks — assert h1 is visible on each route.
+  // Route reachability checks — assert <main> is present on each route.
+  // Using <main> rather than h1 visibility because: some templates visually-hide
+  // their h1 (clip-path: inset(50%)) and isVisible() returns false even when the
+  // page rendered correctly; others use h2 via SiteSectionHeader and emit no h1.
+  // Every template wraps content in a semantic <main>, making it a reliable signal.
   for (const route of routes) {
     const url = baseUrl.replace(/\/$/, '') + route;
     try {
       await page.goto(url, { waitUntil: 'load' });
-      const h1 = page.locator('h1').first();
-      const visible = await h1.isVisible().catch(() => false);
-      if (visible) {
-        passes.push({ viewport: viewport.name, route, check: 'h1 visible', result: 'PASS' });
+      const count = await page.locator('main').count();
+      if (count > 0) {
+        passes.push({ viewport: viewport.name, route, check: 'main present', result: 'PASS' });
       } else {
         errors.push({
           viewport: viewport.name,
           route,
-          check: 'h1 visible',
+          check: 'main present',
           result: 'FAIL',
-          detail: 'No visible <h1> found on page.',
+          detail: 'No <main> found in DOM.',
         });
       }
     } catch (err) {
@@ -92,7 +95,7 @@ for (const viewport of viewports.length > 0
         route,
         check: 'page load',
         result: 'FAIL',
-        detail: String(err.message),
+        detail: err instanceof Error ? err.message : String(err),
       });
     }
   }
@@ -205,7 +208,7 @@ for (const viewport of viewports.length > 0
         route: from,
         check: `${role}[name=${name}] clickable`,
         result: 'FAIL',
-        detail: `${err.message}${interceptInfo}${note ? ' Note: ' + note : ''}`,
+        detail: `${err instanceof Error ? err.message : String(err)}${interceptInfo}${note ? ' Note: ' + note : ''}`,
       });
     }
   }


### PR DESCRIPTION
## Summary

Addresses all three buckets from #149, validated in jordan-site PR #62.

- **`check-rendered-interactions.mjs` — route reachability fix:** replaced `h1` visibility check with `<main>` presence. `isVisible()` returns false for visually-hidden `h1`s (`clip-path: inset(50%)`), and some templates emit no `h1` at all. `<main>` is a universal render signal.
- **`check-rendered-interactions.mjs` — safe error serialization:** both catch blocks now use `err instanceof Error ? err.message : String(err)` to avoid `"undefined"` diagnostics when the thrown value is not an `Error`.
- **`rendered-interactions.yml` (new):** deployment_status-triggered workflow template so downstream repos don't have to wire up the Playwright check themselves. The correct trigger and Vercel filter are non-obvious.
- **`ci.yml` — `check:tooling-version` step:** added as a blocking step in the `check` job so workflow-kit version drift is caught in CI.
- **`ci.yml` — `unused` job:** non-blocking (`continue-on-error: true`) dead-code audit via knip; visible signal without hard-blocking merges.
- **`ci.yml` — `name:` fields:** descriptive names on all jobs (`Format & lint`, `Types, docs & schema`, `Build, smoke & links`) so failure notices are unambiguous.
- **README:** updated file tree, Playwright setup section, and changeset policy example to reflect the new workflow template.

## Test plan

- [ ] Verify `check-rendered-interactions.mjs` template changes match the issue spec exactly (main count, both err catches)
- [ ] Confirm `rendered-interactions.yml` trigger/filter/checkout/env matches the issue spec; uses `node-version: 24`
- [ ] Confirm `ci.yml` has `check:tooling-version` in the `check` job after schema strictness
- [ ] Confirm `unused` job has `continue-on-error: true` and `needs: lint`
- [ ] Confirm all three existing jobs have `name:` fields
- [ ] Confirm README file tree includes `rendered-interactions.yml`
- [ ] Confirm README Playwright setup section documents the workflow copy step and `deployment_status` trigger
- [ ] Confirm README changeset policy lists all new template files

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)