### PR TITLE
fix(theme): apply PDF viewer styles to dynamic pages

### DIFF
--- a/.changeset/fuzzy-pdfs-align.md
+++ b/.changeset/fuzzy-pdfs-align.md
@@ -2,4 +2,4 @@
 '@portfolio-engine/editorial-theme': patch
 ---
 
-Fix PDF.js page and selectable-text layout by making styles for dynamically created viewer nodes global. This prevents text layers from rendering as visible, overlapping document text in Astro consumers, especially on narrow mobile screens.
+Fix PDF.js page and selectable-text layout by making styles for dynamically created viewer nodes global. Prevent repeated page sets when multiple viewer component scripts are present by initializing each viewer exactly once. Together, these changes stop visible overlapping text and documents restarting after their final page.

--- a/.changeset/fuzzy-pdfs-align.md
+++ b/.changeset/fuzzy-pdfs-align.md
@@ -1,0 +1,5 @@
+---
+'@portfolio-engine/editorial-theme': patch
+---
+
+Fix PDF.js page and selectable-text layout by making styles for dynamically created viewer nodes global. This prevents text layers from rendering as visible, overlapping document text in Astro consumers, especially on narrow mobile screens.

--- a/.changeset/fuzzy-pdfs-align.md
+++ b/.changeset/fuzzy-pdfs-align.md
@@ -3,3 +3,9 @@
 ---
 
 Fix PDF.js page and selectable-text layout by making styles for dynamically created viewer nodes global. Prevent repeated page sets when multiple viewer component scripts are present by initializing each viewer exactly once. Together, these changes stop visible overlapping text and documents restarting after their final page.
+
+#### Agent migration
+
+- **Package:** `@portfolio-engine/editorial-theme`
+- **Consumer paths:** pages that render one or more `PdfViewer` components
+- **Actions:** upgrade to the patched release; remove any temporary global styles or duplicate-page cleanup added downstream for these viewer defects

--- a/packages/editorial-theme/package.json
+++ b/packages/editorial-theme/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "test": "node src/lib/collections.test.mjs && node src/lib/profile-person.test.mjs",
+    "test": "node src/lib/collections.test.mjs && node src/lib/profile-person.test.mjs && node src/components/pdf-viewer.test.mjs",
     "check": "tsc --noEmit && pnpm run test",
     "prepublishOnly": "pnpm run build"
   },

--- a/packages/editorial-theme/src/components/PdfViewer.astro
+++ b/packages/editorial-theme/src/components/PdfViewer.astro
@@ -71,6 +71,9 @@ const wrapperClass = ['pdf-reader', 'pe-pdf-viewer', className].filter(Boolean).
 
 <script is:inline type="module">
   for (const root of document.querySelectorAll('[data-pdf-viewer]')) {
+    if (root.dataset.pdfViewerInitialized === 'true') continue;
+    root.dataset.pdfViewerInitialized = 'true';
+
     const PDFJS_URL = root.dataset.pdfjsUrl;
     const PDFJS_WORKER_URL = root.dataset.workerUrl;
     const source = root.dataset.src;

--- a/packages/editorial-theme/src/components/PdfViewer.astro
+++ b/packages/editorial-theme/src/components/PdfViewer.astro
@@ -399,7 +399,7 @@ const wrapperClass = ['pdf-reader', 'pe-pdf-viewer', className].filter(Boolean).
     padding: 1rem;
   }
 
