### PR TITLE
fix: publish releases in the versioning run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
-# Two-phase release on main:
-# 1) Pending `.changeset/*.md` (from dev→main promotion) → `changeset version` + push (triggers this workflow again).
-# 2) No pending changesets → build + `changeset publish` to npm.
+# Release on main:
+# 1) Pending `.changeset/*.md` (from dev→main promotion) → `changeset version` + push.
+# 2) The publish job syncs to the updated main tip, then builds + publishes to npm in the same run.
 #
 # Use RELEASE_BOT_TOKEN when GitHub Actions cannot push to protected `main` (see docs/workflows/release-workflow.md).
 name: Release
@@ -109,8 +109,8 @@ jobs:
           fi
 
           git push "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${ref}"
-          echo "Version commit pushed — npm publish runs on the next workflow run."
-          echo "skip_publish=true" >> "$GITHUB_OUTPUT"
+          echo "Version commit pushed — npm publish will continue from the updated main tip in this workflow run."
+          echo "skip_publish=false" >> "$GITHUB_OUTPUT"
 
       - name: No pending changesets — publish may run
         id: version_pass

--- a/docs/workflows/release-workflow.md
+++ b/docs/workflows/release-workflow.md
@@ -11,27 +11,27 @@ Any changeset that can affect consumer repos should include a `#### Agent migrat
 1. Confirm `.changeset/*.md` files are on **`dev`** before promotion (see **Squash merges and changesets** below).
 2. Open and merge a **`dev` → `main`** PR when ready to release.
 3. Wait for **Actions → Release** on `main`:
-   - First run with pending changesets: **`changeset version`** commits are pushed to `main`, then the workflow ends without publishing.
-   - Next run (triggered by that push): **build** + **`pnpm release`** (`changeset publish`) publishes to npm when versions are new.
-4. Confirm packages on npm (`npm view @portfolio-engine/<pkg> version`) after green Release runs.
+   - With pending changesets, **`changeset version`** commits are pushed to `main`.
+   - In the same run, the publish job syncs to the updated `origin/main`, then **builds** and runs **`pnpm release`** (`changeset publish`).
+4. Confirm packages on npm (`npm view @portfolio-engine/<pkg> version`) after the green Release run.
 5. **Sync main → dev**: after each successful Release, **Sync main into dev** merges `main` into `dev` so version bumps and changelogs flow back. Resolve conflicts locally if that job fails.
 
-Manual rescue: **Actions → Release → Run workflow** (`workflow_dispatch`) on `main` re-runs versioning logic (if changesets remain) or publish (when none remain).
+Manual rescue: **Actions → Release → Run workflow** (`workflow_dispatch`) on `main` re-runs versioning logic (if changesets remain) or safely retries publication (when none remain).
 
 If **Apply changesets** fails with a **non-fast-forward** push, something else updated `main` while the job ran. The workflow now **resets to `origin/main` before versioning** and **rebases version commits before push**; re-run Release once `main` is calm.
 
-The **Promote dev → main** VS Code task (`scripts/promote-dev-to-main.*`) merges the promotion PR and then **queues `Release` via `workflow_dispatch`**, so the npm publish phase always runs even when the automated `RELEASING` push does not start a follow-up workflow (default `GITHUB_TOKEN` limitation).
+The **Promote dev → main** VS Code task (`scripts/promote-dev-to-main.*`) merges the promotion PR and then **queues `Release` via `workflow_dispatch`** as an idempotent fallback. Publication no longer depends on the automated `RELEASING` push starting another workflow, which GitHub suppresses when that push uses the default `GITHUB_TOKEN`.
 
 **Git tags:** `changeset publish` creates tags like `@portfolio-engine/schema@0.3.0`. The **Publish to npm** job uses **`contents: write`** so those tags can be pushed. After a release, refresh locally with `git fetch origin main --tags` if Git Graph does not show new tags.
 
 ## What runs on `main` (`.github/workflows/release.yml`)
 
-Two-phase behavior:
+Single-run behavior:
 
-| Phase   | Trigger                                                                      | What happens                                                                                                                                                                   |
-| ------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Version | Push / dispatch on `main`, pending `.changeset/*.md` (excluding `README.md`) | Sync `HEAD` to remote tip, `pnpm exec changeset version`, lockfile refresh (`pnpm install --no-frozen-lockfile` + lockfile commit if needed), **rebase onto remote**, **push** |
-| Publish | Next push on `main` when no pending changesets                               | `pnpm build`, verify `dist/`, then **`pnpm release`** with `NODE_AUTH_TOKEN`                                                                                                   |
+| Phase   | Trigger / gate                                                               | What happens                                                                                                                                                                        |
+| ------- | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Version | Push / dispatch on `main`, pending `.changeset/*.md` (excluding `README.md`) | Sync `HEAD` to remote tip, `pnpm exec changeset version`, lockfile refresh (`pnpm install --no-frozen-lockfile` + lockfile commit if needed), **rebase onto remote**, then **push** |
+| Publish | After Version, or immediately when no pending changesets                     | Fetch and reset to the latest `origin/main`, `pnpm build`, verify `dist/`, then **`pnpm release`** with `NODE_AUTH_TOKEN`                                                           |
 
 `changeset publish` no-ops when local versions already match the registry.
 
@@ -45,9 +45,9 @@ The default **`GITHUB_TOKEN`** often **cannot push** to protected `main`, even w
 
 Use the same bypass pattern for **`dev`** if **Sync main into dev** must push merge commits through protection.
 
-## Critical: `[skip ci]` blocks Actions
+## Critical: `[skip ci]` blocks downstream Actions
 
-GitHub Actions skips workflows when the **HEAD** commit message/body contains `[skip ci]` (case-insensitive).
+GitHub Actions skips workflows when the **HEAD** commit message/body contains `[skip ci]` (case-insensitive). The Release workflow no longer requires the version commit to trigger a second Release run, but other push workflows—especially **Sync main into dev**—still depend on normal Actions triggering.
 
 This repo sets **`"commit": ["@changesets/cli/commit", { "skipCI": false }]`** in `.changeset/config.json` so automated version commits **still trigger** the Release workflow.
 
@@ -84,8 +84,8 @@ On a fork (with test npm scope or `publishConfig`/`--dry-run` adjustments if you
 
 1. Add **`NPM_TOKEN`** and **`RELEASE_BOT_TOKEN`** (or relax branch protection) so CI can push `main`.
 2. Land a patch changeset on **`dev`**, merge **`dev` → `main`** (squash OK).
-3. Confirm **Release** run #1 pushes version/changelog commits and **does not** publish yet.
-4. Confirm **Release** run #2 builds and publishes (or no-ops if versions match registry).
+3. Confirm the **Release** run pushes version/changelog commits.
+4. Confirm the publish job in that same run syncs to the new `main` tip, builds, and publishes (or no-ops if versions match the registry).
 5. Inspect commit messages: automated version commits must **not** contain `[skip ci]` (see `.changeset/config.json`).
 6. Optionally run `npm view @portfolio-engine/<pkg> version` against your published tags.
 


### PR DESCRIPTION
## Summary

- publish versioned packages from the updated `main` tip in the same Release workflow run
- remove the dependency on a follow-up workflow trigger, which GitHub suppresses for `GITHUB_TOKEN` pushes
- update the release runbook and fork verification steps

## Context

Release #76 versioned the packages after #173, but its publish job was skipped and the automated `RELEASING` push did not create a second workflow run. This left `main` ahead of npm.

Closes #174

## Verification

- `corepack pnpm@10 format`
- `corepack pnpm@10 lint`
- `git diff --check`
- workflow logic reuses the existing publish-job sync to latest `origin/main`

## Changeset

Not required: this changes repository workflow/documentation only and does not alter a published package.

## AI assistance disclosure

Diagnosis, implementation, and verification were AI-assisted and manually reviewed against Release #76.

Signed-off-by: Codex <codex@openai.com>