### PR TITLE
chore: promote PDF viewer regression fixture

### DIFF
--- a/examples/demo-site/public/assets/pdf-viewer/report.pdf
+++ b/examples/demo-site/public/assets/pdf-viewer/report.pdf
@@ -1,0 +1,112 @@
+%PDF-1.3
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 10 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/Contents 11 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/Contents 12 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/PageMode /UseNone /Pages 9 0 R /Type /Catalog
+>>
+endobj
+8 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260821014933-03'00') /Creator (anonymous) /Keywords () /ModDate (D:20260821014933-03'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+9 0 obj
+<<
+/Count 3 /Kids [ 4 0 R 5 0 R 6 0 R ] /Type /Pages
+>>
+endobj
+10 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 200
+>>
+stream
+GarW1Ymu@N&4ClZ@S4$f\WmH.;(;sK=5'1Si/pA4G;8[_+rI.145&UfnjXhi:C]UiJ;qE$Q&l-66Ui8Og1.%4JJ0GXF%Sjkj78t$WD<e"@<U_/DEZ950cF>:hpsegF/T^dnb)k<RJ>@TkW?'2bj10uG^as$\2Cg*#Cg5'[](\2=BOC!$g2ZqTWK[2HkhiF">:r]4Y$~>endstream
+endobj
+11 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 200
+>>
+stream
+GarW1Ymu@N&4ClZ@S4$f\WmH.;(;sK=5'1Si/pA4G;8[_+rI.1Z^KfinjXhi,DXPo@&'r",pYe<OHG?lp=Q?PhunqoS.^t^\GRaal7[gj0KX;R[iT1V(l^-bKK@.g%TPhI^:sV/'AkhgI4)InH$uq+cVKT,[jF'#i,=Rl2AN&-+'*U@_KjrtBPWJe?c?Oj_$_I+4Y-~>endstream
+endobj
+12 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 200
+>>
+stream
+GarW14V*-0&4Cko`KY+WEX*1kUJr!u\$S/8q8sk6],:A<+rI.1Z^Kfinj^J<,0*Go?qXTL&lO99aA@P_"8:f8>X='^Y$r"C\GRa!24P2WYrHaXF:K+`,.'CD"DBOn92GdqI=;->B"gu%q9Ee9Fo#hiNh6dlm`MVA$Wf$B]0oVAH5PIZ#O?JMThUs4q'K^Sn6R>74Y6~>endstream
+endobj
+xref
+0 13
+0000000000 65535 f 
+0000000061 00000 n 
+0000000102 00000 n 
+0000000209 00000 n 
+0000000321 00000 n 
+0000000515 00000 n 
+0000000709 00000 n 
+0000000903 00000 n 
+0000000971 00000 n 
+0000001232 00000 n 
+0000001303 00000 n 
+0000001594 00000 n 
+0000001885 00000 n 
+trailer
+<<
+/ID 
+[<24428483207790345a126cb8216dcb51><24428483207790345a126cb8216dcb51>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 8 0 R
+/Root 7 0 R
+/Size 13
+>>
+startxref
+2176
+%%EOF

--- a/examples/demo-site/public/assets/pdf-viewer/summary.pdf
+++ b/examples/demo-site/public/assets/pdf-viewer/summary.pdf
@@ -1,0 +1,93 @@
+%PDF-1.3
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 9 0 R /MediaBox [ 0 0 612 792 ] /Parent 8 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/Contents 10 0 R /MediaBox [ 0 0 612 792 ] /Parent 8 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/PageMode /UseNone /Pages 8 0 R /Type /Catalog
+>>
+endobj
+7 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260821014933-03'00') /Creator (anonymous) /Keywords () /ModDate (D:20260821014933-03'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+8 0 obj
+<<
+/Count 2 /Kids [ 4 0 R 5 0 R ] /Type /Pages
+>>
+endobj
+9 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 200
+>>
+stream
+GarW10b8ji&;>=W`>d@$dY8%65pcgMDfht'+J`")X-%mM7A:4Q/iS/2pH=?mN#Z_LJMgk=84Woa+;9lf[b+D5E!;N>\]R>6j)S+p.VoO!R-j@nlE8/nW>%9sF,7$YD[pMJMm)W"d6tLe7Ni^']fm?hkGQ@Q];B>q_4MUW]F_4B"@i.@_0OiuB[bHI5)Di]U)/&54e)~>endstream
+endobj
+10 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 200
+>>
+stream
+GarW1Ymu@N&4Cl[@S4$f\IB-cUJr!UDJ=1OJri&OghGj<73kK6G-f/Wll1q_)r9E,!@u/6e'J4MTOS^h\(L2Gk6-\"S5PXO\/l=jFW5lPVYduHVJ1#m8oQS_J8joTB&FRirsJcBNJ,Js&;l`8R%kB!Gm6C,WJX;1_HF*IB<(Zt^m\:Bpg@89A#o/E-T,YXj99eD4e2~>endstream
+endobj
+xref
+0 11
+0000000000 65535 f 
+0000000061 00000 n 
+0000000102 00000 n 
+0000000209 00000 n 
+0000000321 00000 n 
+0000000514 00000 n 
+0000000708 00000 n 
+0000000776 00000 n 
+0000001037 00000 n 
+0000001102 00000 n 
+0000001392 00000 n 
+trailer
+<<
+/ID 
+[<9243cf91a93e243c216d3c1e54452c96><9243cf91a93e243c216d3c1e54452c96>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 7 0 R
+/Root 6 0 R
+/Size 11
+>>
+startxref
+1683
+%%EOF

--- a/examples/demo-site/src/pages-local/pdf-viewer.astro
+++ b/examples/demo-site/src/pages-local/pdf-viewer.astro
@@ -1,0 +1,23 @@
+---
+import PdfViewer from '@portfolio-engine/editorial-theme/components/PdfViewer.astro';
+import Layout from '@portfolio-engine/editorial-theme/layouts/Layout.astro';
+---
+
+<Layout title="PDF viewer regression fixture">
+  <main class="demo-pdf-page">
+    <h1>PDF viewer regression fixture</h1>
+    <p>Two independent readers verify that each document renders exactly once.</p>
+    <PdfViewer src="/assets/pdf-viewer/summary.pdf" title="Two-page summary fixture" />
+    <PdfViewer src="/assets/pdf-viewer/report.pdf" title="Three-page report fixture" />
+  </main>
+</Layout>
+
+<style>
+  .demo-pdf-page {
+    display: grid;
+    gap: var(--space-6);
+    margin-inline: auto;
+    max-width: 72rem;
+    padding: var(--space-8) var(--space-4);
+  }
+</style>

--- a/examples/demo-site/src/registry/portfolio-engine.registry.json
+++ b/examples/demo-site/src/registry/portfolio-engine.registry.json
@@ -35,6 +35,13 @@
       "label": "Contribute",
       "section": null,
       "visibility": "public"
+    },
+    {
+      "pattern": "/pdf-viewer",
+      "page": "pdf-viewer.astro",
+      "label": "PDF viewer",
+      "section": null,
+      "visibility": "public"
     }
   ]
 }


### PR DESCRIPTION
Promotes the upstream-controlled two-viewer browser regression fixture after successful preview verification. No package code or version changes.