### PR TITLE
fix(scripts): wait for follow-up publish run in promote-dev-to-main

### DIFF
--- a/scripts/promote-dev-to-main.ps1
+++ b/scripts/promote-dev-to-main.ps1
@@ -142,15 +142,18 @@ $publishJob = $dispatchJobs | Where-Object { $_.name -eq 'Publish to npm' }
 if ($publishJob -and $publishJob.conclusion -eq 'skipped') {
   Write-Host ''
   Write-Host 'Publish job skipped (version-bump commit was pushed). Waiting for the follow-up push-triggered publish run...'
+  # Fetch origin/main to get the version-bump commit SHA pushed by the version job.
+  # Matching by SHA is precise — timestamp-based matching can accidentally select the
+  # earlier merge-triggered push run, which completes before the publish run starts.
+  git fetch origin main | Out-Null
+  $bumpSha = (git rev-parse origin/main).Trim()
+
   $followUpId = $null
   for ($k = 0; $k -lt 60; $k++) {
-    $rows = gh run list --workflow Release --branch main --limit 10 --json databaseId,event,createdAt | ConvertFrom-Json
+    $rows = gh run list --workflow Release --branch main --limit 10 --json databaseId,event,headSha | ConvertFrom-Json
     foreach ($row in $rows) {
       if ($row.event -ne 'push') { continue }
-      try {
-        $created = [datetime]::Parse($row.createdAt, $null, [System.Globalization.DateTimeStyles]::RoundtripKind)
-      } catch { continue }
-      if ($created -ge $dispatchAfter) { $followUpId = $row.databaseId; break }
+      if ($row.headSha -eq $bumpSha) { $followUpId = $row.databaseId; break }
     }
     if ($null -ne $followUpId) { break }
     Start-Sleep -Seconds 5

--- a/scripts/promote-dev-to-main.ps1
+++ b/scripts/promote-dev-to-main.ps1
@@ -130,5 +130,39 @@ if ($null -eq $runId) {
 gh run watch $runId --exit-status
 Write-Host "Release run $runId completed."
 Write-Host 'Tip: git fetch origin main --tags  (then refresh Git Graph)'
-$runUrl = "https://github.com/$((gh repo view --json nameWithOwner -q .nameWithOwner).Trim())/actions/runs/$runId"
+
+$repoName = (gh repo view --json nameWithOwner -q .nameWithOwner).Trim()
+$verifyRunId = $runId
+
+# When changesets are pending the version job pushes a bump commit (via PAT) and sets
+# skip_publish=true. That push event triggers a second Release run which does the actual
+# npm publish. Detect this and wait for the follow-up run before verifying npm.
+$dispatchJobs = (gh run view $runId --json jobs | ConvertFrom-Json).jobs
+$publishJob = $dispatchJobs | Where-Object { $_.name -eq 'Publish to npm' }
+if ($publishJob -and $publishJob.conclusion -eq 'skipped') {
+  Write-Host ''
+  Write-Host 'Publish job skipped (version-bump commit was pushed). Waiting for the follow-up push-triggered publish run...'
+  $followUpId = $null
+  for ($k = 0; $k -lt 60; $k++) {
+    $rows = gh run list --workflow Release --branch main --limit 10 --json databaseId,event,createdAt | ConvertFrom-Json
+    foreach ($row in $rows) {
+      if ($row.event -ne 'push') { continue }
+      try {
+        $created = [datetime]::Parse($row.createdAt, $null, [System.Globalization.DateTimeStyles]::RoundtripKind)
+      } catch { continue }
+      if ($created -ge $dispatchAfter) { $followUpId = $row.databaseId; break }
+    }
+    if ($null -ne $followUpId) { break }
+    Start-Sleep -Seconds 5
+  }
+  if ($null -ne $followUpId) {
+    gh run watch $followUpId --exit-status
+    Write-Host "Publish run $followUpId completed."
+    $verifyRunId = $followUpId
+  } else {
+    Write-Warning 'Could not find the follow-up publish run within timeout. Verifying npm anyway.'
+  }
+}
+
+$runUrl = "https://github.com/$repoName/actions/runs/$verifyRunId"
 Verify-MainPublishedVersions -RunUrl $runUrl


### PR DESCRIPTION
## Summary

The `promote-dev-to-main.ps1` script was calling `Verify-MainPublishedVersions` immediately after the `workflow_dispatch` Release run finished, without accounting for the two-phase publish behaviour:

1. When pending changesets exist, the first run applies the version bump, pushes the commit via PAT, and sets `skip_publish=true` — the publish job is skipped.
2. The PAT push triggers a second push-based Release run that does the actual npm publish.

The script was racing against that second run and producing a spurious version-mismatch error.

## Fix

After the `workflow_dispatch` run completes, inspect its `Publish to npm` job conclusion. If `skipped`:

1. Run `git fetch origin main` and capture the tip SHA with `git rev-parse origin/main` — this is the version-bump commit pushed by the first run.
2. Poll `gh run list` for a push-triggered Release run whose `headSha` matches that exact SHA.
3. Wait for it with `gh run watch`, then point `Verify-MainPublishedVersions` at that run's ID.

Matching by SHA (instead of the original timestamp approach) eliminates any ambiguity with the earlier merge-triggered push run. When publish runs in the first pass (no pending changesets), the new code is a no-op.

## Reviewer comments addressed

- **Codex (P2)** and **Copilot** both flagged that the original timestamp-based lookup could match an unrelated push run and produce the same race condition. Fixed in commit `1c3d181` using SHA-based matching. Replies posted to both inline comments. Latest Copilot re-review on that commit generated no new comments.

## Test plan

- [ ] Run `promote-dev-to-main.ps1` when pending changesets exist — verify the script waits for the follow-up push run and exits clean
- [ ] Run when no changesets are pending — verify the new block is skipped entirely and verification still passes

## Target layer

- [x] CI/release tooling

## Changeset

- [x] Not needed — internal script only, no package API surface change

## AI assistance

- [x] Yes — Claude Sonnet 4.6, output reviewed