### PR TITLE
feat: add résumé PDF and route controls

### DIFF
--- a/.changeset/clean-cobras-resume.md
+++ b/.changeset/clean-cobras-resume.md
@@ -1,0 +1,13 @@
+---
+'@portfolio-engine/schema': minor
+'@portfolio-engine/engine-core': minor
+'@portfolio-engine/editorial-theme': minor
+---
+
+Add a validated résumé PDF URL, a built-in download action, and a backward-compatible `resumePage` route flag.
+
+#### Agent migration
+
+- Packages: `@portfolio-engine/schema`, `@portfolio-engine/engine-core`, `@portfolio-engine/editorial-theme`
+- Consumer paths: `src/config/site.json`, `src/config/features.json`, and the consumer `public/` directory
+- Actions: place the public PDF under `public/`, set `site.resumePdfUrl` to its root-relative path, and keep or add a `/resume` navigation item. Existing consumers need no change because `features.resumePage` defaults to `true`.

--- a/docs/downstream/route-ownership.md
+++ b/docs/downstream/route-ownership.md
@@ -22,6 +22,11 @@ Files under **`src/pages/`** are normal Astro routes. Astro owns them directly. 
 
 ## Résumé (`/resume`) visibility
 
+The editorial theme injects `/resume` by default. Configure a canonical PDF with
+`site.resumePdfUrl` (for example `/documents/resume.pdf`) to show the built-in
+download action. Set `features.resumePage` to `false` when a consumer should not
+have any résumé route.
+
 If you want **full doctor/manifest visibility** for `/resume`, implement it as a **consumer-local registry** route (pattern `/resume`, page under `src/pages-local`). If `/resume` is intentionally a **fully custom** Astro page under `src/pages/resume.astro`, that is valid, but document for your team that it **will not** be engine-injected and **may not** show up in the Portfolio Engine manifest—doctor will not list it as a first-class engine route.
 
 ## Quick comparison

--- a/examples/demo-site/src/config/features.json
+++ b/examples/demo-site/src/config/features.json
@@ -2,6 +2,7 @@
   "blog": false,
   "work": true,
   "contact": true,
