### PR TITLE
fix(editorial-theme): add explicit Tailwind @source for theme templates

### DIFF
--- a/.changeset/fix-editorial-theme-tailwind-content-detection.md
+++ b/.changeset/fix-editorial-theme-tailwind-content-detection.md
@@ -1,0 +1,20 @@
+---
+'@portfolio-engine/editorial-theme': patch
+---
+
+Fix theme utility classes silently missing CSS when a component's classes aren't otherwise used in the consumer's own source (most visibly: the homepage hero rendering with no top offset, its heading/bio clipped behind the fixed nav).
+
+`global.css` did `@import "tailwindcss"` with no explicit `@source`. Tailwind v4's automatic content detection respects `.gitignore`, which excludes `node_modules` in virtually every consumer project — so any utility class used only inside this package's own `components/`, `layouts/`, or `pages/` (and not coincidentally already used somewhere in the consumer's own `src/`) was silently generating zero CSS. The class still appeared in the rendered markup; it just did nothing.
+
+This was most visible on `HeroSection`: `min-h-screen` and `pt-24` are not used elsewhere in a typical consumer, so they were dropped entirely, collapsing the hero to unpadded block flow — the `<h1>`/bio `<p>` rendered flush under the fixed nav (`Nav.astro`, `h-16`/`z-50`) regardless of viewport height or how short the tagline/bio copy was. Verified via computed-style/getBoundingClientRect inspection (not just visual comparison) that `paddingTop`/`minHeight` were literally `0px` before this fix and correct afterward, across viewport heights from 350px to 900px.
+
+Added explicit `@source` directives in `global.css` covering `../components/**/*.astro`, `../layouts/**/*.astro`, and `../pages/**/*.astro` (paths are relative to the CSS file and resolve the same way in both `src/` and the published `dist/`, since `tsup`'s asset-copy step preserves the directory layout). This is a general content-detection fix, not Hero-specific — it makes _every_ editorial-theme utility class reliably generate, regardless of what the specific consumer's own pages happen to already use.
+
+#### Agent migration
+
+- **Packages:** `@portfolio-engine/editorial-theme`
+- **Consumer paths:** no file changes required
+- **Actions:**
+  - No migration needed — pure CSS-generation bug fix, no API/schema/prop change.
+  - If a consumer shortened hero copy (tagline/`shortBio`) specifically to work around clipped/overlapping hero text, that workaround is no longer necessary.
+  - If a consumer added any local CSS override to compensate for a theme component rendering with missing spacing/sizing (anywhere in the theme, not just the hero), it's worth re-checking after upgrading — the underlying cause may now be fixed.

--- a/packages/editorial-theme/src/styles/global.css
+++ b/packages/editorial-theme/src/styles/global.css
@@ -1,6 +1,19 @@
 @import "./design-tokens.css";
 @import "tailwindcss";
 
+/*
+ * Explicit sources: Tailwind's automatic content detection respects .gitignore, which
+ * excludes node_modules in virtually every consumer project. Without these, any utility
+ * class used only inside this package's own components/layouts/pages (and not already
+ * used somewhere in the consumer's own src/) is silently never generated — the class
+ * appears in the rendered markup but produces no CSS rule at all.
+ * Paths are relative to this file and mirror 1:1 between src/ (this repo) and dist/
+ * (published package), since tsup's copyAssets step preserves the directory layout.
+ */
+@source "../components/**/*.astro";
+@source "../layouts/**/*.astro";
+@source "../pages/**/*.astro";
+
 @theme {
   --font-sans: var(--font-sans-stack);
   --font-serif: var(--font-serif-stack);


### PR DESCRIPTION
## Summary

- `editorial-theme`'s `global.css` did `@import "tailwindcss"` with no explicit `@source`. Tailwind v4's automatic content detection respects `.gitignore`, which excludes `node_modules` in virtually every consumer project — so any utility class used only inside this package's own `components/`, `layouts/`, or `pages/` (and not coincidentally already used somewhere in the consumer's own `src/`) was silently generating **zero CSS**. The class still appears in the rendered markup; it just does nothing.
- Reported downstream as agreni-site#10 ("text being cut off") and visible on agreni-site PR #11: the homepage hero's `<h1>`/bio `<p>` rendered flush under the fixed nav bar. Root-caused to this: `min-h-screen` and `pt-24` on `HeroSection`'s wrapping `<section>` aren't used anywhere else in a typical consumer, so both were silently dropped, collapsing the hero to unpadded block flow.
- Fix: added explicit `@source` directives in `global.css` covering `../components/**/*.astro`, `../layouts/**/*.astro`, `../pages/**/*.astro`. This is a general content-detection fix (not Hero-specific) — every editorial-theme utility class now reliably generates regardless of what a given consumer's own pages happen to already use.
- `HeroSection.astro`'s markup is **unchanged** — I initially assumed a `min-h-screen`/`justify-center` vs. fixed-nav centering-math bug and drafted a markup fix, but disproved that once the real CSS-generation bug was found and fixed: `padding-top` is a hard floor under flexbox `justify-content: center`, so once `pt-24` actually generates, the heading can never render above it regardless of viewport height or content length. Verified this by testing viewport heights down to 350px.

## Target layer

`packages/editorial-theme` (styles only).

## AI assistance

This PR was drafted with assistance from an AI coding agent (Claude) and reviewed by me.

## Commands run

- `pnpm lint` — pass
- `pnpm --filter @portfolio-engine/editorial-theme check` (tsc + tests) — pass
- `pnpm --filter @portfolio-engine/editorial-theme build` — pass

## Visual QA

Actually inspected in a browser (not just code reading): ran `examples/demo-site` (long `shortBio`/`tagline` content, a realistic reproduction of the reported bug) with Playwright/Chromium, before and after the fix, at viewport heights 350–900px.

- **Before:** `getComputedStyle(section).paddingTop` / `.minHeight` were literally `0px`; `<h1>` top edge measured ~0.8px *above* the nav's bottom edge (overlapping) at every tested height.
- **After:** `paddingTop`/`minHeight` generate correctly; `<h1>` renders 70px+ clear of the nav at every tested height, 350–900px. Screenshots confirm no clipping/overlap. Console errors checked — none introduced.
- Also rebuilt `examples/demo-site` with its normal config (Hero override enabled) as a regression check — unaffected, builds clean.

## Remaining risks / follow-ups

- This is a content-detection fix with broad (but backward-compatible) effect: any editorial-theme component/page utility class that was previously silently dropped will now generate CSS. This should only ever *fix* missing styling, never change already-working styling, but worth a general visual pass on a real consumer site after upgrading, beyond just the hero.
- Did not investigate whether `packages/admin-tools` has the same `@source` gap in its own Tailwind entry — out of scope for this fix (agreni-site's reported bug is on public pages only), flagging in case it's worth a follow-up issue.