### PR TITLE
chore(release): promote publish retry fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,6 +200,9 @@ jobs:
         run: pnpm release
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # The workspace was built and dist/ verified above. Avoid concurrent package
+          # lifecycle rebuilds changing resolution while Changesets publishes siblings.
+          NPM_CONFIG_IGNORE_SCRIPTS: 'true'
 
       - name: Verify npm registry matches main package versions
         run: |

--- a/docs/workflows/release-workflow.md
+++ b/docs/workflows/release-workflow.md
@@ -35,6 +35,8 @@ Single-run behavior:
 
 `changeset publish` no-ops when local versions already match the registry.
 
+The workflow sets `NPM_CONFIG_IGNORE_SCRIPTS=true` only for the `changeset publish` step. It has already built the complete workspace and verified every publishable package's `dist/index.js`, so rerunning package `prepublishOnly` scripts during concurrent publication is both redundant and unsafe for workspace dependency resolution. Package-level lifecycle scripts remain available for direct/manual publication outside this workflow.
+
 Do **not** run `changeset version` locally for routine releases; CI owns version commits on `main`.
 
 ## Branch protection and bot pushes


### PR DESCRIPTION
## Summary

Promote #178 to `main` and retry the partially completed package release.

## Included

- #178 — publish the already-built, verified artifacts without redundant package lifecycle rebuilds
- closes #177

## Expected release behavior

- `schema@0.9.0`, `engine-core@0.4.0`, and `admin-tools@0.0.29` already exist on npm and will no-op
- `editorial-theme@0.9.0` is the only missing version and should publish
- registry verification and package tag creation should then complete

## Verification

- Changeset guard passed
- full CI passed (lint, check, build, smoke-packed)
- Vercel preview reached READY
- no package source changed; no changeset is required

## AI assistance disclosure

Diagnosis, implementation, and release preparation were AI-assisted and manually verified against Release #77.

Signed-off-by: Codex <codex@openai.com>