+  "resumePage": true,
   "testimonials": false,
   "pillars": [
     {

--- a/packages/editorial-theme/README.md
+++ b/packages/editorial-theme/README.md
@@ -66,6 +66,7 @@ See that package for the canonical Zod schemas. A minimal set:
   "description": "Personal portfolio.",
   "baseUrl": "https://example.com",
   "tagline": "designs for clarity",
+  "resumePdfUrl": "/documents/resume.pdf",
   "contact": {
     "heading": "Let's work together",
     "body": "Reach out and let's find what's possible.",
@@ -73,6 +74,10 @@ See that package for the canonical Zod schemas. A minimal set:
   "bookingUrl": "https://calendly.com/your-handle/30min",
 }
 ```
+
+The built-in `/resume` page renders structured `profile/cv` content and shows a
+download action when `site.resumePdfUrl` is configured. Set `resumePage` to
+`false` in `features.json` to disable route injection; it defaults to `true`.
 
 ```jsonc
 // config/navigation.json
@@ -97,6 +102,7 @@ See that package for the canonical Zod schemas. A minimal set:
   "blog": true,
   "work": true,
   "contact": true,
+  "resumePage": true,
   "testimonials": true,
   "pillars": [{ "heading": "Product Design", "body": "Thoughtful interfaces." }],
   "ctaBody": "Let's talk.",

--- a/packages/editorial-theme/src/pages/resume.astro
+++ b/packages/editorial-theme/src/pages/resume.astro
@@ -3,9 +3,14 @@ import Layout from '../layouts/Layout.astro';
 import Reveal from '../components/Reveal.astro';
 import SectionIntro from '../components/SectionIntro.astro';
 import { getEntry } from 'astro:content';
+import { config } from '@portfolio-engine:config';
+import { getBase, resolveAssetUrl } from '../lib/utils';
 import { loadProfilePerson, resolveLongBioParagraphs } from '../lib/load-profile-person';
 
+const base = getBase();
 const person = await loadProfilePerson();
+const resumePdfUrl = resolveAssetUrl(config.site.resumePdfUrl, base);
+const resumePdfIsExternal = resumePdfUrl?.startsWith('https://') ?? false;
 
 const cvEntry = await getEntry('profile', 'cv');
 if (import.meta.env.DEV && !cvEntry) {
@@ -89,6 +94,22 @@ function formatExperienceDateRange(role: CvExperience): string | null {
       <h1 class="mb-6 font-serif text-5xl font-bold leading-tight md:text-6xl">
         {person.name}
       </h1>
+      {
+        resumePdfUrl && (
+          <a
+            href={resumePdfUrl}
+            download={resumePdfIsExternal ? undefined : true}
+            target={resumePdfIsExternal ? '_blank' : undefined}
+            rel={resumePdfIsExternal ? 'noopener noreferrer' : undefined}
+            class="mb-8 inline-flex min-h-11 items-center justify-center gap-2 rounded-full border border-[var(--color-accent-primary)] bg-[var(--color-accent-primary)] px-5 py-2.5 text-sm font-semibold text-[var(--color-surface-page)] transition-colors hover:bg-transparent hover:text-[var(--color-accent-primary)] focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[var(--color-accent-primary)]"
+          >
+            <svg aria-hidden="true" viewBox="0 0 24 24" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M12 3v12m0 0 4-4m-4 4-4-4M5 21h14" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+            Download résumé PDF
+          </a>
+        )
+      }
       {summaryParagraphs.length > 0 && (
         <div class="mt-6 max-w-2xl space-y-4 text-lg leading-relaxed text-[var(--color-text-muted)]">
           {summaryParagraphs.map((para) => (

--- a/packages/editorial-theme/src/registry.ts
+++ b/packages/editorial-theme/src/registry.ts
@@ -14,7 +14,15 @@ export const DEFAULT_ROUTE_REGISTRY: RouteRegistryEntry[] = [
   { pattern: '/writing', label: 'Writing', section: null, visibility: 'public', remappable: true, disableable: true },
   { pattern: '/writing/[slug]', label: 'Writing detail', section: null, visibility: 'hidden', remappable: true, disableable: true },
   { pattern: '/contact', label: 'Contact', section: null, visibility: 'public', remappable: true, disableable: true },
-  { pattern: '/resume', label: 'Résumé', section: null, visibility: 'public', remappable: true, disableable: true },
+  {
+    pattern: '/resume',
+    label: 'Résumé',
+    section: null,
+    visibility: 'public',
+    remappable: true,
+    disableable: true,
+    featureFlag: 'resumePage',
+  },
 ];
 
 export const DEFAULT_OVERRIDE_SURFACES: OverrideSurfaceEntry[] = [

--- a/packages/engine-core/src/integration.ts
+++ b/packages/engine-core/src/integration.ts
@@ -146,7 +146,31 @@ export function createEngineIntegration(options: EngineIntegrationOptions): Astr
         const discovered = discoverRoutes(pagesDir, registries.routes);
 
         // 3. Apply route remaps / disables from downstream config
-        const { routes: activeRoutes, disabled, remapped } = applyRouteOverrides(discovered, options.routes ?? {});
+        const {
+          routes: overriddenRoutes,
+          disabled: explicitlyDisabled,
+          remapped,
+        } = applyRouteOverrides(discovered, options.routes ?? {});
+
+        // Theme registries may associate a route with a boolean features.json key.
+        // Missing/unknown keys fail fast so a registry typo cannot silently expose a route.
+        const resolvedFeatures = resolvedConfig.features as Record<string, unknown>;
+        const featureDisabled: string[] = [];
+        const activeRoutes = overriddenRoutes.filter((route) => {
+          const featureFlag = route.routeRecord.featureFlag;
+          if (!featureFlag) return true;
+          if (!(featureFlag in resolvedFeatures)) {
+            throw new Error(
+              `[portfolio-engine] Route "${route.pattern}" references unknown feature flag "${featureFlag}".`,
+            );
+          }
+          if (resolvedFeatures[featureFlag] === false) {
+            featureDisabled.push(route.pattern);
+            return false;
+          }
+          return true;
+        });
+        const disabled = [...explicitlyDisabled, ...featureDisabled];
 
         const registryRelative =
           options.consumerRegistryPath ?? CONSUMER_REGISTRY_DEFAULT_RELATIVE_PATH;

--- a/packages/engine-core/src/types.ts
+++ b/packages/engine-core/src/types.ts
@@ -14,6 +14,8 @@ export interface RouteRecord {
   visibility: 'public' | 'admin-only' | 'hidden';
   remappable: boolean;
   disableable: boolean;
+  /** Optional boolean key in the resolved features config that controls injection. */
+  featureFlag?: string;
 }
 
 /** Stable public type: the full list of registered routes after override resolution. */

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -7,6 +7,27 @@ Shared Zod schemas for portfolio-engine content and configuration:
 
 Consumed by both `engine-core` (for validation) and downstream consumer sites (for type safety).
 
+## Résumé document and route
+
+Set a canonical public PDF in `config/site.json` and control the built-in route
+from `config/features.json`:
+
+```jsonc
+// config/site.json
+{
+  "resumePdfUrl": "/documents/resume.pdf"
+}
+
+// config/features.json
+{
+  "resumePage": true
+}
+```
+
+`resumePdfUrl` accepts a root-relative consumer asset or an absolute HTTPS URL.
+`resumePage` defaults to `true` for backward compatibility. Set it to `false`
+to stop the editorial theme from injecting `/resume`.
+
 See [`docs/packages/schema.md`](../../docs/packages/schema.md) for architecture detail.
 
 ## Status

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "check": "tsc --noEmit",
+    "check": "tsc --noEmit && node src/config.test.mjs",
     "prepublishOnly": "pnpm run build"
   },
   "dependencies": {

--- a/packages/schema/src/config.test.mjs
+++ b/packages/schema/src/config.test.mjs
@@ -21,8 +21,7 @@ assert.equal(
   true,
 );
 assert.equal(
-  SiteConfigSchema.safeParse({ ...baseSite, resumePdfUrl: '//cdn.example.com/resume.pdf' })
-    .success,
+  SiteConfigSchema.safeParse({ ...baseSite, resumePdfUrl: '//cdn.example.com/resume.pdf' }).success,
   false,
 );
 assert.equal(

--- a/packages/schema/src/config.test.mjs
+++ b/packages/schema/src/config.test.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { FeaturesConfigSchema, SiteConfigSchema } from '../dist/index.js';
+
+const baseSite = {
+  title: 'Test site',
+  description: 'Schema fixture.',
+  baseUrl: 'https://example.com',
+  tagline: 'Test',
+  contact: { heading: 'Contact', body: 'Hello.' },
+};
+
+assert.equal(
+  SiteConfigSchema.safeParse({ ...baseSite, resumePdfUrl: '/documents/resume.pdf' }).success,
+  true,
+);
+assert.equal(
+  SiteConfigSchema.safeParse({
+    ...baseSite,
+    resumePdfUrl: 'https://cdn.example.com/resume.pdf',
+  }).success,
+  true,
+);
+assert.equal(
+  SiteConfigSchema.safeParse({ ...baseSite, resumePdfUrl: '//cdn.example.com/resume.pdf' })
+    .success,
+  false,
+);
+assert.equal(
+  SiteConfigSchema.safeParse({ ...baseSite, resumePdfUrl: 'http://example.com/resume.pdf' })
+    .success,
+  false,
+);
+
+assert.equal(FeaturesConfigSchema.parse({}).resumePage, true);
+assert.equal(FeaturesConfigSchema.parse({ resumePage: false }).resumePage, false);
+
+console.log('site config resume controls: all assertions passed');

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -53,7 +53,8 @@ export const SiteConfigSchema = z.object({
   resumePdfUrl: z
     .string()
     .refine(
-      (value) => value.startsWith('/') || value.startsWith('https://'),
+      (value) =>
+        (value.startsWith('/') && !value.startsWith('//')) || value.startsWith('https://'),
       'Resume PDF URL must be root-relative (for example /documents/resume.pdf) or an absolute https:// URL.',
     )
     .optional(),

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -47,6 +47,17 @@ export const SiteConfigSchema = z.object({
   baseUrl: z.url(),
   tagline: z.string(),
   /**
+   * Canonical public résumé document. Use a root-relative consumer asset or an
+   * absolute HTTPS URL; the editorial theme exposes it from `/resume`.
+   */
+  resumePdfUrl: z
+    .string()
+    .refine(
+      (value) => value.startsWith('/') || value.startsWith('https://'),
+      'Resume PDF URL must be root-relative (for example /documents/resume.pdf) or an absolute https:// URL.',
+    )
+    .optional(),
+  /**
    * Optional public footer link to `/admin`. Visibility is independent of auth:
    * anyone can see the URL; GitHub OAuth still gates access. Prefer `PUBLIC_SHOW_ADMIN_LINK=true`
    * for env-driven production, or set `showPublicLink` here for config-as-code.
@@ -102,6 +113,8 @@ export const FeaturesConfigSchema = z.object({
   testimonials: z.boolean().default(false),
   work: z.boolean().default(true),
   contact: z.boolean().default(true),
+  /** Controls injection of the editorial theme's `/resume` route. */
+  resumePage: z.boolean().default(true),
   pillars: z
     .array(
       z.object({

--- a/packages/schema/src/registry.ts
+++ b/packages/schema/src/registry.ts
@@ -7,6 +7,8 @@ export interface RouteRegistryEntry {
   visibility: RouteVisibility;
   remappable: boolean;
   disableable: boolean;
+  /** Optional boolean key in features.json that controls route injection. */
+  featureFlag?: string;
   agentGuidance?: string;
   adminDescription?: string;
 }


### PR DESCRIPTION
## Summary

Adds the missing reusable résumé document contract and completes the built-in page behavior:

- validates a root-relative or absolute HTTPS `site.resumePdfUrl`;
- shows a base-path-safe download action on the built-in `/resume` page;
- adds `features.resumePage`, defaulting to `true` so existing consumers keep the route;
- adds generic registry feature gating and records feature-disabled routes in the manifest;
- documents consumer setup and migration.

## Target layer

- [x] `packages/schema`
- [x] `packages/engine-core`
- [x] `packages/editorial-theme`
- [x] `examples/demo-site`
- [x] docs/governance

## Issue link

Closes #74.
Closes #75.

## Downstream origin

- [x] Yes — `agreni-site`

Agreni needs a published résumé PDF and a reliable on-page/downloadable résumé. The URL contract, route control, and built-in CTA are reusable across consumers and cannot be expressed with content alone.

## Layer check

- [x] no, upstream package change is required

A downstream override could add one local button, but would duplicate URL validation, base-path resolution, route behavior, and manifest diagnostics.

## AI assistance

- [x] Yes

Codex drafted and reviewed the implementation. No downstream content or personal data is included.

## Private data and secrets check

- [x] I did not include secrets, credentials, tokens, or private keys.
- [x] I did not include private downstream content that should not be public.
- [x] I did not put private files in `public/`.
- [x] I did not hardcode consumer-specific logic into upstream packages.

## Tests/checks

Commands run:

```bash
corepack pnpm@10 install --frozen-lockfile
corepack pnpm@10 format:write
corepack pnpm@10 lint
corepack pnpm@10 check
corepack pnpm@10 build
corepack pnpm@10 --filter demo-site build
corepack pnpm@10 --filter @portfolio-engine/schema check
```

Additional verification:

- built the demo with `resumePage: false`; `/resume` was absent and recorded in `manifest.routeOverrides.disabled`;
- built the demo with a local PDF URL; prerendered HTML contained the resolved href, `download` attribute, icon, and accessible text;
- Vercel preview reached `READY`; authenticated browser QA confirmed the deployed `/resume` page has meaningful content, one H1/main landmark, no error overlay, no horizontal overflow, and no application console errors. The conditional PDF-button path is covered by the separate prerendered-output assertion.

- [x] `pnpm check` passes
- [x] `pnpm build` passes
- [x] Tests updated (schema URL/default regression tests and rendered-output assertions)
- [x] Relevant docs updated

## Changeset

- [x] Added

## Reviewer notes

The feature flag defaults to the current behavior (`true`). The generic registry hook fails fast on an unknown feature key so registry typos cannot silently expose a route.