### PR TITLE
fix: skip lifecycle rebuilds during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,6 +200,9 @@ jobs:
         run: pnpm release
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # The workspace was built and dist/ verified above. Avoid concurrent package
+          # lifecycle rebuilds changing resolution while Changesets publishes siblings.
+          NPM_CONFIG_IGNORE_SCRIPTS: 'true'
 
       - name: Verify npm registry matches main package versions
         run: |

--- a/docs/workflows/release-workflow.md
+++ b/docs/workflows/release-workflow.md
@@ -35,6 +35,8 @@ Single-run behavior:
 
 `changeset publish` no-ops when local versions already match the registry.
 
+The workflow sets `NPM_CONFIG_IGNORE_SCRIPTS=true` only for the `changeset publish` step. It has already built the complete workspace and verified every publishable package's `dist/index.js`, so rerunning package `prepublishOnly` scripts during concurrent publication is both redundant and unsafe for workspace dependency resolution. Package-level lifecycle scripts remain available for direct/manual publication outside this workflow.
+
 Do **not** run `changeset version` locally for routine releases; CI owns version commits on `main`.
 
 ## Branch protection and bot pushes


### PR DESCRIPTION
## Summary

- skip package lifecycle scripts only during the workflow's Changesets publish step
- continue building the full workspace and verifying each publishable `dist/index.js` before publication
- retain package `prepublishOnly` scripts for direct/manual publishing
- document why the workflow publishes the verified artifacts without rebuilding

## Context

Release #77 published three packages but failed for `@portfolio-engine/editorial-theme@0.9.0` when its redundant concurrent `prepublishOnly` build could not resolve `@portfolio-engine/engine-core`.

Closes #177

## Verification

- `corepack pnpm@10 format`
- `corepack pnpm@10 lint`
- `git diff --check`
- Release #77 confirmed the earlier full-workspace build and dist verification succeed

## Changeset

Not required: this changes repository workflow/documentation only and does not alter a published package.

## AI assistance disclosure

Diagnosis, implementation, and verification were AI-assisted and manually reviewed against the Release #77 logs.

Signed-off-by: Codex <codex@openai.com>