### PR TITLE
chore(release): promote dev -> main

### DIFF
--- a/.changeset/fix-editorial-theme-tailwind-content-detection.md
+++ b/.changeset/fix-editorial-theme-tailwind-content-detection.md
@@ -1,0 +1,20 @@
+---
+'@portfolio-engine/editorial-theme': patch
+---
+
+Fix theme utility classes silently missing CSS when a component's classes aren't otherwise used in the consumer's own source (most visibly: the homepage hero rendering with no top offset, its heading/bio clipped behind the fixed nav).
+
+`global.css` did `@import "tailwindcss"` with no explicit `@source`. Tailwind v4's automatic content detection respects `.gitignore`, which excludes `node_modules` in virtually every consumer project — so any utility class used only inside this package's own `components/`, `layouts/`, or `pages/` (and not coincidentally already used somewhere in the consumer's own `src/`) was silently generating zero CSS. The class still appeared in the rendered markup; it just did nothing.
+
+This was most visible on `HeroSection`: `min-h-screen` and `pt-24` are not used elsewhere in a typical consumer, so they were dropped entirely, collapsing the hero to unpadded block flow — the `<h1>`/bio `<p>` rendered flush under the fixed nav (`Nav.astro`, `h-16`/`z-50`) regardless of viewport height or how short the tagline/bio copy was. Verified via computed-style/getBoundingClientRect inspection (not just visual comparison) that `paddingTop`/`minHeight` were literally `0px` before this fix and correct afterward, across viewport heights from 350px to 900px.
+
+Added explicit `@source` directives in `global.css` covering `../components/**/*.astro`, `../layouts/**/*.astro`, and `../pages/**/*.astro` (paths are relative to the CSS file and resolve the same way in both `src/` and the published `dist/`, since `tsup`'s asset-copy step preserves the directory layout). This is a general content-detection fix, not Hero-specific — it makes _every_ editorial-theme utility class reliably generate, regardless of what the specific consumer's own pages happen to already use.
+
+#### Agent migration
+
+- **Packages:** `@portfolio-engine/editorial-theme`
+- **Consumer paths:** no file changes required
+- **Actions:**
+  - No migration needed — pure CSS-generation bug fix, no API/schema/prop change.
+  - If a consumer shortened hero copy (tagline/`shortBio`) specifically to work around clipped/overlapping hero text, that workaround is no longer necessary.
+  - If a consumer added any local CSS override to compensate for a theme component rendering with missing spacing/sizing (anywhere in the theme, not just the hero), it's worth re-checking after upgrading — the underlying cause may now be fixed.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,7 @@ This file adds Copilot-specific operational notes that supplement `AGENTS.md`.
 
 ## Code review
 
-Automatic Copilot code review is enabled via repository rulesets for PRs into `dev` and `epic/**`. That behavior is not defined in workflow YAML.
+Automatic Copilot code review is intended to be configured via repository rulesets for PRs into `dev` and `epic/**`; it is not defined in workflow YAML. Until issue #36 is completed and the rulesets are verified, request Copilot review manually on each PR.
 
 After a review, apply inline suggestions or comment `@copilot` on the PR to have the coding agent push commits. There is no supported fully hands-off "review then auto-commit everything" mode.
 

--- a/packages/editorial-theme/src/styles/global.css
+++ b/packages/editorial-theme/src/styles/global.css
@@ -1,6 +1,19 @@
 @import "./design-tokens.css";
 @import "tailwindcss";
 
+/*
+ * Explicit sources: Tailwind's automatic content detection respects .gitignore, which
+ * excludes node_modules in virtually every consumer project. Without these, any utility
+ * class used only inside this package's own components/layouts/pages (and not already
+ * used somewhere in the consumer's own src/) is silently never generated — the class
+ * appears in the rendered markup but produces no CSS rule at all.
+ * Paths are relative to this file and mirror 1:1 between src/ (this repo) and dist/
+ * (published package), since tsup's copyAssets step preserves the directory layout.
+ */
+@source "../components/**/*.astro";
+@source "../layouts/**/*.astro";
+@source "../pages/**/*.astro";
+
 @theme {
   --font-sans: var(--font-sans-stack);
   --font-serif: var(--font-serif-stack);


### PR DESCRIPTION
Promotes `dev` to `main` to ship #163 (fix(editorial-theme): add explicit Tailwind @source for theme templates) plus #162 (docs).

Includes a pending changeset for `@portfolio-engine/editorial-theme` (patch) — Release workflow will version + publish on merge per the standard two-phase flow.