### PR TITLE
fix(schema): emit !important on ThemeTokenOverrides CSS custom properties

### DIFF
--- a/.changeset/fix-theme-override-css-important.md
+++ b/.changeset/fix-theme-override-css-important.md
@@ -1,0 +1,17 @@
+---
+'@portfolio-engine/schema': patch
+---
+
+Fix `ThemeTokenOverrides` CSS cascade: add `!important` to emitted custom properties.
+
+In Astro SSG builds, Astro injects bundled CSS (`design-tokens.css`) as `<link>` tags at the end of `<head>`, after any inline `<style>` blocks. `ThemeTokenOverrides` emits an inline `:root { ... }` block, so the bundled stylesheet's default token values appeared later in the document and won the cascade — consumer-configured theme values were silently ignored.
+
+`buildThemeOverrideCss` in `design-resolve.ts` now appends `!important` to every non-default custom property declaration it emits. `!important` on CSS custom properties is valid per spec and wins over normal declarations regardless of source order.
+
+#### Agent migration
+
+- **Packages:** `@portfolio-engine/schema`
+- **Consumer paths:** no file changes required
+- **Actions:**
+  - No migration needed — this is a bug fix. Theme overrides configured in `src/config/theme.json` will now apply correctly in SSG builds without any changes to consumer repos.
+  - If you added a manual workaround (e.g. a `<style>` block or a late-loading stylesheet that re-declared the same CSS custom properties to compensate for the broken cascade), remove those workarounds — the override mechanism now works as documented.

--- a/packages/schema/src/design-resolve.ts
+++ b/packages/schema/src/design-resolve.ts
@@ -297,12 +297,12 @@ export function buildThemeOverrideCss(theme: ThemeConfig | undefined): string {
   const lines: string[] = [];
 
   for (const [key, { value, source }] of colors) {
-    if (source !== 'default') lines.push(`  ${key}: ${value};`);
+    if (source !== 'default') lines.push(`  ${key}: ${value} !important;`);
   }
   for (const [key, { value, source }] of typos) {
     if (source !== 'default') {
-      if (key === 'font-size') lines.push(`  font-size: ${value};`);
-      else lines.push(`  ${key}: ${value};`);
+      if (key === 'font-size') lines.push(`  font-size: ${value} !important;`);
+      else lines.push(`  ${key}: ${value} !important;`);
     }
   }
 


### PR DESCRIPTION
Fixes #157.

## Problem

In Astro SSG builds, Astro injects bundled CSS (e.g. `design-tokens.css`) as `<link rel="stylesheet">` tags at the **end** of `<head>`, after any inline `<style>` blocks. `ThemeTokenOverrides` emits an inline `:root { ... }` block, so the bundled stylesheet's default token values appear later in the document and win the cascade — consumer-configured values are silently ignored.

## Fix

Add `!important` to every custom property declaration emitted by `buildThemeOverrideCss` in `packages/schema/src/design-resolve.ts`. `!important` on CSS custom properties is valid per spec and wins over normal declarations regardless of source order. No structural changes to `ThemeTokenOverrides.astro` or `Layout.astro` are needed.

```ts
// before
lines.push(`  ${key}: ${value};`);
// after
lines.push(`  ${key}: ${value} !important;`);
```

## Changeset

Added `.changeset/fix-theme-override-css-important.md` — patch bump on `@portfolio-engine/schema`. No consumer migration required; existing `theme.json` overrides will now apply correctly in SSG builds automatically.

## Reviewer comments addressed

- **Copilot** flagged that a changeset was needed for this package behavior change. Added in this update.

## Test plan

- [x] `pnpm check` passes
- [ ] Build a consumer site with a `theme.json` that overrides `semanticColors.accent.primary`
- [ ] Confirm the configured value (not the default) appears in rendered components
- [ ] Confirm no regressions for sites with no `theme.json` overrides (empty override block → no inline style emitted)

## Target layer

- [x] `packages/schema`

## AI assistance

- [x] Yes — Claude Sonnet 4.6, output reviewed