### PR TITLE
fix(engine-core,editorial-theme): resolve overrides.styles at config time, not per-request

### DIFF
--- a/.changeset/fix-override-styles-runtime-enoent.md
+++ b/.changeset/fix-override-styles-runtime-enoent.md
@@ -1,0 +1,20 @@
+---
+'@portfolio-engine/engine-core': patch
+'@portfolio-engine/editorial-theme': patch
+---
+
+Fix `ENOENT` crash on any server-rendered route when a consumer configures `overrides.styles`.
+
+`resolveOverrides()` (`engine-core`) previously stored resolved **file paths** for `overrides.styles` in the `__styles__` entry of the `@portfolio-engine:overrides` virtual module. `Layout.astro` (`editorial-theme`) then called `fs.readFileSync()` on those paths **at request time**. That works for prerendered/static routes (built once, when the consumer's `src/` tree is present on the build machine), but any server-rendered route (`export const prerender = false`, or any route under `output: 'server'`) re-runs `Layout.astro`'s frontmatter **per request** — and serverless runtimes (Vercel included) don't bundle the raw source tree, only what static analysis can trace. Since the path came from a runtime-parsed JSON string, it isn't traceable, so the file is missing at runtime: `ENOENT: no such file or directory, open '.../src/overrides/styles/....css'`. Astro's error handling for this case can result in a `200` response with an **empty body** rather than a clean `500` — the page silently renders blank.
+
+`resolveOverrides()` now reads and inlines the CSS **content** (not paths) at config-resolution time — this runs once during `astro build`/dev-server-start, when the source tree is guaranteed to exist, regardless of whether any given route ends up prerendered or server-rendered. `Layout.astro` no longer touches the filesystem at all; it just reads the already-resolved string from the virtual module.
+
+Verified against `tests/fixtures/node-ssr` (`output: 'server'`): built with an `overrides.styles` entry, then the source file was deleted before starting the built server — the override CSS still rendered correctly with no runtime error, confirming no filesystem dependency survives into the running server.
+
+#### Agent migration
+
+- **Packages:** `@portfolio-engine/engine-core`, `@portfolio-engine/editorial-theme`
+- **Consumer paths:** no file changes required — `astro.config.*`'s `overrides.styles` option is unchanged.
+- **Actions:**
+  - No migration needed — internal implementation fix, same public config shape.
+  - If any consumer route using `overrides.styles` is server-rendered (`prerender = false`, or an `output: 'server'`/`'hybrid'` project) and previously rendered blank/broken, it should now render correctly after upgrading — no workaround needed.

--- a/packages/editorial-theme/src/layouts/Layout.astro
+++ b/packages/editorial-theme/src/layouts/Layout.astro
@@ -13,11 +13,12 @@ import '../styles/global.css';
 import { editorialGoogleFontsStylesheetHref } from '../lib/google-fonts.js';
 import { config } from '@portfolio-engine:config';
 import { overrides } from '@portfolio-engine:overrides';
-import { readFileSync } from 'node:fs';
 import { getBase } from '../lib/utils';
 
-const styleFiles: string[] = overrides.__styles__ ? JSON.parse(overrides.__styles__) : [];
-const extraCss = styleFiles.map((p: string) => readFileSync(p, 'utf-8')).join('\n');
+// Already-resolved CSS content (read once at config-resolution time by
+// `resolveOverrides()` in engine-core) — never read from disk here, so this works
+// identically for prerendered and server-rendered routes.
+const extraCss = overrides.__styles__ ?? '';
 
 interface Props {
   title: string;

--- a/packages/engine-core/src/override-resolution.ts
+++ b/packages/engine-core/src/override-resolution.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import type { OverrideMap } from './types.js';
@@ -62,8 +63,15 @@ export function resolveOverrides(
     }
   }
   if (styles.length > 0) {
-    // JSON-encoded array — avoids ambiguity since file paths can legally contain ';'.
-    overrideMap['__styles__'] = JSON.stringify(styles.map((p) => resolve(projectRootDir, p)));
+    // Read and inline the CSS content here, at config-resolution time (runs once during
+    // `astro build`/dev-server-start, when the consumer's source tree is guaranteed to be
+    // on disk) — not deferred to request time. The resulting virtual module is plain
+    // serialized data with no filesystem dependency, so it works the same in serverless
+    // functions, which don't bundle the raw source tree and would ENOENT on any
+    // server-rendered (non-prerendered) route trying to re-read these paths per-request.
+    overrideMap['__styles__'] = styles
+      .map((p) => readFileSync(resolve(projectRootDir, p), 'utf-8'))
+      .join('\n');
   }
 
   return overrideMap;


### PR DESCRIPTION
## Summary

- `resolveOverrides()` (`engine-core`) stored **file paths** for `overrides.styles`; `Layout.astro` (`editorial-theme`) called `fs.readFileSync()` on those paths **at request time**.
- Works fine for prerendered/static routes (the read happens once, during `astro build`, when the consumer's `src/` tree is on the build machine). Crashes on any **server-rendered** route (`prerender = false`, or any route under `output: 'server'`), because serverless runtimes (Vercel included) don't bundle the raw source tree — only what static analysis can trace, and a path pulled from a runtime-parsed JSON string isn't traceable.
- The failure mode is nasty: Astro's error handling for this specific case (an exception mid-render) can produce a `200` response with a **completely empty body**, not a clean `500` — the page just silently renders blank, no error surfaced to the visitor.
- Found live: agreni-site's `/admin` (`prerender = false`) went blank after adding a `Footer.astro` override with `overrides.styles: ['./src/overrides/styles/custom.css']`. Vercel function logs showed: `Error: ENOENT: no such file or directory, open '/vercel/path0/src/overrides/styles/custom.css'`.

## Fix

`resolveOverrides()` now reads and inlines the CSS **content** at config-resolution time (runs once, during `astro build`/dev-server-start) instead of deferring to a later `readFileSync`. `Layout.astro` no longer touches the filesystem — it just reads the already-resolved string out of the `@portfolio-engine:overrides` virtual module.

## Target layer

`packages/engine-core` (`override-resolution.ts`) + `packages/editorial-theme` (`Layout.astro`).

## AI assistance

Drafted with assistance from Claude and reviewed by me.

## Commands run

- `pnpm lint` — pass
- `pnpm --filter @portfolio-engine/engine-core --filter @portfolio-engine/editorial-theme check` — pass
- `pnpm --filter @portfolio-engine/engine-core --filter @portfolio-engine/editorial-theme build` — pass

## Visual QA / verification

Reproduced the exact production condition locally against `tests/fixtures/node-ssr` (`output: 'server'`, real per-request SSR, not just prerendering):

1. Added a temporary `overrides.styles` entry and CSS file.
2. `astro build`.
3. **Deleted/hid the source CSS file** (simulating a serverless runtime with no source tree).
4. Started the built server (`node dist/server/entry.mjs`) and requested a page.
5. **Before this fix** (verified against the live agreni-site deployment, not re-tested locally against reverted code): `200` with empty body, `ENOENT` in server logs.
6. **After this fix**: `200`, correct HTML, override CSS content present in the response, zero server errors — confirmed by grepping the rendered HTML for a marker string only present in the override CSS file that had just been deleted from disk.

Test scaffolding was not committed (temporary file + config, reverted after verification).

## Remaining risks / follow-ups

None expected — this narrows the filesystem access window (config-time only) without changing the public `overrides.styles` config shape at all.