-  .pdf-reader__page {
+  :global(.pdf-reader__page) {
     position: relative;
     margin: 0 auto 1rem;
     overflow: hidden;
@@ -407,17 +407,17 @@ const wrapperClass = ['pdf-reader', 'pe-pdf-viewer', className].filter(Boolean).
     box-shadow: 0 0.3rem 1.4rem rgb(0 0 0 / 12%);
   }
 
-  .pdf-reader__page canvas,
-  .pdf-reader__page .textLayer {
+  :global(.pdf-reader__page canvas),
+  :global(.pdf-reader__page .textLayer) {
     position: absolute;
     inset: 0;
   }
 
-  .pdf-reader__page canvas {
+  :global(.pdf-reader__page canvas) {
     display: block;
   }
 
-  .textLayer {
+  :global(.textLayer) {
     overflow: hidden;
     line-height: 1;
     opacity: 1;
@@ -427,7 +427,7 @@ const wrapperClass = ['pdf-reader', 'pe-pdf-viewer', className].filter(Boolean).
     z-index: 2;
   }
 
-  .textLayer :is(span, br) {
+  :global(.textLayer :is(span, br)) {
     position: absolute;
     color: transparent;
     white-space: pre;
@@ -435,12 +435,12 @@ const wrapperClass = ['pdf-reader', 'pe-pdf-viewer', className].filter(Boolean).
     transform-origin: 0 0;
   }
 
-  .textLayer span.markedContent {
+  :global(.textLayer span.markedContent) {
     top: 0;
     height: 0;
   }
 
-  .textLayer ::selection {
+  :global(.textLayer ::selection) {
     color: transparent;
     background: color-mix(in srgb, var(--color-accent-primary) 38%, transparent);
   }

--- a/packages/editorial-theme/src/components/pdf-viewer.test.mjs
+++ b/packages/editorial-theme/src/components/pdf-viewer.test.mjs
@@ -20,4 +20,15 @@ for (const selector of dynamicSelectors) {
   );
 }
 
-console.log('PDF viewer dynamic selector scoping: all assertions passed');
+assert.match(
+  source,
+  /if \(root\.dataset\.pdfViewerInitialized === 'true'\) continue;/,
+  'each viewer must skip repeated initialization when multiple component scripts run on one page',
+);
+assert.match(
+  source,
+  /root\.dataset\.pdfViewerInitialized = 'true';/,
+  'each viewer must be marked before asynchronous PDF loading begins',
+);
+
+console.log('PDF viewer initialization and dynamic selector scoping: all assertions passed');

--- a/packages/editorial-theme/src/components/pdf-viewer.test.mjs
+++ b/packages/editorial-theme/src/components/pdf-viewer.test.mjs
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { URL } from 'node:url';
+
+const source = await readFile(new URL('./PdfViewer.astro', import.meta.url), 'utf8');
+
+const dynamicSelectors = [
+  '.pdf-reader__page',
+  '.pdf-reader__page canvas',
+  '.pdf-reader__page .textLayer',
+  '.textLayer :is(span, br)',
+  '.textLayer span.markedContent',
+  '.textLayer ::selection',
+];
+
+for (const selector of dynamicSelectors) {
+  assert.ok(
+    source.includes(`:global(${selector})`) || source.includes(`:global(${selector}),`),
+    `${selector} must be global because PDF.js creates it after Astro scopes the component CSS`,
+  );
+}
+
+console.log('PDF viewer dynamic selector scoping: all assertions passed');


### PR DESCRIPTION
Closes #183.

## Summary

- mark PDF.js-created page, canvas, and selectable-text selectors as global so Astro does not scope them to server-rendered nodes
- initialize each viewer root exactly once, even when multiple component scripts are present on the same page
- prevent complete page sets from being appended repeatedly after the document’s last page
- add regression checks for dynamic selector scoping and duplicate initialization
- add a patch changeset with downstream migration guidance

## Target layer

`packages/editorial-theme`: both defects are reusable viewer behavior and cannot be corrected through consumer content or configuration.

## Validation

- `pnpm --filter @portfolio-engine/editorial-theme test` — passed
- `pnpm --filter @portfolio-engine/editorial-theme check` — passed after building workspace dependencies
- `pnpm lint` — passed
- `pnpm --filter @portfolio-engine/editorial-theme build` — passed
- `git diff --check` — passed
- reproduced both defects from Android Chrome screenshots supplied from the downstream Vercel preview

## Downstream

Unblocks the corrected summary and thesis viewers in `rainonej/agreni-site#27`. After this patch is released, downstream will upgrade and remove its temporary CSS fallback before merging.

> This PR was drafted with assistance from an AI coding agent and requires human review.