### PR TITLE
docs: correct Copilot review ruleset status

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,7 @@ This file adds Copilot-specific operational notes that supplement `AGENTS.md`.
 
 ## Code review
 
-Automatic Copilot code review is enabled via repository rulesets for PRs into `dev` and `epic/**`. That behavior is not defined in workflow YAML.
+Automatic Copilot code review is intended to be configured via repository rulesets for PRs into `dev` and `epic/**`; it is not defined in workflow YAML. Until issue #36 is completed and the rulesets are verified, request Copilot review manually on each PR.
 
 After a review, apply inline suggestions or comment `@copilot` on the PR to have the coding agent push commits. There is no supported fully hands-off "review then auto-commit everything" mode.
 


### PR DESCRIPTION
## Summary

- corrects the repository guidance that currently claims automatic Copilot review rulesets are enabled
- records the actual current state: no rulesets are installed
- directs contributors to request Copilot review manually until #36 is completed and verified

## Verification

- [x] repository rulesets API returned an empty list on 2026-08-13
- [x] full CI passes
- [x] Changeset guard passes; this documentation-only change does not require a package changeset

Closes no issue: #36 remains open for the actual repository-setting work.
