### PR TITLE
release: promote PDF viewer fixes to main

### DIFF
--- a/.changeset/fuzzy-pdfs-align.md
+++ b/.changeset/fuzzy-pdfs-align.md
@@ -1,0 +1,11 @@
+---
+'@portfolio-engine/editorial-theme': patch
+---
+
+Fix PDF.js page and selectable-text layout by making styles for dynamically created viewer nodes global. Prevent repeated page sets when multiple viewer component scripts are present by initializing each viewer exactly once. Together, these changes stop visible overlapping text and documents restarting after their final page.
+
+#### Agent migration
+
+- **Package:** `@portfolio-engine/editorial-theme`
+- **Consumer paths:** pages that render one or more `PdfViewer` components
+- **Actions:** upgrade to the patched release; remove any temporary global styles or duplicate-page cleanup added downstream for these viewer defects

--- a/packages/editorial-theme/package.json
+++ b/packages/editorial-theme/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "test": "node src/lib/collections.test.mjs && node src/lib/profile-person.test.mjs",
+    "test": "node src/lib/collections.test.mjs && node src/lib/profile-person.test.mjs && node src/components/pdf-viewer.test.mjs",
     "check": "tsc --noEmit && pnpm run test",
     "prepublishOnly": "pnpm run build"
   },

--- a/packages/editorial-theme/src/components/PdfViewer.astro
+++ b/packages/editorial-theme/src/components/PdfViewer.astro
@@ -71,6 +71,9 @@ const wrapperClass = ['pdf-reader', 'pe-pdf-viewer', className].filter(Boolean).
 
 <script is:inline type="module">
   for (const root of document.querySelectorAll('[data-pdf-viewer]')) {
+    if (root.dataset.pdfViewerInitialized === 'true') continue;
+    root.dataset.pdfViewerInitialized = 'true';
+
     const PDFJS_URL = root.dataset.pdfjsUrl;
     const PDFJS_WORKER_URL = root.dataset.workerUrl;
     const source = root.dataset.src;
@@ -399,7 +402,7 @@ const wrapperClass = ['pdf-reader', 'pe-pdf-viewer', className].filter(Boolean).
     padding: 1rem;
   }
 
-  .pdf-reader__page {
+  :global(.pdf-reader__page) {
     position: relative;
     margin: 0 auto 1rem;
     overflow: hidden;
@@ -407,17 +410,17 @@ const wrapperClass = ['pdf-reader', 'pe-pdf-viewer', className].filter(Boolean).
     box-shadow: 0 0.3rem 1.4rem rgb(0 0 0 / 12%);
   }
 
-  .pdf-reader__page canvas,
-  .pdf-reader__page .textLayer {
+  :global(.pdf-reader__page canvas),
+  :global(.pdf-reader__page .textLayer) {
     position: absolute;
     inset: 0;
   }
 
-  .pdf-reader__page canvas {
+  :global(.pdf-reader__page canvas) {
     display: block;
   }
 
-  .textLayer {
+  :global(.textLayer) {
     overflow: hidden;
     line-height: 1;
     opacity: 1;
@@ -427,7 +430,7 @@ const wrapperClass = ['pdf-reader', 'pe-pdf-viewer', className].filter(Boolean).
     z-index: 2;
   }
 
-  .textLayer :is(span, br) {
+  :global(.textLayer :is(span, br)) {
     position: absolute;
     color: transparent;
     white-space: pre;
@@ -435,12 +438,12 @@ const wrapperClass = ['pdf-reader', 'pe-pdf-viewer', className].filter(Boolean).
     transform-origin: 0 0;
   }
 
-  .textLayer span.markedContent {
+  :global(.textLayer span.markedContent) {
     top: 0;
     height: 0;
   }
 
-  .textLayer ::selection {
+  :global(.textLayer ::selection) {
     color: transparent;
     background: color-mix(in srgb, var(--color-accent-primary) 38%, transparent);
   }

--- a/packages/editorial-theme/src/components/pdf-viewer.test.mjs
+++ b/packages/editorial-theme/src/components/pdf-viewer.test.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { URL } from 'node:url';
+
+const source = await readFile(new URL('./PdfViewer.astro', import.meta.url), 'utf8');
+
+const dynamicSelectors = [
+  '.pdf-reader__page',
+  '.pdf-reader__page canvas',
+  '.pdf-reader__page .textLayer',
+  '.textLayer :is(span, br)',
+  '.textLayer span.markedContent',
+  '.textLayer ::selection',
+];
+
+for (const selector of dynamicSelectors) {
+  assert.ok(
+    source.includes(`:global(${selector})`) || source.includes(`:global(${selector}),`),
+    `${selector} must be global because PDF.js creates it after Astro scopes the component CSS`,
+  );
+}
+
+assert.match(
+  source,
+  /if \(root\.dataset\.pdfViewerInitialized === 'true'\) continue;/,
+  'each viewer must skip repeated initialization when multiple component scripts run on one page',
+);
+assert.match(
+  source,
+  /root\.dataset\.pdfViewerInitialized = 'true';/,
+  'each viewer must be marked before asynchronous PDF loading begins',
+);
+
+console.log('PDF viewer initialization and dynamic selector scoping: all assertions passed');


### PR DESCRIPTION
## Release scope

Promote the current `dev` branch to `main`, including:

- PDF.js dynamic page/text-layer styling fix
- per-viewer initialization guard that prevents repeated page sequences when multiple viewers are present
- regression coverage for both defects
- patch changeset and downstream migration guidance

## Validation

Upstream PR #184 passed:

- changeset guard
- lint and formatting
- typecheck and Astro checks
- workspace and fixture builds
- packed tarball consumer smoke test

After merge, the `Release` workflow on `main` should version and publish the patched `@portfolio-engine/editorial-theme`, then sync `main` back into `dev`.

> This release PR was prepared with assistance from an AI coding agent.