### PR TITLE
chore(release): promote dev -> main

### DIFF
--- a/.changeset/fix-override-styles-runtime-enoent.md
+++ b/.changeset/fix-override-styles-runtime-enoent.md
@@ -1,0 +1,20 @@
+---
+'@portfolio-engine/engine-core': patch
+'@portfolio-engine/editorial-theme': patch
+---
+
+Fix `ENOENT` crash on any server-rendered route when a consumer configures `overrides.styles`.
+
+`resolveOverrides()` (`engine-core`) previously stored resolved **file paths** for `overrides.styles` in the `__styles__` entry of the `@portfolio-engine:overrides` virtual module. `Layout.astro` (`editorial-theme`) then called `fs.readFileSync()` on those paths **at request time**. That works for prerendered/static routes (built once, when the consumer's `src/` tree is present on the build machine), but any server-rendered route (`export const prerender = false`, or any route under `output: 'server'`) re-runs `Layout.astro`'s frontmatter **per request** — and serverless runtimes (Vercel included) don't bundle the raw source tree, only what static analysis can trace. Since the path came from a runtime-parsed JSON string, it isn't traceable, so the file is missing at runtime: `ENOENT: no such file or directory, open '.../src/overrides/styles/....css'`. Astro's error handling for this case can result in a `200` response with an **empty body** rather than a clean `500` — the page silently renders blank.
+
+`resolveOverrides()` now reads and inlines the CSS **content** (not paths) at config-resolution time — this runs once during `astro build`/dev-server-start, when the source tree is guaranteed to exist, regardless of whether any given route ends up prerendered or server-rendered. `Layout.astro` no longer touches the filesystem at all; it just reads the already-resolved string from the virtual module.
+
+Verified against `tests/fixtures/node-ssr` (`output: 'server'`): built with an `overrides.styles` entry, then the source file was deleted before starting the built server — the override CSS still rendered correctly with no runtime error, confirming no filesystem dependency survives into the running server.
+
+#### Agent migration
+
+- **Packages:** `@portfolio-engine/engine-core`, `@portfolio-engine/editorial-theme`
+- **Consumer paths:** no file changes required — `astro.config.*`'s `overrides.styles` option is unchanged.
+- **Actions:**
+  - No migration needed — internal implementation fix, same public config shape.
+  - If any consumer route using `overrides.styles` is server-rendered (`prerender = false`, or an `output: 'server'`/`'hybrid'` project) and previously rendered blank/broken, it should now render correctly after upgrading — no workaround needed.

--- a/packages/editorial-theme/src/layouts/Layout.astro
+++ b/packages/editorial-theme/src/layouts/Layout.astro
@@ -13,11 +13,12 @@ import '../styles/global.css';
 import { editorialGoogleFontsStylesheetHref } from '../lib/google-fonts.js';
 import { config } from '@portfolio-engine:config';
 import { overrides } from '@portfolio-engine:overrides';
-import { readFileSync } from 'node:fs';
 import { getBase } from '../lib/utils';
 
-const styleFiles: string[] = overrides.__styles__ ? JSON.parse(overrides.__styles__) : [];
-const extraCss = styleFiles.map((p: string) => readFileSync(p, 'utf-8')).join('\n');
+// Already-resolved CSS content (read once at config-resolution time by
+// `resolveOverrides()` in engine-core) — never read from disk here, so this works
+// identically for prerendered and server-rendered routes.
+const extraCss = overrides.__styles__ ?? '';
 
 interface Props {
   title: string;

--- a/packages/engine-core/src/override-resolution.ts
+++ b/packages/engine-core/src/override-resolution.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import type { OverrideMap } from './types.js';
@@ -62,8 +63,15 @@ export function resolveOverrides(
     }
   }
   if (styles.length > 0) {
-    // JSON-encoded array — avoids ambiguity since file paths can legally contain ';'.
-    overrideMap['__styles__'] = JSON.stringify(styles.map((p) => resolve(projectRootDir, p)));
+    // Read and inline the CSS content here, at config-resolution time (runs once during
+    // `astro build`/dev-server-start, when the consumer's source tree is guaranteed to be
+    // on disk) — not deferred to request time. The resulting virtual module is plain
+    // serialized data with no filesystem dependency, so it works the same in serverless
+    // functions, which don't bundle the raw source tree and would ENOENT on any
+    // server-rendered (non-prerendered) route trying to re-read these paths per-request.
+    overrideMap['__styles__'] = styles
+      .map((p) => readFileSync(resolve(projectRootDir, p), 'utf-8'))
+      .join('\n');
   }
 
   return overrideMap;


### PR DESCRIPTION
Promotes `dev` to `main` to ship #165 (fix(engine-core,editorial-theme): resolve overrides.styles at config time, not per-request).

Includes a pending changeset for `@portfolio-engine/engine-core` and `@portfolio-engine/editorial-theme` (both patch) — Release workflow will version + publish on merge.